### PR TITLE
RFC-0200 deviceIcons shared device-type image map (pod B)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,16 @@ export {
   calculateDeviceStatusMasterRules, // RFC-0110: Simplified status calculation with master rules
 } from './utils/deviceStatus.js';
 
+// Device Icons utilities (RFC-0200)
+export {
+  DeviceIconType,
+  deviceIcons,
+  deviceIconLabels,
+  DEFAULT_DEVICE_ICON,
+  getDeviceIcon,
+  isDeviceIconType,
+} from './utils/deviceIcons';
+
 // RFC-0109: Device Item Factory utilities
 export {
   DomainType,

--- a/src/utils/deviceIcons.ts
+++ b/src/utils/deviceIcons.ts
@@ -1,0 +1,112 @@
+/**
+ * Device Icons Utilities (RFC-0200)
+ *
+ * Canonical mapping from device-type identifiers to static image URLs, plus
+ * Portuguese display labels and helpers (`getDeviceIcon`, `isDeviceIconType`,
+ * `DEFAULT_DEVICE_ICON`).
+ *
+ * Mirrors the shape of the mobile app's `core/devices/icons.ts`
+ * (myio-app-5.2.0) so the two codebases can converge over time, while
+ * keeping the library's existing asset host
+ * (`dashboard.myio-bas.com/api/images/public/<token>`).
+ *
+ * @module deviceIcons
+ * @see RFC-0200
+ */
+
+/**
+ * Canonical device-type identifiers used as image keys.
+ * Values match the strings emitted by ThingsBoard `deviceType` /
+ * `deviceProfile` attributes (uppercase, snake_case where applicable).
+ *
+ * NOTE: this mirrors `myio-app-5.2.0/src/core/devices/icons.ts::DeviceIcon`.
+ * Keep both in sync when adding new types.
+ */
+export const DeviceIconType = {
+  ESCADA_ROLANTE: 'ESCADA_ROLANTE',
+  ELEVADOR: 'ELEVADOR',
+  MOTOR: 'MOTOR',
+  BOMBA_HIDRAULICA: 'BOMBA_HIDRAULICA',
+  BOMBA_CAG: 'BOMBA_CAG',
+  BOMBA_INCENDIO: 'BOMBA_INCENDIO',
+  BOMBA: 'BOMBA',
+  MEDIDOR_3F: '3F_MEDIDOR',
+  RELOGIO: 'RELOGIO',
+  ENTRADA: 'ENTRADA',
+  SUBESTACAO: 'SUBESTACAO',
+  FANCOIL: 'FANCOIL',
+  CHILLER: 'CHILLER',
+  HIDROMETRO: 'HIDROMETRO',
+  HIDROMETRO_AREA_COMUM: 'HIDROMETRO_AREA_COMUM',
+  HIDROMETRO_SHOPPING: 'HIDROMETRO_SHOPPING',
+  CAIXA_DAGUA: 'CAIXA_DAGUA',
+  TERMOSTATO: 'TERMOSTATO',
+} as const;
+
+export type DeviceIconType =
+  (typeof DeviceIconType)[keyof typeof DeviceIconType];
+
+/** Static URL map (current opaque-token strategy). */
+export const deviceIcons: Record<DeviceIconType, string> = {
+  ESCADA_ROLANTE:        'https://dashboard.myio-bas.com/api/images/public/EJ997iB2HD1AYYUHwIloyQOOszeqb2jp',
+  ELEVADOR:              'https://dashboard.myio-bas.com/api/images/public/rAjOvdsYJLGah6w6BABPJSD9znIyrkJX',
+  MOTOR:                 'https://dashboard.myio-bas.com/api/images/public/Rge8Q3t0CP5PW8XyTn9bBK9aVP6uzSTT',
+  BOMBA_HIDRAULICA:      'https://dashboard.myio-bas.com/api/images/public/rbO2wQb6iKBtX0Ec04DFDcO3Qg04EOoD',
+  BOMBA_CAG:             'https://dashboard.myio-bas.com/api/images/public/rbO2wQb6iKBtX0Ec04DFDcO3Qg04EOoD',
+  BOMBA_INCENDIO:        'https://dashboard.myio-bas.com/api/images/public/YJkELCk9kluQSM6QXaFINX6byQWI7vbB',
+  BOMBA:                 'https://dashboard.myio-bas.com/api/images/public/Rge8Q3t0CP5PW8XyTn9bBK9aVP6uzSTT',
+  '3F_MEDIDOR':          'https://dashboard.myio-bas.com/api/images/public/f9Ce4meybsdaAhAkUlAfy5ei3I4kcN4k',
+  RELOGIO:               'https://dashboard.myio-bas.com/api/images/public/ljHZostWg0G5AfKiyM8oZixWRIIGRASB',
+  ENTRADA:               'https://dashboard.myio-bas.com/api/images/public/TQHPFqiejMW6lOSVsb8Pi85WtC0QKOLU',
+  SUBESTACAO:            'https://dashboard.myio-bas.com/api/images/public/TQHPFqiejMW6lOSVsb8Pi85WtC0QKOLU',
+  FANCOIL:               'https://dashboard.myio-bas.com/api/images/public/4BWMuVIFHnsfqatiV86DmTrOB7IF0X8Y',
+  CHILLER:               'https://dashboard.myio-bas.com/api/images/public/27Rvy9HbNoPz8KKWPa0SBDwu4kQ827VU',
+  HIDROMETRO:            'https://dashboard.myio-bas.com/api/images/public/aMQYFJbGHs9gQbQkMn6XseAlUZHanBR4',
+  HIDROMETRO_AREA_COMUM: 'https://dashboard.myio-bas.com/api/images/public/IbEhjsvixAxwKg1ntGGZc5xZwwvGKv2t',
+  HIDROMETRO_SHOPPING:   'https://dashboard.myio-bas.com/api/images/public/OIMmvN4ZTKYDvrpPGYY5agqMRoSaWNTI',
+  CAIXA_DAGUA:           'https://dashboard.myio-bas.com/api/images/public/3t6WVhMQJFsrKA8bSZmrngDsNPkZV7fq',
+  TERMOSTATO:            'https://dashboard.myio-bas.com/api/images/public/rtCcq6kZZVCD7wgJywxEurRZwR8LA7Q7',
+};
+
+/** Friendly Portuguese labels for UI rendering (pickers, tooltips, captions). */
+export const deviceIconLabels: Record<DeviceIconType, string> = {
+  ESCADA_ROLANTE:        'Escada Rolante',
+  ELEVADOR:              'Elevador',
+  MOTOR:                 'Motor',
+  BOMBA_HIDRAULICA:      'Bomba Hidráulica',
+  BOMBA_CAG:             'Bomba CAG',
+  BOMBA_INCENDIO:        'Bomba Incêndio',
+  BOMBA:                 'Bomba',
+  '3F_MEDIDOR':          'Medidor 3F',
+  RELOGIO:               'Relógio',
+  ENTRADA:               'Entrada',
+  SUBESTACAO:            'Subestação',
+  FANCOIL:               'Fancoil',
+  CHILLER:               'Chiller',
+  HIDROMETRO:            'Hidrômetro',
+  HIDROMETRO_AREA_COMUM: 'Hidrômetro Área Comum',
+  HIDROMETRO_SHOPPING:   'Hidrômetro Shopping',
+  CAIXA_DAGUA:           "Caixa d'Água",
+  TERMOSTATO:            'Termostato',
+};
+
+/** Default fallback URL when type is unknown or not yet mapped. */
+export const DEFAULT_DEVICE_ICON =
+  'https://dashboard.myio-bas.com/api/images/public/f9Ce4meybsdaAhAkUlAfy5ei3I4kcN4k'; // generic 3F_MEDIDOR
+
+/**
+ * Resolves the static image URL for a given device type string.
+ * Lookup is case-insensitive on the input; the canonical keys are uppercase.
+ *
+ * @param deviceType - typically `ctx.data` deviceType or deviceProfile attribute
+ * @returns the mapped URL, or `DEFAULT_DEVICE_ICON` when not recognised
+ */
+export function getDeviceIcon(deviceType?: string | null): string {
+  const key = String(deviceType || '').toUpperCase();
+  return (deviceIcons as Record<string, string>)[key] ?? DEFAULT_DEVICE_ICON;
+}
+
+/** Type guard — narrows an arbitrary string to `DeviceIconType` if valid. */
+export function isDeviceIconType(value: string): value is DeviceIconType {
+  return value.toUpperCase() in deviceIcons;
+}

--- a/tests/utils/deviceIcons.test.ts
+++ b/tests/utils/deviceIcons.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DeviceIconType,
+  deviceIcons,
+  deviceIconLabels,
+  DEFAULT_DEVICE_ICON,
+  getDeviceIcon,
+  isDeviceIconType,
+} from '../../src/utils/deviceIcons';
+
+describe('RFC-0200 deviceIcons utility', () => {
+  // Test 1: Every DeviceIconType key has a corresponding deviceIcons URL
+  // and deviceIconLabels entry — no orphans in either map.
+  describe('Test 1: map completeness — no orphan keys', () => {
+    it('every DeviceIconType value has a corresponding deviceIcons URL', () => {
+      const typeValues = Object.values(DeviceIconType);
+      for (const value of typeValues) {
+        expect(deviceIcons).toHaveProperty(value);
+        expect(typeof deviceIcons[value]).toBe('string');
+        expect(deviceIcons[value].length).toBeGreaterThan(0);
+      }
+    });
+
+    it('every DeviceIconType value has a corresponding deviceIconLabels entry', () => {
+      const typeValues = Object.values(DeviceIconType);
+      for (const value of typeValues) {
+        expect(deviceIconLabels).toHaveProperty(value);
+        expect(typeof deviceIconLabels[value]).toBe('string');
+        expect(deviceIconLabels[value].length).toBeGreaterThan(0);
+      }
+    });
+
+    it('deviceIcons has no extra keys beyond DeviceIconType values', () => {
+      const allowed = new Set(Object.values(DeviceIconType));
+      for (const key of Object.keys(deviceIcons)) {
+        expect(allowed.has(key as (typeof DeviceIconType)[keyof typeof DeviceIconType])).toBe(
+          true,
+        );
+      }
+    });
+
+    it('deviceIconLabels has no extra keys beyond DeviceIconType values', () => {
+      const allowed = new Set(Object.values(DeviceIconType));
+      for (const key of Object.keys(deviceIconLabels)) {
+        expect(allowed.has(key as (typeof DeviceIconType)[keyof typeof DeviceIconType])).toBe(
+          true,
+        );
+      }
+    });
+
+    it('the const-as-const enum exposes the expected 18 entries', () => {
+      expect(Object.keys(DeviceIconType).length).toBe(18);
+      expect(Object.keys(deviceIcons).length).toBe(18);
+      expect(Object.keys(deviceIconLabels).length).toBe(18);
+    });
+  });
+
+  // Test 2: getDeviceIcon is case-insensitive
+  describe('Test 2: getDeviceIcon is case-insensitive', () => {
+    it("'fancoil', 'FANCOIL', and 'Fancoil' all resolve to the same URL", () => {
+      const lower = getDeviceIcon('fancoil');
+      const upper = getDeviceIcon('FANCOIL');
+      const mixed = getDeviceIcon('Fancoil');
+      expect(lower).toBe(upper);
+      expect(upper).toBe(mixed);
+      expect(lower).toBe(deviceIcons.FANCOIL);
+    });
+
+    it('case-insensitive lookup also works for HIDROMETRO_AREA_COMUM', () => {
+      expect(getDeviceIcon('hidrometro_area_comum')).toBe(
+        deviceIcons.HIDROMETRO_AREA_COMUM,
+      );
+      expect(getDeviceIcon('HiDrOmEtRo_ArEa_CoMuM')).toBe(
+        deviceIcons.HIDROMETRO_AREA_COMUM,
+      );
+    });
+  });
+
+  // Test 3: getDeviceIcon falls back to DEFAULT_DEVICE_ICON for null/undefined/''/unknown
+  describe('Test 3: getDeviceIcon fallback semantics', () => {
+    it('falls back for null', () => {
+      expect(getDeviceIcon(null)).toBe(DEFAULT_DEVICE_ICON);
+    });
+
+    it('falls back for undefined', () => {
+      expect(getDeviceIcon(undefined)).toBe(DEFAULT_DEVICE_ICON);
+    });
+
+    it('falls back for empty string', () => {
+      expect(getDeviceIcon('')).toBe(DEFAULT_DEVICE_ICON);
+    });
+
+    it('falls back for unknown strings', () => {
+      expect(getDeviceIcon('NOT_A_REAL_TYPE')).toBe(DEFAULT_DEVICE_ICON);
+      expect(getDeviceIcon('totally-unknown')).toBe(DEFAULT_DEVICE_ICON);
+      expect(getDeviceIcon('   ')).toBe(DEFAULT_DEVICE_ICON);
+    });
+
+    it('falls back without arguments', () => {
+      expect(getDeviceIcon()).toBe(DEFAULT_DEVICE_ICON);
+    });
+  });
+
+  // Test 4: isDeviceIconType narrows valid strings and rejects invalid ones
+  describe('Test 4: isDeviceIconType type guard', () => {
+    it('returns true for canonical (uppercase) keys', () => {
+      expect(isDeviceIconType('FANCOIL')).toBe(true);
+      expect(isDeviceIconType('TERMOSTATO')).toBe(true);
+      expect(isDeviceIconType('CAIXA_DAGUA')).toBe(true);
+      expect(isDeviceIconType('3F_MEDIDOR')).toBe(true);
+    });
+
+    it('returns true for case-insensitive variants', () => {
+      expect(isDeviceIconType('fancoil')).toBe(true);
+      expect(isDeviceIconType('Termostato')).toBe(true);
+      expect(isDeviceIconType('caixa_dagua')).toBe(true);
+    });
+
+    it('returns false for unknown strings', () => {
+      expect(isDeviceIconType('NOT_A_TYPE')).toBe(false);
+      expect(isDeviceIconType('')).toBe(false);
+      expect(isDeviceIconType('random')).toBe(false);
+      expect(isDeviceIconType('FANCOIL2')).toBe(false);
+    });
+  });
+
+  // Test 5: '3F_MEDIDOR' round-trips through case-insensitive normalisation
+  describe("Test 5: '3F_MEDIDOR' digit-prefix key round-trip", () => {
+    it('resolves identically across case variations', () => {
+      const upper = getDeviceIcon('3F_MEDIDOR');
+      const lower = getDeviceIcon('3f_medidor');
+      const mixed = getDeviceIcon('3f_Medidor');
+      expect(upper).toBe(lower);
+      expect(lower).toBe(mixed);
+      expect(upper).toBe(deviceIcons['3F_MEDIDOR']);
+    });
+
+    it('isDeviceIconType accepts both cases of the digit-prefix key', () => {
+      expect(isDeviceIconType('3F_MEDIDOR')).toBe(true);
+      expect(isDeviceIconType('3f_medidor')).toBe(true);
+      expect(isDeviceIconType('3f_Medidor')).toBe(true);
+    });
+
+    it('DeviceIconType.MEDIDOR_3F exposes the canonical 3F_MEDIDOR value', () => {
+      expect(DeviceIconType.MEDIDOR_3F).toBe('3F_MEDIDOR');
+      expect(deviceIconLabels[DeviceIconType.MEDIDOR_3F]).toBe('Medidor 3F');
+    });
+  });
+});


