### PR TITLE
RFC-0201 Phase 1 — gcdrDeviceId propagation + STATE.itemsBase (pod F0)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -210,6 +210,9 @@ export {
   STATUS_COLORS,
 } from './components/premium-modals/settings/annotations/types';
 
+// Canonical baseline types (RFC-0201 Phase-1 — pod F0)
+export type { BaseItem, BaseItemDomain } from './types';
+
 // RFC-0104: Annotation Indicator Component
 export { AnnotationIndicator, createAnnotationIndicator } from './utils/AnnotationIndicator';
 

--- a/src/thingsboard/main-dashboard-shopping/v-5.4.0/controller.js
+++ b/src/thingsboard/main-dashboard-shopping/v-5.4.0/controller.js
@@ -89,7 +89,16 @@ let _temperatureGridLojas = null;
 // ============================================================================
 
 /**
- * Extract device metadata from all rows for a single device
+ * Extract device metadata from all rows for a single device.
+ *
+ * Canonical implementation lives at `./lib/extractDeviceMetadataFromRows.js`
+ * (used by tests). This inline copy MUST mirror it exactly — TB widgets are
+ * loaded as global scripts and cannot ES-import at runtime, so the duplication
+ * is intentional. If you change one, change both.
+ *
+ * Returned shape mirrors `v-5.2.0/WIDGET/MAIN_VIEW/controller.js
+ * ::buildMetadataMapFromCtxData`, including `gcdrDeviceId` (RFC-0201 Phase-1
+ * row #1) — TB sometimes lowercases the dataKey name, so check both.
  */
 function extractDeviceMetadataFromRows(rows) {
   if (!rows || rows.length === 0) return null;
@@ -165,6 +174,8 @@ function extractDeviceMetadataFromRows(rows) {
     domain,
     lastActivityTime: dataKeyValues['lastActivityTime'],
     lastConnectTime: dataKeyValues['lastConnectTime'],
+    // RFC-0201 Phase-1 row #1: gcdrDeviceId propagation (case-insensitive).
+    gcdrDeviceId: dataKeyValues['gcdrDeviceId'] || dataKeyValues['gcdrdeviceid'] || null,
   };
 }
 
@@ -293,6 +304,10 @@ function processDataAndDispatchEvents() {
     ...classified.water.hidrometro,
   ];
   const allTemp = [...classified.temperature.termostato, ...classified.temperature.termostato_external];
+
+  // RFC-0201 Phase-1 row #2: flat baseline of all classified devices, used by
+  // cross-domain alarm/ticket lookups (e.g., AlarmServiceOrchestrator).
+  window.STATE.itemsBase = [...allEnergy, ...allWater, ...allTemp];
 
   // Calculate totals
   const energyTotal = allEnergy.reduce((sum, d) => sum + Number(d.value || 0), 0);

--- a/src/thingsboard/main-dashboard-shopping/v-5.4.0/lib/extractDeviceMetadataFromRows.js
+++ b/src/thingsboard/main-dashboard-shopping/v-5.4.0/lib/extractDeviceMetadataFromRows.js
@@ -1,0 +1,96 @@
+/* global window */
+
+/**
+ * RFC-0201 Phase-1 (Pod F0) — extract `extractDeviceMetadataFromRows` from
+ * `v-5.4.0/controller.js` into a small importable helper so it can be unit-
+ * tested without booting the full ThingsBoard global-script controller.
+ *
+ * Mirrors the schema returned by `v-5.2.0/WIDGET/MAIN_VIEW/controller.js
+ * ::buildMetadataMapFromCtxData` — including the `gcdrDeviceId` field
+ * (with lowercase `gcdrdeviceid` fallback, since TB sometimes lowercases
+ * the dataKey name).
+ *
+ * @typedef {import('../../../../types/BaseItem').BaseItem} BaseItem
+ *
+ * @param {Array<{ datasource?: any, dataKey?: { name?: string }, data?: any[][] }>} rows
+ * @returns {BaseItem | null}
+ */
+export function extractDeviceMetadataFromRows(rows) {
+  if (!rows || rows.length === 0) return null;
+
+  const firstRow = rows[0];
+  const datasource = firstRow.datasource || {};
+  const entityId = datasource.entityId;
+  const deviceName = datasource.entityName || '';
+  const entityLabel = datasource.entityLabel || '';
+
+  const dataKeyValues = {};
+  const dataKeyTimestamps = {};
+
+  for (const row of rows) {
+    const keyName = row.dataKey?.name;
+    if (keyName && row.data && row.data.length > 0) {
+      const latestData = row.data[row.data.length - 1];
+      if (Array.isArray(latestData) && latestData.length >= 2) {
+        dataKeyTimestamps[keyName] = latestData[0];
+        dataKeyValues[keyName] = latestData[1];
+      }
+    }
+  }
+
+  const deviceType = dataKeyValues['deviceType'] || '';
+  const deviceProfile = dataKeyValues['deviceProfile'] || deviceType;
+  const connectionStatus = dataKeyValues['connectionStatus'] || 'no_info';
+
+  // Domain detection (RFC-0111)
+  const isWater = deviceType.toUpperCase().includes('HIDROMETRO');
+  const isTemperature = deviceType.toUpperCase().includes('TERMOSTATO');
+  const domain = isWater ? 'water' : isTemperature ? 'temperature' : 'energy';
+
+  // Calculate device status
+  let deviceStatus = 'offline';
+  if (typeof window !== 'undefined' && window.MyIOLibrary?.calculateDeviceStatusMasterRules) {
+    const telemetryTs =
+      domain === 'energy'
+        ? dataKeyTimestamps['consumption']
+        : domain === 'water'
+        ? dataKeyTimestamps['pulses']
+        : dataKeyTimestamps['temperature'];
+    deviceStatus = window.MyIOLibrary.calculateDeviceStatusMasterRules({
+      connectionStatus,
+      telemetryTimestamp: telemetryTs,
+      delayMins: 1440,
+      domain,
+    });
+  }
+
+  return {
+    id: entityId,
+    entityId,
+    name: deviceName,
+    label: dataKeyValues['label'] || entityLabel,
+    labelOrName: dataKeyValues['label'] || entityLabel || deviceName,
+    deviceType,
+    deviceProfile,
+    identifier: dataKeyValues['identifier'] || '',
+    centralName: dataKeyValues['centralName'] || '',
+    slaveId: dataKeyValues['slaveId'] || '',
+    centralId: dataKeyValues['centralId'] || '',
+    customerId: dataKeyValues['customerId'] || '',
+    ownerName: dataKeyValues['ownerName'] || '',
+    ingestionId: dataKeyValues['ingestionId'] || '',
+    consumption: dataKeyValues['consumption'] || null,
+    val: dataKeyValues['consumption'] || dataKeyValues['pulses'] || dataKeyValues['temperature'] || null,
+    value: dataKeyValues['consumption'] || dataKeyValues['pulses'] || dataKeyValues['temperature'] || null,
+    pulses: dataKeyValues['pulses'],
+    temperature: dataKeyValues['temperature'],
+    connectionStatus,
+    deviceStatus,
+    domain,
+    lastActivityTime: dataKeyValues['lastActivityTime'],
+    lastConnectTime: dataKeyValues['lastConnectTime'],
+    // RFC-0201 Phase-1 row #1: gcdrDeviceId propagation (case-insensitive
+    // — TB sometimes lowercases the dataKey name).
+    gcdrDeviceId: dataKeyValues['gcdrDeviceId'] || dataKeyValues['gcdrdeviceid'] || null,
+  };
+}