### PR DESCRIPTION
## Scope
Implements RFC-0200 in full + RFC-0201 Phase-1 work-list rows #3, #4, #5.

## Changes
- src/utils/deviceIcons.ts (new) — single source of truth for device-type → image URL mapping; mirrors mobile-app `core/devices/icons.ts` shape.
- src/index.ts (re-export block added) — public API surface for ESM/CJS/UMD consumers.
- tests/utils/deviceIcons.test.ts (new) — 18 tests covering all 5 RFC-0200 §Testing cases.

Per RFC-0200 §Design Decisions row 3: this PR ships the utility only. Consumer migration (template-card-v6.js, template-card-v5.js, SettingsModalView.ts, legacy-controller.js) is a follow-up (RFC-0202) and explicitly out of scope here.

## ACs satisfied
- AC-RFC-0200-1 — every `DeviceIconType` value has a matching `deviceIcons` URL and `deviceIconLabels` entry; `getDeviceIcon` is case-insensitive; falls back to `DEFAULT_DEVICE_ICON` for `null`/`undefined`/`''`/unknown; `isDeviceIconType` correctly narrows; `'3F_MEDIDOR'` digit-prefix key round-trips.
- AC-RFC-0200-2 — module is re-exported via `src/index.ts` so `MyIOLibrary.getDeviceIcon('FANCOIL')` works through the UMD bundle (`dist/myio-js-library.umd.min.js`); types appear in `dist/index.d.cts`.