--- a/src/types/BaseItem.ts
+++ b/src/types/BaseItem.ts
@@ -1,0 +1,81 @@
+/**
+ * RFC-0201 — Canonical baseline item shape produced by
+ * `extractDeviceMetadataFromRows` in `v-5.4.0/controller.js` and
+ * mirrored from `v-5.2.0/WIDGET/MAIN_VIEW/controller.js
+ * ::buildMetadataMapFromCtxData`.
+ *
+ * This is the un-classified "base" device descriptor that flows from
+ * `ctx.data` into `STATE.itemsBase` and downstream into orchestrator
+ * items, alarm lookups, and grid rendering.
+ *
+ * Public API stability: this type is re-exported from `src/index.ts`
+ * for TypeScript consumers (v-5.4.0 .ts forks, the showcase, third-
+ * party integrations).
+ */
+
+/** Domain bucket used for classification (RFC-0111). */
+export type BaseItemDomain = 'energy' | 'water' | 'temperature';
+
+/**
+ * Canonical baseline device shape — every field returned by
+ * `extractDeviceMetadataFromRows`. Numeric telemetry fields can be
+ * either a number or `null` because TB delivers them as the latest
+ * `[timestamp, value]` pair and the value may be missing.
+ */
+export interface BaseItem {
+  /** Mirrors `entityId` for use as a stable React/DOM key. */
+  id: string;
+  /** ThingsBoard entity UUID. */
+  entityId: string;
+  /** Raw entity name from datasource. */
+  name: string;
+  /** Human-readable label (TB attr `label` falls back to `entityLabel`). */
+  label: string;
+  /** `label` ?? `entityLabel` ?? `name` — convenience for UI rendering. */
+  labelOrName: string;
+  /** TB `deviceType` SERVER_SCOPE attribute. */
+  deviceType: string;
+  /** TB `deviceProfile` (falls back to `deviceType`). */
+  deviceProfile: string;
+  /** Free-form identifier (e.g., asset tag, store code). */
+  identifier: string;
+  /** Display name of the central/gateway. */
+  centralName: string;
+  /** Modbus slave ID (when applicable). */
+  slaveId: string | number;
+  /** ThingsBoard ID of the parent central asset. */
+  centralId: string;
+  /** GCDR / TB customer ID. */
+  customerId: string;
+  /** Owner display name (tenant or store owner). */
+  ownerName: string;
+  /** GCDR ingestion ID — the canonical key on the GCDR API side. */
+  ingestionId: string;
+  /** Latest energy consumption value (kWh). */
+  consumption: number | string | null;
+  /** First non-null of `consumption | pulses | temperature`. */
+  val: number | string | null;
+  /** Same as `val` — separate field for legacy consumers. */
+  value: number | string | null;
+  /** Latest water pulses count. */
+  pulses: number | string | undefined;
+  /** Latest temperature reading (°C). */
+  temperature: number | string | undefined;
+  /** Raw connection status from TB. */
+  connectionStatus: string;
+  /** Computed status (online / offline / waiting / weak / etc.). */
+  deviceStatus: string;
+  /** Domain bucket for classification. */
+  domain: BaseItemDomain;
+  /** Latest activity timestamp (epoch ms). */
+  lastActivityTime: number | string | undefined;
+  /** Latest connect timestamp (epoch ms). */
+  lastConnectTime: number | string | undefined;
+  /**
+   * GCDR device UUID — the bridge key between TB devices and the GCDR
+   * Alarm/Ticket APIs. Sourced from the TB SERVER_SCOPE attribute
+   * `gcdrDeviceId` (with lowercase `gcdrdeviceid` fallback).
+   * `null` when the device has no GCDR mapping.
+   */
+  gcdrDeviceId: string | null;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,8 @@
+/**
+ * RFC-0201 — Public types barrel for `myio-js-library`.
+ *
+ * Add new public type re-exports here so `src/index.ts` can pull
+ * everything from a single module path.
+ */
+
+export type { BaseItem, BaseItemDomain } from './BaseItem';

--- a/tests/v-5.4.0/extractDeviceMetadataFromRows.test.ts
+++ b/tests/v-5.4.0/extractDeviceMetadataFromRows.test.ts
@@ -1,0 +1,101 @@
+/**
+ * RFC-0201 Phase-1 (Pod F0) — AC-Fix-gcdrDeviceId-1
+ *
+ * Verifies that `extractDeviceMetadataFromRows` returns a `gcdrDeviceId`
+ * field sourced from the TB dataKey `gcdrDeviceId` (with case-insensitive
+ * fallback to `gcdrdeviceid`).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractDeviceMetadataFromRows } from '../../src/thingsboard/main-dashboard-shopping/v-5.4.0/lib/extractDeviceMetadataFromRows.js';
+
+/**
+ * Build a single TB-shaped row for one (entityId, dataKey) pair.
+ * `data` is the standard TB `[[ts, value], ...]` array.
+ */
+function makeRow(entityId: string, keyName: string, value: any, ts = 1714400000000) {
+  return {
+    datasource: { entityId, entityName: 'demo-device', entityLabel: 'Demo Device' },
+    dataKey: { name: keyName },
+    data: [[ts, value]],
+  };
+}
+
+describe('extractDeviceMetadataFromRows — RFC-0201 gcdrDeviceId propagation', () => {
+  it('returns gcdrDeviceId when the dataKey is the canonical camelCase "gcdrDeviceId"', () => {
+    const rows = [
+      makeRow('e1', 'gcdrDeviceId', 'abc-123'),
+      makeRow('e1', 'deviceType', '3F_MEDIDOR'),
+    ];
+
+    const result = extractDeviceMetadataFromRows(rows);
+
+    expect(result).not.toBeNull();
+    expect(result!.gcdrDeviceId).toBe('abc-123');
+  });
+
+  it('falls back to lowercase "gcdrdeviceid" when TB lowercases the dataKey name', () => {
+    const rows = [
+      makeRow('e2', 'gcdrdeviceid', 'lower-cased-uuid'),
+      makeRow('e2', 'deviceType', '3F_MEDIDOR'),
+    ];
+
+    const result = extractDeviceMetadataFromRows(rows);
+
+    expect(result).not.toBeNull();
+    expect(result!.gcdrDeviceId).toBe('lower-cased-uuid');
+  });
+
+  it('prefers camelCase over lowercase when both are present', () => {
+    const rows = [
+      makeRow('e3', 'gcdrDeviceId', 'camel-wins'),
+      makeRow('e3', 'gcdrdeviceid', 'lower-loses'),
+      makeRow('e3', 'deviceType', '3F_MEDIDOR'),
+    ];
+
+    const result = extractDeviceMetadataFromRows(rows);
+
+    expect(result!.gcdrDeviceId).toBe('camel-wins');
+  });
+
+  it('returns gcdrDeviceId === null when neither key is present', () => {
+    const rows = [
+      makeRow('e4', 'deviceType', '3F_MEDIDOR'),
+      makeRow('e4', 'connectionStatus', 'online'),
+    ];
+
+    const result = extractDeviceMetadataFromRows(rows);
+
+    expect(result).not.toBeNull();
+    expect(result!.gcdrDeviceId).toBeNull();
+  });
+
+  it('returns null when rows is empty or undefined', () => {
+    expect(extractDeviceMetadataFromRows([])).toBeNull();
+    expect(extractDeviceMetadataFromRows(null as unknown as any[])).toBeNull();
+  });
+
+  it('preserves all canonical BaseItem fields alongside gcdrDeviceId', () => {
+    const rows = [
+      makeRow('e5', 'gcdrDeviceId', 'g-5'),
+      makeRow('e5', 'deviceType', 'HIDROMETRO'),
+      makeRow('e5', 'deviceProfile', 'HIDROMETRO'),
+      makeRow('e5', 'identifier', 'HID-1'),
+      makeRow('e5', 'connectionStatus', 'online'),
+      makeRow('e5', 'pulses', 42),
+      makeRow('e5', 'ingestionId', 'ing-5'),
+    ];
+
+    const result = extractDeviceMetadataFromRows(rows)!;
+
+    expect(result.id).toBe('e5');
+    expect(result.entityId).toBe('e5');
+    expect(result.deviceType).toBe('HIDROMETRO');
+    expect(result.identifier).toBe('HID-1');
+    expect(result.connectionStatus).toBe('online');
+    expect(result.pulses).toBe(42);
+    expect(result.ingestionId).toBe('ing-5');
+    expect(result.domain).toBe('water'); // HIDROMETRO -> water (RFC-0111)
+    expect(result.gcdrDeviceId).toBe('g-5');
+  });
+});

--- a/tests/v-5.4.0/processDataAndDispatchEvents.test.ts
+++ b/tests/v-5.4.0/processDataAndDispatchEvents.test.ts
@@ -1,0 +1,203 @@
+/**
+ * RFC-0201 Phase-1 (Pod F0) — AC-Fix-gcdrDeviceId-2
+ *
+ * Verifies that after `processDataAndDispatchEvents` runs against a
+ * classified set of `ctx.data` rows, `window.STATE.itemsBase` exists
+ * as a flat array of every device, each with a `gcdrDeviceId` field
+ * (possibly null).
+ *
+ * Strategy: load `controller.js` source, expose its inner functions
+ * via a tiny shim, eval it with a mocked `self.ctx`, then invoke
+ * `processDataAndDispatchEvents()` directly. This is option (b) from
+ * the directive — required because `processDataAndDispatchEvents` is
+ * not exported (lives inside the global-script controller).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import vm from 'node:vm';
+
+const CONTROLLER_PATH = resolve(
+  __dirname,
+  '../../src/thingsboard/main-dashboard-shopping/v-5.4.0/controller.js'
+);
+
+/** Build a TB-shaped row helper for a given (entityId, dataKey, value). */
+function makeRow(
+  entityId: string,
+  entityName: string,
+  keyName: string,
+  value: any,
+  ts = 1714400000000,
+  aliasName = 'AllDevices'
+) {
+  return {
+    datasource: { entityId, entityName, entityLabel: entityName, aliasName },
+    dataKey: { name: keyName },
+    data: [[ts, value]],
+  };
+}
+
+interface ProcessedSandbox {
+  window: any;
+  self: any;
+  /** Invokes the controller's `processDataAndDispatchEvents`. */
+  run: () => boolean;
+}
+
+/**
+ * Load controller.js into a fresh vm context with mocked globals.
+ * We append a small bridge that re-exports the inner function we need.
+ */
+function loadController(ctxData: any[]): ProcessedSandbox {
+  const source = readFileSync(CONTROLLER_PATH, 'utf-8');
+
+  // Append a bridge so we can reach the closed-over function from outside.
+  const bridge = `
+    ;globalThis.__processDataAndDispatchEvents = processDataAndDispatchEvents;
+  `;
+
+  // Minimal MyIOLibrary stub — only what `extractDeviceMetadataFromRows`
+  // and `classifyAllDevices` reach for. Domain detection in
+  // `extractDeviceMetadataFromRows` already works without the stub
+  // (string-based on deviceType), so we can safely return undefined for
+  // unknown helpers.
+  const mockWindow: any = {
+    MyIOLibrary: {
+      calculateDeviceStatusMasterRules: () => 'online',
+      // Mirror the real RFC-0111 helpers just enough to get devices into
+      // valid (domain, context) buckets. `classifyAllDevices` discards
+      // any device whose `classified[domain][context]` slot is undefined.
+      getDomainFromDeviceType: (deviceType: string) => {
+        const t = String(deviceType || '').toUpperCase();
+        if (t.includes('HIDROMETRO')) return 'water';
+        if (t.includes('TERMOSTATO')) return 'temperature';
+        return 'energy';
+      },
+      detectContext: (_device: any, domain: string) => {
+        if (domain === 'water') return 'hidrometro';
+        if (domain === 'temperature') return 'termostato';
+        return 'equipments';
+      },
+    },
+    MyIOUtils: {
+      temperatureLimits: { minTemperature: 18, maxTemperature: 26 },
+    },
+    STATE: {},
+    addEventListener: () => {},
+    dispatchEvent: () => true,
+    CustomEvent: globalThis.CustomEvent ?? class {
+      detail: any;
+      type: string;
+      constructor(type: string, init?: { detail?: any }) {
+        this.type = type;
+        this.detail = init?.detail;
+      }
+    },
+    localStorage: {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    },
+  };
+
+  const mockSelf: any = {
+    ctx: { data: ctxData, http: { getServerCredentials: () => null } },
+  };
+
+  // Polyfill CustomEvent inside the vm context (controller.js uses
+  // `new CustomEvent(...)` as a free identifier, not `window.CustomEvent`).
+  class SandboxCustomEvent {
+    type: string;
+    detail: any;
+    constructor(type: string, init?: { detail?: any }) {
+      this.type = type;
+      this.detail = init?.detail;
+    }
+  }
+
+  const sandbox: any = {
+    window: mockWindow,
+    self: mockSelf,
+    document: { addEventListener: () => {} },
+    MyIOLibrary: mockWindow.MyIOLibrary,
+    localStorage: mockWindow.localStorage,
+    CustomEvent: SandboxCustomEvent,
+    console,
+    setTimeout,
+    clearTimeout,
+    fetch: async () => ({ ok: false, status: 0, json: async () => ({}) }),
+    globalThis: {} as any,
+  };
+  sandbox.globalThis = sandbox;
+
+  vm.createContext(sandbox);
+  vm.runInContext(source + bridge, sandbox);
+
+  return {
+    window: mockWindow,
+    self: mockSelf,
+    run: () => sandbox.__processDataAndDispatchEvents(),
+  };
+}
+
+describe('processDataAndDispatchEvents — RFC-0201 STATE.itemsBase', () => {
+  let sandbox: ProcessedSandbox;
+
+  beforeEach(() => {
+    // 3 devices: one energy (with gcdrDeviceId), one water (with lowercase
+    // gcdrdeviceid), one temperature (no gcdr mapping).
+    const rows = [
+      // Energy — 3F_MEDIDOR
+      makeRow('en-1', 'energy-loja', 'deviceType', '3F_MEDIDOR'),
+      makeRow('en-1', 'energy-loja', 'deviceProfile', '3F_MEDIDOR'),
+      makeRow('en-1', 'energy-loja', 'identifier', 'LJ-001'),
+      makeRow('en-1', 'energy-loja', 'gcdrDeviceId', 'gcdr-en-1'),
+      makeRow('en-1', 'energy-loja', 'consumption', 123.45),
+      // Water — HIDROMETRO with lowercase key
+      makeRow('wt-1', 'water-banho', 'deviceType', 'HIDROMETRO'),
+      makeRow('wt-1', 'water-banho', 'identifier', 'HD-001'),
+      makeRow('wt-1', 'water-banho', 'gcdrdeviceid', 'gcdr-wt-1'),
+      makeRow('wt-1', 'water-banho', 'pulses', 99),
+      // Temperature — TERMOSTATO without gcdrDeviceId
+      makeRow('tm-1', 'temp-loja', 'deviceType', 'TERMOSTATO'),
+      makeRow('tm-1', 'temp-loja', 'identifier', 'TM-001'),
+      makeRow('tm-1', 'temp-loja', 'temperature', 22.5),
+    ];
+
+    sandbox = loadController(rows);
+  });
+
+  it('exposes window.STATE.itemsBase as a flat array of all devices', () => {
+    const ok = sandbox.run();
+    expect(ok).toBe(true);
+
+    const itemsBase = sandbox.window.STATE.itemsBase;
+    expect(Array.isArray(itemsBase)).toBe(true);
+    expect(itemsBase.length).toBe(3);
+
+    const ids = itemsBase.map((it: any) => it.entityId).sort();
+    expect(ids).toEqual(['en-1', 'tm-1', 'wt-1']);
+  });
+
+  it('every item in STATE.itemsBase has a gcdrDeviceId field (possibly null)', () => {
+    sandbox.run();
+    const itemsBase = sandbox.window.STATE.itemsBase;
+
+    for (const item of itemsBase) {
+      expect(item).toHaveProperty('gcdrDeviceId');
+    }
+  });
+
+  it('preserves the gcdrDeviceId values across both case variants', () => {
+    sandbox.run();
+    const byEntity: Record<string, any> = Object.fromEntries(
+      sandbox.window.STATE.itemsBase.map((it: any) => [it.entityId, it])
+    );
+
+    expect(byEntity['en-1'].gcdrDeviceId).toBe('gcdr-en-1');
+    expect(byEntity['wt-1'].gcdrDeviceId).toBe('gcdr-wt-1');
+    expect(byEntity['tm-1'].gcdrDeviceId).toBeNull();
+  });
+});


### PR DESCRIPTION
## Scope
Implements RFC-0201 Phase-1 work-list rows #1, #2 — the foundation pod that unblocks the rest of Phase 1 (AlarmServiceOrchestrator, alarm badges, AllReportModal API filter, etc.).

## Changes
- `src/thingsboard/main-dashboard-shopping/v-5.4.0/controller.js` — `extractDeviceMetadataFromRows` now returns `gcdrDeviceId` (with `gcdrdeviceid` lowercase fallback, mirroring the v-5.2.0 strategy in `buildMetadataMapFromCtxData`); `processDataAndDispatchEvents` now populates `window.STATE.itemsBase` as a flat array of all classified devices.
- `src/thingsboard/main-dashboard-shopping/v-5.4.0/lib/extractDeviceMetadataFromRows.js` (new) — canonical importable copy of the helper for unit testing. Controller.js keeps its inline mirror because TB widgets are loaded as global scripts and cannot ES-import at runtime; both copies must stay in lockstep (called out in JSDoc).
- `src/types/BaseItem.ts` (new) — canonical TypeScript interface for the baseline device shape returned by `extractDeviceMetadataFromRows`. Includes every existing field plus `gcdrDeviceId: string | null`.
- `src/types/index.ts` (new) — public-types barrel re-exporting `BaseItem`, `BaseItemDomain`.
- `src/index.ts` — added `export type { BaseItem, BaseItemDomain } from './types'` near the existing types block.
- `tests/v-5.4.0/extractDeviceMetadataFromRows.test.ts` (new) — 6 cases covering AC-Fix-gcdrDeviceId-1 (camelCase, lowercase, both-present precedence, null fallback, empty/null rows, full BaseItem shape preserved).
- `tests/v-5.4.0/processDataAndDispatchEvents.test.ts` (new) — 3 cases covering AC-Fix-gcdrDeviceId-2 (`STATE.itemsBase` is a flat array of all 3 classified devices; every item has `gcdrDeviceId`; values preserved across both case variants).

## ACs satisfied
- AC-Fix-gcdrDeviceId-1 — `extractDeviceMetadataFromRows` returns `gcdrDeviceId: "abc-123"` for the canonical case AND for the lowercase TB-emitted variant; returns `null` when neither key is present.
- AC-Fix-gcdrDeviceId-2 — `STATE.itemsBase` is a flat array (`[...allEnergy, ...allWater, ...allTemp]`); every item carries `gcdrDeviceId` (possibly `null`).

## Test results
```
tests/v-5.4.0/extractDeviceMetadataFromRows.test.ts   6 passed
tests/v-5.4.0/processDataAndDispatchEvents.test.ts    3 passed
Test Files  2 passed (2)
     Tests  9 passed (9)
```
Full-suite run (`npx vitest run`): 25 test files, 15 passed, 10 failed — **all 10 failures are pre-existing on `integration/phase-1`** (NODE-RED tests using jest API in a vitest config; `tests/deviceStatus.test.js`, `tests/format.test.js`, `tests/render*.test.js` baseline issues). No regression introduced. My new test files contribute +9 passing tests, 0 failures.

## controller.js LOC delta
+15 / -1 (net +14): inline `gcdrDeviceId` field, `window.STATE.itemsBase` write, JSDoc cross-reference comment.

## Notes / design choices
- **Testing strategy**: hybrid of options (a) and (b) from the directive. Option (a) for `extractDeviceMetadataFromRows`: extracted into `src/thingsboard/main-dashboard-shopping/v-5.4.0/lib/extractDeviceMetadataFromRows.js` so the test can ESM-import it directly. The controller keeps its inline copy because the TB widget runtime cannot ES-import at load time — duplication is intentional and flagged in JSDoc on both copies. Option (b) for `processDataAndDispatchEvents`: that function is closure-private inside the global-script controller, so the test loads `controller.js` source via `node:vm` with mocked `self.ctx`/`window`/`MyIOLibrary`/`CustomEvent`, then invokes the bridged function and inspects `window.STATE.itemsBase`.
- **Lint**: `npm run lint` reports ~6080 errors on this base branch — all pre-existing (TB global-script `no-undef` warnings on `self`, `window`, etc., across `src/MYIO-SIM/`, `src/NODE-RED/`, etc.). My new files lint clean: `0 errors, 0 warnings` for the helper JS; `.ts` files in `src/types/` and `tests/v-5.4.0/` are not picked up by the existing eslint config (warning-only, file ignored). No regression introduced.
- **Two ghost-deleted CSVs**: `src/thingsboard/smart-hospital/Tabela_Temp_V5/prod/target-to-customer/...long-filename.csv` show as deleted in `git status` — these are the long-filename casualties from the worktree checkout (Windows MAX_PATH limit) and exist on `integration/phase-1` but never landed on disk in this worktree. They are NOT staged in this commit.
- **Scope discipline**: did not touch `createComponents`, `_prefetchCustomerAlarms`, `AlarmServiceOrchestrator` construction (Pod A, next wave), `settingsSchema.json` (Pod C), or `showcase/`. Strictly rows #1, #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)