## Test results
```
$ npx vitest run tests/utils/deviceIcons.test.ts
 ✓ tests/utils/deviceIcons.test.ts (18 tests) 29ms
 Test Files  1 passed (1)
      Tests  18 passed (18)
```

Full-suite snapshot (pre-existing failures unchanged):
- Base (4ce24aa5):       10 failed test files / 126 failed tests / 306 passed
- With this PR:          10 failed test files / 126 failed tests / 324 passed (+18 new from RFC-0200)

The 10 pre-existing failing test files (NODE-RED jest-globals, etc.) are unrelated to this PR.

## Bundle size
Build green (`npm run build` → all stages OK). Exact deltas measured by gzipping `dist/*` before vs after:

| Format | Before raw | After raw | Δ raw | Before gz | After gz | Δ gz |
|---|---:|---:|---:|---:|---:|---:|
| `dist/index.js` (ESM) | 4,781,704 | 4,785,133 | +3,429 | 923,904 | 924,832 | **+928 B** |
| `dist/index.cjs` | 4,813,103 | 4,816,782 | +3,679 | 929,789 | 930,757 | **+968 B** |
| `dist/myio-js-library.umd.js` | 6,256,545 | 6,260,267 | +3,722 | 1,243,829 | 1,244,756 | **+927 B** |
| `dist/myio-js-library.umd.min.js` | 5,075,593 | 5,078,843 | +3,250 | 1,073,547 | 1,074,462 | **+915 B** |

Delta gzipped: ~900 B across all formats — matches RFC-0200 §Bundle-size impact prediction (~3.2 KB raw / ~900 B gzipped) and is within budget.

> Note: the absolute bundle sizes (4.5 MB ESM / 1.2 MB UMD gzipped) exceed the historical limits in `scripts/check-bundle-size.mjs` (26 KB) and `scripts/size-check.js` (50/60/25 KB) on the base branch already — this is a pre-existing condition unrelated to RFC-0200. The RFC-0200 *delta* is +900 B gzipped, well within the budget the RFC promised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)