### PR TITLE
RFC-0201 Phase 1 — AlarmServiceOrchestrator + alarm badges + Header tooltip (pod A)

### DIFF
--- a/src/components/alarms/createAlarmServiceOrchestrator.ts
+++ b/src/components/alarms/createAlarmServiceOrchestrator.ts
@@ -1,0 +1,228 @@
+/**
+ * RFC-0183 / RFC-0201 Phase 1 — AlarmServiceOrchestrator factory.
+ *
+ * Builds an in-memory join between the customer alarm list (GCDR Alarms API)
+ * and the per-device baseline (`STATE.itemsBase`) so device cards can render
+ * an alarm-count badge without re-querying the API per card.
+ *
+ * The shape mirrors the production `window.AlarmServiceOrchestrator`
+ * constructed in `v-5.2.0/WIDGET/MAIN_VIEW/controller.js
+ * ::_buildAlarmServiceOrchestrator` (READ-ONLY reference). v-5.2.0 keys the
+ * map by `alarm.deviceId` (which equals the GCDR device UUID); v-5.4.0 keeps
+ * the same convention by keying on `BaseItem.gcdrDeviceId`.
+ *
+ * Lifecycle:
+ *   1. Controller calls the factory once `customerAlarms` and
+ *      `STATE.itemsBase` are both populated.
+ *   2. `refresh()` re-fetches via the supplied `refreshFn`, snapshots the
+ *      previous map, rebuilds, then dispatches `myio:alarm-closed` on
+ *      `window` for every alarm-id present in the previous snapshot but
+ *      missing from the new one.
+ */
+
+import type { BaseItem } from '../../types/BaseItem';
+
+/**
+ * Minimal GCDR alarm shape consumed by the orchestrator. Only the fields
+ * we read are typed strictly; everything else is preserved as `unknown`
+ * so consumers that care about API-specific fields can narrow further.
+ */
+export interface GCDRAlarm {
+  /** Stable alarm id (used for diffing across `refresh()` calls). */
+  id: string;
+  /** GCDR device UUID — matches `BaseItem.gcdrDeviceId`. */
+  gcdrDeviceId: string;
+  /** Open / Acked / Closed / etc. */
+  state?: string;
+  /** Severity level (free-form on the API side). */
+  severity?: string;
+  /**
+   * Some deployments of the GCDR Alarm API return `deviceId` instead of
+   * `gcdrDeviceId`. The factory accepts both — matching v-5.2.0's
+   * normalization step.
+   */
+  deviceId?: string;
+  /** Optional alarm-type tag. */
+  alarmType?: string;
+  /** Tags array used by the internal-support filter heuristic. */
+  tags?: string[];
+  /** Category used by the internal-support filter heuristic. */
+  category?: string;
+  /** Pass-through for any other fields the upstream API includes. */
+  [k: string]: unknown;
+}
+
+/**
+ * Public contract of the constructed orchestrator. v-5.2.0 attaches this
+ * object to `window.AlarmServiceOrchestrator`; v-5.4.0 mirrors that.
+ */
+export interface AlarmServiceOrchestrator {
+  /** `Map<gcdrDeviceId, GCDRAlarm[]>` — the join result. */
+  deviceAlarmMap: Map<string, GCDRAlarm[]>;
+  /** Returns the alarm count for a single device, or `0` if none. */
+  getAlarmCountForDevice(gcdrDeviceId: string | null | undefined): number;
+  /** Returns the alarm array for a single device, or `[]` if none. */
+  getAlarmsForDevice(gcdrDeviceId: string | null | undefined): GCDRAlarm[];
+  /**
+   * Re-fetches via the supplied `refreshFn`, recomputes the device map,
+   * dispatches `myio:alarm-closed` for each removed alarm-id.
+   */
+  refresh(): Promise<void>;
+}
+
+export interface CreateAlarmOrchestratorOpts {
+  /** All open customer alarms (already pre-fetched by the controller). */
+  customerAlarms: GCDRAlarm[];
+  /** Flat base list of all classified devices for the customer. */
+  itemsBase: BaseItem[];
+  /**
+   * When `false` (default in widget settings), alarms whose underlying
+   * device is offline are omitted from the join — preventing badge
+   * floods when a central drops.
+   */
+  showOfflineAlarms: boolean;
+  /**
+   * Pluggable re-fetch routine — the controller wraps
+   * `_prefetchCustomerAlarms` and returns the new `customerAlarms` list.
+   */
+  refreshFn: () => Promise<GCDRAlarm[]>;
+}
+
+/**
+ * Produces a `GCDRAlarm[]` filtered by the supplied options. Pulled out
+ * so `refresh()` can re-use the same logic without duplicating the
+ * offline-gating heuristic.
+ */
+function filterAlarms(
+  alarms: GCDRAlarm[],
+  itemsBase: BaseItem[],
+  showOfflineAlarms: boolean,
+): GCDRAlarm[] {
+  // Normalize `gcdrDeviceId` (v-5.2.0 normalizes alarm.source ← alarm.deviceId).
+  const normalized = alarms.map((alarm) => ({
+    ...alarm,
+    gcdrDeviceId: alarm.gcdrDeviceId || alarm.deviceId || '',
+  }));
+
+  if (showOfflineAlarms) return normalized.filter((a) => Boolean(a.gcdrDeviceId));
+
+  // Build a quick lookup: gcdrDeviceId → device.deviceStatus
+  const statusByGcdrId = new Map<string, string>();
+  for (const item of itemsBase) {
+    if (!item?.gcdrDeviceId) continue;
+    statusByGcdrId.set(item.gcdrDeviceId, (item.deviceStatus || '').toLowerCase());
+  }
+
+  return normalized.filter((a) => {
+    if (!a.gcdrDeviceId) return false;
+    const status = statusByGcdrId.get(a.gcdrDeviceId);
+    if (status === 'offline' || status === 'no_info') return false;
+    return true;
+  });
+}
+
+/**
+ * Builds `Map<gcdrDeviceId, GCDRAlarm[]>` from a flat alarm list.
+ */
+function buildDeviceAlarmMap(alarms: GCDRAlarm[]): Map<string, GCDRAlarm[]> {
+  const map = new Map<string, GCDRAlarm[]>();
+  for (const alarm of alarms) {
+    const id = alarm.gcdrDeviceId;
+    if (!id) continue;
+    if (!map.has(id)) map.set(id, []);
+    map.get(id)!.push(alarm);
+  }
+  return map;
+}
+
+/**
+ * Snapshots `Map<id, alarmId>` so we can compute the closed-alarm diff in
+ * `refresh()` without holding onto the entire previous alarm objects.
+ */
+function snapshotAlarmIndex(
+  deviceAlarmMap: Map<string, GCDRAlarm[]>,
+): Map<string, string> {
+  // alarmId → gcdrDeviceId
+  const idx = new Map<string, string>();
+  deviceAlarmMap.forEach((alarms, gid) => {
+    for (const a of alarms) {
+      if (a.id) idx.set(a.id, gid);
+    }
+  });
+  return idx;
+}
+
+/**
+ * Factory: creates a stateful `AlarmServiceOrchestrator` instance.
+ *
+ * Side effect on `refresh()`: dispatches `myio:alarm-closed` on `window`
+ * for each alarm-id present in the previous snapshot but missing from the
+ * new one. Payload: `{ alarmId, gcdrDeviceId }`.
+ */
+export function createAlarmServiceOrchestrator(
+  opts: CreateAlarmOrchestratorOpts,
+): AlarmServiceOrchestrator {
+  const { itemsBase, refreshFn } = opts;
+  let { showOfflineAlarms } = opts;
+
+  let deviceAlarmMap = buildDeviceAlarmMap(
+    filterAlarms(opts.customerAlarms || [], itemsBase, showOfflineAlarms),
+  );
+
+  function getAlarmCountForDevice(gcdrDeviceId: string | null | undefined): number {
+    if (!gcdrDeviceId) return 0;
+    return deviceAlarmMap.get(gcdrDeviceId)?.length ?? 0;
+  }
+
+  function getAlarmsForDevice(gcdrDeviceId: string | null | undefined): GCDRAlarm[] {
+    if (!gcdrDeviceId) return [];
+    return deviceAlarmMap.get(gcdrDeviceId) ?? [];
+  }
+
+  async function refresh(): Promise<void> {
+    // Snapshot the previous index so we can compute the closed-alarm diff
+    // (alarm-id keyed — count-keyed would false-positive on
+    // close-and-reopen-in-same-cycle scenarios).
+    const previousIndex = snapshotAlarmIndex(deviceAlarmMap);
+
+    let nextAlarms: GCDRAlarm[] = [];
+    try {
+      nextAlarms = (await refreshFn()) || [];
+    } catch (err) {
+      // Surface the failure via console; do not blow up the orchestrator —
+      // consumers will keep the previous map until the next successful
+      // refresh.
+      // eslint-disable-next-line no-console
+      console.warn('[AlarmServiceOrchestrator] refresh() failed:', err);
+      return;
+    }
+
+    deviceAlarmMap = buildDeviceAlarmMap(
+      filterAlarms(nextAlarms, itemsBase, showOfflineAlarms),
+    );
+
+    // Compute the closed-alarm diff (RFC-0193): alarm-ids present in old but
+    // not in new.
+    const newIndex = snapshotAlarmIndex(deviceAlarmMap);
+    if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+      previousIndex.forEach((gcdrDeviceId, alarmId) => {
+        if (!newIndex.has(alarmId)) {
+          window.dispatchEvent(
+            new CustomEvent('myio:alarm-closed', {
+              detail: { alarmId, gcdrDeviceId },
+            }),
+          );
+        }
+      });
+    }
+  }
+
+  return {
+    get deviceAlarmMap() {
+      return deviceAlarmMap;
+    },
+    getAlarmCountForDevice,
+    getAlarmsForDevice,
+    refresh,
+  };
+}

--- a/src/components/header/createHeaderComponent.ts
+++ b/src/components/header/createHeaderComponent.ts
@@ -82,6 +82,56 @@ declare global {
  * });
  * ```
  */
+/**
+ * RFC-0183 / RFC-0201 Phase 1 — Internal-support alarm predicate.
+ *
+ * Default heuristic: an alarm is "internal-support" when it has an
+ * `internal_support` tag or a `category === 'internal_support'`. This
+ * mirrors the convention used by v-5.2.0's `_prefetchCustomerAlarms`
+ * which queries with `isInternalSupportRule=<bool>`. If the upstream API
+ * later canonicalizes a different field name, update this helper.
+ *
+ * NOTE: This is a documented assumption — the rule semantics in
+ * v-5.2.0 are encoded server-side via the API query param, not in a
+ * client-side predicate. See RFC-0201 § Misuse Audit, row #15.
+ */
+function isInternalSupportAlarm(alarm: { tags?: unknown; category?: unknown }): boolean {
+  if (!alarm) return false;
+  const tags = alarm.tags;
+  if (Array.isArray(tags) && tags.includes('internal_support')) return true;
+  if (alarm.category === 'internal_support') return true;
+  return false;
+}
+
+/**
+ * RFC-0183 / RFC-0201 Phase 1 — Inject (once) the CSS var pinning the
+ * desktop tooltip width to 320 px (Sally's UX spec). Tooltip components
+ * read `--myio-tooltip-width-desktop` at render time.
+ */
+function _injectTooltipWidthVar(width: number): void {
+  if (typeof document === 'undefined') return;
+  const STYLE_ID = 'myio-header-tooltip-width-vars';
+  let styleEl = document.getElementById(STYLE_ID) as HTMLStyleElement | null;
+  if (!styleEl) {
+    styleEl = document.createElement('style');
+    styleEl.id = STYLE_ID;
+    document.head.appendChild(styleEl);
+  }
+  styleEl.textContent = `
+    :root { --myio-tooltip-width-desktop: ${width}px; }
+    @media (min-width: 768px) {
+      .myio-info-tooltip,
+      .myio-energy-summary-tooltip,
+      .myio-water-summary-tooltip,
+      .myio-temp-summary-tooltip,
+      .myio-equipment-summary-tooltip {
+        width: var(--myio-tooltip-width-desktop, 320px) !important;
+        max-width: var(--myio-tooltip-width-desktop, 320px) !important;
+      }
+    }
+  `;
+}
+
 export function createHeaderComponent(params: HeaderComponentParams): HeaderComponentInstance {
   const { container } = params;
 
@@ -89,6 +139,12 @@ export function createHeaderComponent(params: HeaderComponentParams): HeaderComp
   if (!container || !(container instanceof HTMLElement)) {
     throw new Error('[HeaderComponent] Invalid container element. Please provide a valid HTMLElement.');
   }
+
+  // RFC-0183 / RFC-0201 Phase 1 — pin tooltip width via CSS var (default 320 px).
+  const tooltipWidth = params.tooltipWidth ?? 320;
+  _injectTooltipWidthVar(tooltipWidth);
+
+  const isInternalSupportRule = params.isInternalSupportRule === true;
 
   // Create view
   const view = new HeaderView(params);
@@ -582,6 +638,39 @@ export function createHeaderComponent(params: HeaderComponentParams): HeaderComp
     return view.getThemeMode();
   }
 
+  /**
+   * RFC-0183 / RFC-0201 Phase 1 — Reads the live alarm count from
+   * `window.AlarmServiceOrchestrator`, deduplicating by alarm-id (one
+   * alarm should never be counted twice even if it ever appears under
+   * multiple device buckets) and honoring `isInternalSupportRule`.
+   */
+  function getAlarmCount(): number {
+    const aso = (
+      typeof window !== 'undefined'
+        ? (window as unknown as {
+            AlarmServiceOrchestrator?: {
+              deviceAlarmMap?: Map<string, Array<{ id?: unknown; tags?: unknown; category?: unknown }>>;
+            };
+          }).AlarmServiceOrchestrator
+        : undefined
+    );
+    const map = aso?.deviceAlarmMap;
+    if (!map) return 0;
+
+    const seen = new Set<string>();
+    let count = 0;
+    map.forEach((alarms) => {
+      for (const a of alarms) {
+        const id = String(a?.id ?? '');
+        if (!id || seen.has(id)) continue;
+        if (isInternalSupportRule && isInternalSupportAlarm(a)) continue;
+        seen.add(id);
+        count += 1;
+      }
+    });
+    return count;
+  }
+
   function destroy(): void {
     log('Destroying component');
 
@@ -660,5 +749,8 @@ export function createHeaderComponent(params: HeaderComponentParams): HeaderComp
     // Event registration
     on,
     off,
+
+    // RFC-0183 / RFC-0201 Phase 1
+    getAlarmCount,
   };
 }

--- a/src/components/header/types.ts
+++ b/src/components/header/types.ts
@@ -411,6 +411,27 @@ export interface HeaderComponentParams {
   onCardClick?: (cardType: CardType) => void;
   /** Called when hovering over a card */
   onCardHover?: (cardType: CardType, isHovering: boolean) => void;
+
+  // RFC-0183 / RFC-0201 Phase 1 — Header alarm tooltip wiring
+  /**
+   * Desktop tooltip width in pixels. Pinned to 320 by default per Sally's
+   * UX spec (`--myio-tooltip-width-desktop`). Below 768px breakpoint the
+   * tooltip is content-driven.
+   */
+  tooltipWidth?: number;
+  /**
+   * When `true`, internal-support alarms are filtered out of the visible
+   * Header alarm count (so customer-facing tooltips don't include the
+   * MYIO-internal noise). Default: `false`.
+   */
+  isInternalSupportRule?: boolean;
+  /**
+   * When `true`, alarms whose underlying device is offline still count
+   * toward the Header total. When `false` (default), they are excluded.
+   * Mirrors the orchestrator-level setting so the Header total matches
+   * the badge totals on cards.
+   */
+  showOfflineAlarms?: boolean;
 }
 
 // ============================================================================
@@ -468,6 +489,14 @@ export interface HeaderComponentInstance {
   on: (event: HeaderEventType, handler: HeaderEventHandler) => void;
   /** Unregister an event handler */
   off: (event: HeaderEventType, handler: HeaderEventHandler) => void;
+
+  // RFC-0183 / RFC-0201 Phase 1
+  /**
+   * Returns the deduplicated alarm count read from
+   * `window.AlarmServiceOrchestrator`, with `isInternalSupportRule`
+   * filtering applied if enabled on the component.
+   */
+  getAlarmCount: () => number;
 }
 
 // ============================================================================

--- a/src/components/telemetry-grid-shopping/TelemetryGridShoppingView.ts
+++ b/src/components/telemetry-grid-shopping/TelemetryGridShoppingView.ts
@@ -237,6 +237,15 @@ export class TelemetryGridShoppingView {
       this._refreshTicketBadges();
     });
 
+    // RFC-0183 / RFC-0201 Phase 1: Re-render alarm badges when the orchestrator
+    // signals an alarm was closed or the alarm map was just (re)built.
+    window.addEventListener('myio:alarm-closed', () => {
+      this._refreshAlarmBadges();
+    });
+    window.addEventListener('myio:alarms-refreshed', () => {
+      this._refreshAlarmBadges();
+    });
+
     // Search toggle
     const btnSearch = this.root.querySelector('#btnSearch');
     btnSearch?.addEventListener('click', () => this.toggleSearch());
@@ -550,11 +559,23 @@ export class TelemetryGridShoppingView {
             wrapper.appendChild(cardElement);
             this.cardInstances.set(device.entityId, $card);
 
-            // RFC-0183: Inject alarm badge if device has active alarms
+            // RFC-0183 / RFC-0201 Phase 1: Inject alarm badge if device has
+            // active alarms. Hidden when count = 0 OR (when
+            // `showOfflineAlarms = false` AND device is offline). The
+            // showOfflineAlarms gating happens at orchestrator level (offline
+            // alarms are filtered out of `deviceAlarmMap` in that case), so
+            // here we only need to short-circuit on offline-device cards
+            // when the orchestrator was built with offline-gating ON.
             const aso = (window as unknown as { AlarmServiceOrchestrator?: {
               getAlarmCountForDevice: (id: string) => number;
             } }).AlarmServiceOrchestrator;
-            if (aso && device.gcdrDeviceId) {
+            const settingsView = (window as unknown as {
+              MyIOUtils?: { showOfflineAlarms?: boolean };
+            }).MyIOUtils;
+            const showOfflineAlarms = settingsView?.showOfflineAlarms === true;
+            const deviceStatus = (device as { deviceStatus?: string }).deviceStatus?.toLowerCase() ?? '';
+            const isOffline = deviceStatus === 'offline' || deviceStatus === 'no_info';
+            if (aso && device.gcdrDeviceId && !(isOffline && !showOfflineAlarms)) {
               const count = aso.getAlarmCountForDevice(device.gcdrDeviceId);
               if (count > 0) {
                 wrapper.appendChild(this._createAlarmBadge(count));
@@ -688,14 +709,18 @@ export class TelemetryGridShoppingView {
 
   private _createAlarmBadge(count: number): HTMLElement {
     this._injectAlarmBadgeStyles();
+    // RFC-0201 Phase 1 (Sally's UX spec): 20×20 px red bell at top-right of
+    // card, 6px inset (`--myio-badge-offset`), white bell glyph; count > 1
+    // rendered as superscript number to the lower-right of the bell.
     const badge = document.createElement('div');
     badge.className = 'myio-alarm-badge';
     badge.title = `${count} alarme${count !== 1 ? 's' : ''} ativo${count !== 1 ? 's' : ''}`;
+    const display = count > 99 ? '99+' : String(count);
     badge.innerHTML = `
-      <svg viewBox="0 0 24 24" width="10" height="10" fill="currentColor" aria-hidden="true">
+      <svg class="myio-alarm-badge__glyph" viewBox="0 0 24 24" width="12" height="12" fill="currentColor" aria-hidden="true">
         <path d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.9 2 2 2zm6-6V11c0-3.07-1.63-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.64 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"/>
       </svg>
-      <span>${count > 99 ? '99+' : count}</span>
+      ${count > 1 ? `<sup class="myio-alarm-badge__count">${display}</sup>` : ''}
     `;
     return badge;
   }
@@ -706,26 +731,83 @@ export class TelemetryGridShoppingView {
     if (document.getElementById('myio-alarm-badge-styles')) return;
     const s = document.createElement('style');
     s.id = 'myio-alarm-badge-styles';
+    // RFC-0201 Phase 1: Sally's UX spec — pin offset as a CSS var so future
+    // redesigns don't drift; circle, top-right, white bell glyph, sup count.
     s.textContent = `
+      .card-wrapper { position: relative; --myio-badge-offset: 6px; }
       .myio-alarm-badge {
         position: absolute;
-        top: 6px;
-        left: 6px;
+        top: var(--myio-badge-offset, 6px);
+        right: var(--myio-badge-offset, 6px);
+        width: 20px;
+        height: 20px;
         background: #dc2626;
         color: #fff;
-        border-radius: 10px;
-        padding: 2px 5px;
-        font-size: 10px;
-        font-weight: 700;
+        border-radius: 50%;
         display: flex;
         align-items: center;
-        gap: 2px;
+        justify-content: center;
         z-index: 10;
         pointer-events: none;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+      }
+      .myio-alarm-badge__glyph { display: block; }
+      .myio-alarm-badge__count {
+        position: absolute;
+        bottom: -4px;
+        right: -6px;
+        background: #fff;
+        color: #dc2626;
+        border-radius: 8px;
+        padding: 0 3px;
+        font-size: 9px;
+        font-weight: 700;
         line-height: 1.3;
+        min-width: 12px;
+        text-align: center;
       }
     `;
     document.head.appendChild(s);
+  }
+
+  /**
+   * RFC-0183 / RFC-0201 Phase 1: Refresh alarm-badge counts on all currently
+   * rendered card wrappers without re-rendering the grid. Triggered by
+   * `myio:alarm-closed` and `myio:alarms-refreshed`.
+   */
+  private _refreshAlarmBadges(): void {
+    const aso = (window as unknown as { AlarmServiceOrchestrator?: {
+      getAlarmCountForDevice: (id: string) => number;
+    } }).AlarmServiceOrchestrator;
+    if (!aso) return;
+
+    const settingsView = (window as unknown as {
+      MyIOUtils?: { showOfflineAlarms?: boolean };
+    }).MyIOUtils;
+    const showOfflineAlarms = settingsView?.showOfflineAlarms === true;
+
+    const devices = this.controller.getFilteredDevices();
+    const wrappers = this.shopsListEl?.querySelectorAll<HTMLElement>('.card-wrapper');
+    if (!wrappers) return;
+
+    wrappers.forEach((wrapper) => {
+      // Drop the stale badge before reading the new count.
+      wrapper.querySelector('.myio-alarm-badge')?.remove();
+
+      const entityId = wrapper.dataset.entityId;
+      if (!entityId) return;
+      const device = devices.find((d) => d.entityId === entityId);
+      if (!device || !device.gcdrDeviceId) return;
+
+      const status = (device as { deviceStatus?: string }).deviceStatus?.toLowerCase() ?? '';
+      const isOffline = status === 'offline' || status === 'no_info';
+      if (isOffline && !showOfflineAlarms) return;
+
+      const count = aso.getAlarmCountForDevice(device.gcdrDeviceId);
+      if (count > 0) {
+        wrapper.appendChild(this._createAlarmBadge(count));
+      }
+    });
   }
 
   // =========================================================================

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,16 @@ export {
   isDeviceIconType,
 } from './utils/deviceIcons';
 
+// Alarm Service Orchestrator (RFC-0183 / RFC-0201 Phase 1)
+export {
+  createAlarmServiceOrchestrator,
+} from './components/alarms/createAlarmServiceOrchestrator';
+export type {
+  AlarmServiceOrchestrator,
+  GCDRAlarm,
+  CreateAlarmOrchestratorOpts,
+} from './components/alarms/createAlarmServiceOrchestrator';
+
 // RFC-0109: Device Item Factory utilities
 export {
   DomainType,

--- a/src/thingsboard/main-dashboard-shopping/v-5.4.0/controller.js
+++ b/src/thingsboard/main-dashboard-shopping/v-5.4.0/controller.js
@@ -1079,6 +1079,38 @@ self.onInit = async function () {
     _prefetchCustomerAlarms(gcdrCustomerId, gcdrTenantId, alarmsApiBaseUrl);
   }
 
+  // RFC-0183 / RFC-0201 Phase 1 (rows #8, #9): build window.AlarmServiceOrchestrator
+  // once both `customerAlarms` (from `_prefetchCustomerAlarms`) and `STATE.itemsBase`
+  // (from `processDataAndDispatchEvents`, dispatched as `myio:data-ready`) are ready.
+  // We register the listener BEFORE `createComponents()` so we never miss the first
+  // `myio:data-ready` event (which can fire during component construction).
+  let _alarmOrchBuilt = false;
+  const _showOfflineAlarms = settings.showOfflineAlarms ?? false;
+  window.addEventListener('myio:data-ready', () => {
+    if (_alarmOrchBuilt) return;
+    const lib = window.MyIOLibrary;
+    if (!lib?.createAlarmServiceOrchestrator) return;
+    const customerAlarms = window.MyIOOrchestrator?.customerAlarms;
+    const itemsBase = window.STATE?.itemsBase;
+    if (!Array.isArray(customerAlarms) || !Array.isArray(itemsBase)) return;
+    window.AlarmServiceOrchestrator = lib.createAlarmServiceOrchestrator({
+      customerAlarms,
+      itemsBase,
+      showOfflineAlarms: _showOfflineAlarms,
+      refreshFn: async () => {
+        await _prefetchCustomerAlarms(gcdrCustomerId, gcdrTenantId, alarmsApiBaseUrl);
+        return window.MyIOOrchestrator?.customerAlarms ?? [];
+      },
+    });
+    _alarmOrchBuilt = true;
+    LogHelper.log(
+      '[MAIN] AlarmServiceOrchestrator constructed; deviceAlarmMap size:',
+      window.AlarmServiceOrchestrator.deviceAlarmMap.size,
+    );
+    // Notify cards/tooltips so they can re-render with the now-available counts.
+    window.dispatchEvent(new CustomEvent('myio:alarms-refreshed'));
+  });
+
   // Create components
   createComponents();
 

--- a/tests/components/alarms/createAlarmServiceOrchestrator.test.ts
+++ b/tests/components/alarms/createAlarmServiceOrchestrator.test.ts
@@ -1,0 +1,248 @@
+/**
+ * RFC-0183 / RFC-0201 Phase-1 — AC-RFC-0183-1, AC-RFC-0183-2.
+ *
+ * Verifies the AlarmServiceOrchestrator factory correctly:
+ *   - Joins customerAlarms × itemsBase by `gcdrDeviceId` into
+ *     `Map<gcdrDeviceId, GCDRAlarm[]>`.
+ *   - Returns 0/[] for null/undefined lookups.
+ *   - Honors the `showOfflineAlarms` gate at orchestrator level.
+ *   - Re-fetches via `refreshFn` and dispatches `myio:alarm-closed` for
+ *     every alarm-id present in the previous snapshot but absent from
+ *     the new one.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  createAlarmServiceOrchestrator,
+  type GCDRAlarm,
+} from '../../../src/components/alarms/createAlarmServiceOrchestrator';
+import type { BaseItem } from '../../../src/types/BaseItem';
+
+/**
+ * Build a minimal `BaseItem` with just the fields the orchestrator reads.
+ * The factory only touches `gcdrDeviceId` and `deviceStatus`; everything
+ * else is filler to satisfy the type.
+ */
+function makeItem(overrides: Partial<BaseItem>): BaseItem {
+  return {
+    id: overrides.entityId ?? 'tb-default',
+    entityId: overrides.entityId ?? 'tb-default',
+    name: 'Device',
+    label: 'Device',
+    labelOrName: 'Device',
+    deviceType: '3F_MEDIDOR',
+    deviceProfile: '3F_MEDIDOR',
+    identifier: '',
+    centralName: '',
+    slaveId: '',
+    centralId: '',
+    customerId: '',
+    ownerName: '',
+    ingestionId: '',
+    consumption: null,
+    val: null,
+    value: null,
+    pulses: undefined,
+    temperature: undefined,
+    connectionStatus: 'online',
+    deviceStatus: 'online',
+    domain: 'energy',
+    lastActivityTime: undefined,
+    lastConnectTime: undefined,
+    gcdrDeviceId: null,
+    ...overrides,
+  };
+}
+
+function makeAlarm(overrides: Partial<GCDRAlarm>): GCDRAlarm {
+  return {
+    id: 'alarm-default',
+    gcdrDeviceId: 'gcdr-default',
+    state: 'OPEN',
+    severity: 'major',
+    ...overrides,
+  };
+}
+
+describe('RFC-0183 createAlarmServiceOrchestrator', () => {
+  describe('AC-RFC-0183-1 — deviceAlarmMap join + counts', () => {
+    it('builds correct counts for 3 alarms across 2 devices (1 + 2)', () => {
+      // Three customers devices, two of them have alarms.
+      const itemsBase: BaseItem[] = [
+        makeItem({ entityId: 'tb-A', gcdrDeviceId: 'gcdr-A', deviceStatus: 'online' }),
+        makeItem({ entityId: 'tb-B', gcdrDeviceId: 'gcdr-B', deviceStatus: 'online' }),
+        makeItem({ entityId: 'tb-C', gcdrDeviceId: 'gcdr-C', deviceStatus: 'online' }),
+      ];
+      const customerAlarms: GCDRAlarm[] = [
+        makeAlarm({ id: 'a1', gcdrDeviceId: 'gcdr-A' }),
+        makeAlarm({ id: 'a2', gcdrDeviceId: 'gcdr-B' }),
+        makeAlarm({ id: 'a3', gcdrDeviceId: 'gcdr-B' }),
+      ];
+
+      const orch = createAlarmServiceOrchestrator({
+        customerAlarms,
+        itemsBase,
+        showOfflineAlarms: true, // not relevant when all online
+        refreshFn: async () => [],
+      });
+
+      expect(orch.getAlarmCountForDevice('gcdr-A')).toBe(1);
+      expect(orch.getAlarmCountForDevice('gcdr-B')).toBe(2);
+      // Unaffected device → 0.
+      expect(orch.getAlarmCountForDevice('gcdr-C')).toBe(0);
+      // Map size should equal the number of devices that have alarms.
+      expect(orch.deviceAlarmMap.size).toBe(2);
+    });
+
+    it('returns 0 for null/undefined gcdrDeviceId', () => {
+      const orch = createAlarmServiceOrchestrator({
+        customerAlarms: [],
+        itemsBase: [],
+        showOfflineAlarms: false,
+        refreshFn: async () => [],
+      });
+      expect(orch.getAlarmCountForDevice(null)).toBe(0);
+      expect(orch.getAlarmCountForDevice(undefined)).toBe(0);
+      expect(orch.getAlarmsForDevice(null)).toEqual([]);
+      expect(orch.getAlarmsForDevice(undefined)).toEqual([]);
+    });
+
+    it('accepts alarm.deviceId as a fallback when gcdrDeviceId is missing', () => {
+      // Some GCDR API responses still use `deviceId` instead of `gcdrDeviceId`
+      // — the factory must accept both (mirrors v-5.2.0 normalization).
+      const itemsBase = [
+        makeItem({ entityId: 'tb-A', gcdrDeviceId: 'gcdr-A', deviceStatus: 'online' }),
+      ];
+      const customerAlarms = [
+        // gcdrDeviceId omitted, deviceId provided:
+        { id: 'a1', deviceId: 'gcdr-A' } as unknown as GCDRAlarm,
+      ];
+      const orch = createAlarmServiceOrchestrator({
+        customerAlarms,
+        itemsBase,
+        showOfflineAlarms: true,
+        refreshFn: async () => [],
+      });
+      expect(orch.getAlarmCountForDevice('gcdr-A')).toBe(1);
+    });
+  });
+
+  describe('AC-RFC-0183-2 — showOfflineAlarms gating', () => {
+    it('hides alarms on offline devices when showOfflineAlarms = false', () => {
+      const itemsBase: BaseItem[] = [
+        makeItem({ entityId: 'tb-A', gcdrDeviceId: 'gcdr-A', deviceStatus: 'offline' }),
+        makeItem({ entityId: 'tb-B', gcdrDeviceId: 'gcdr-B', deviceStatus: 'online' }),
+      ];
+      const customerAlarms: GCDRAlarm[] = [
+        makeAlarm({ id: 'a1', gcdrDeviceId: 'gcdr-A' }),
+        makeAlarm({ id: 'a2', gcdrDeviceId: 'gcdr-B' }),
+      ];
+
+      const orch = createAlarmServiceOrchestrator({
+        customerAlarms,
+        itemsBase,
+        showOfflineAlarms: false,
+        refreshFn: async () => [],
+      });
+
+      expect(orch.getAlarmCountForDevice('gcdr-A')).toBe(0); // offline → hidden
+      expect(orch.getAlarmCountForDevice('gcdr-B')).toBe(1); // online → visible
+    });
+
+    it('shows alarms on offline devices when showOfflineAlarms = true', () => {
+      const itemsBase: BaseItem[] = [
+        makeItem({ entityId: 'tb-A', gcdrDeviceId: 'gcdr-A', deviceStatus: 'offline' }),
+      ];
+      const customerAlarms: GCDRAlarm[] = [
+        makeAlarm({ id: 'a1', gcdrDeviceId: 'gcdr-A' }),
+      ];
+
+      const orch = createAlarmServiceOrchestrator({
+        customerAlarms,
+        itemsBase,
+        showOfflineAlarms: true,
+        refreshFn: async () => [],
+      });
+
+      expect(orch.getAlarmCountForDevice('gcdr-A')).toBe(1);
+    });
+
+    it('treats no_info status as offline for the gating heuristic', () => {
+      const itemsBase: BaseItem[] = [
+        makeItem({ entityId: 'tb-A', gcdrDeviceId: 'gcdr-A', deviceStatus: 'no_info' }),
+      ];
+      const customerAlarms: GCDRAlarm[] = [makeAlarm({ id: 'a1', gcdrDeviceId: 'gcdr-A' })];
+      const orch = createAlarmServiceOrchestrator({
+        customerAlarms,
+        itemsBase,
+        showOfflineAlarms: false,
+        refreshFn: async () => [],
+      });
+      expect(orch.getAlarmCountForDevice('gcdr-A')).toBe(0);
+    });
+  });
+
+  describe('refresh() — closed-alarm diff dispatches myio:alarm-closed', () => {
+    let dispatched: CustomEvent[] = [];
+
+    beforeEach(() => {
+      dispatched = [];
+      // Capture every CustomEvent dispatched onto window.
+      const orig = window.dispatchEvent.bind(window);
+      vi.spyOn(window, 'dispatchEvent').mockImplementation((ev: Event) => {
+        if (ev instanceof CustomEvent) dispatched.push(ev);
+        return orig(ev);
+      });
+    });
+
+    it('dispatches myio:alarm-closed for every removed alarm-id', async () => {
+      const itemsBase: BaseItem[] = [
+        makeItem({ entityId: 'tb-A', gcdrDeviceId: 'gcdr-A', deviceStatus: 'online' }),
+      ];
+      const initial: GCDRAlarm[] = [
+        makeAlarm({ id: 'a1', gcdrDeviceId: 'gcdr-A' }),
+        makeAlarm({ id: 'a2', gcdrDeviceId: 'gcdr-A' }),
+      ];
+      // After refresh, only a1 remains — a2 should fire myio:alarm-closed.
+      const refreshed: GCDRAlarm[] = [makeAlarm({ id: 'a1', gcdrDeviceId: 'gcdr-A' })];
+
+      const orch = createAlarmServiceOrchestrator({
+        customerAlarms: initial,
+        itemsBase,
+        showOfflineAlarms: true,
+        refreshFn: async () => refreshed,
+      });
+
+      expect(orch.getAlarmCountForDevice('gcdr-A')).toBe(2);
+      await orch.refresh();
+      expect(orch.getAlarmCountForDevice('gcdr-A')).toBe(1);
+
+      const closed = dispatched.filter((e) => e.type === 'myio:alarm-closed');
+      expect(closed).toHaveLength(1);
+      expect((closed[0].detail as { alarmId: string }).alarmId).toBe('a2');
+      expect((closed[0].detail as { gcdrDeviceId: string }).gcdrDeviceId).toBe('gcdr-A');
+    });
+
+    it('does not dispatch myio:alarm-closed when no alarms were removed', async () => {
+      const itemsBase: BaseItem[] = [
+        makeItem({ entityId: 'tb-A', gcdrDeviceId: 'gcdr-A', deviceStatus: 'online' }),
+      ];
+      const initial: GCDRAlarm[] = [makeAlarm({ id: 'a1', gcdrDeviceId: 'gcdr-A' })];
+      const refreshed: GCDRAlarm[] = [
+        makeAlarm({ id: 'a1', gcdrDeviceId: 'gcdr-A' }),
+        makeAlarm({ id: 'a2', gcdrDeviceId: 'gcdr-A' }), // new alarm — not closed
+      ];
+
+      const orch = createAlarmServiceOrchestrator({
+        customerAlarms: initial,
+        itemsBase,
+        showOfflineAlarms: true,
+        refreshFn: async () => refreshed,
+      });
+
+      await orch.refresh();
+      const closed = dispatched.filter((e) => e.type === 'myio:alarm-closed');
+      expect(closed).toHaveLength(0);
+    });
+  });
+});

--- a/tests/components/header/createHeaderComponent.alarms.test.ts
+++ b/tests/components/header/createHeaderComponent.alarms.test.ts
@@ -1,0 +1,114 @@
+/**
+ * RFC-0183 / RFC-0201 Phase-1 — AC-RFC-0183-3 + isInternalSupportRule
+ *
+ * Verifies that:
+ *   1. `createHeaderComponent({ tooltipWidth: 320 })` injects the desktop
+ *      tooltip-width CSS var to the page (Sally's UX spec).
+ *   2. `getAlarmCount()` reads from `window.AlarmServiceOrchestrator` and
+ *      filters internal-support entries when `isInternalSupportRule = true`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createHeaderComponent } from '../../../src/components/header/createHeaderComponent';
+
+/** Minimal fake AlarmServiceOrchestrator stub matching the shape the
+ *  Header component reads (deviceAlarmMap with alarm objects). */
+function fakeAlarmOrch(alarmsByDevice: Record<string, Array<Record<string, unknown>>>) {
+  const map = new Map<string, Array<Record<string, unknown>>>();
+  for (const [k, v] of Object.entries(alarmsByDevice)) map.set(k, v);
+  return { deviceAlarmMap: map };
+}
+
+let mountEl: HTMLElement;
+
+beforeEach(() => {
+  mountEl = document.createElement('div');
+  document.body.appendChild(mountEl);
+});
+
+afterEach(() => {
+  // Clean up DOM between tests so the injected style tag doesn't leak.
+  document.getElementById('myio-header-tooltip-width-vars')?.remove();
+  mountEl.remove();
+  delete (window as unknown as { AlarmServiceOrchestrator?: unknown }).AlarmServiceOrchestrator;
+});
+
+describe('RFC-0201 Phase-1 — Header alarm tooltip + count', () => {
+  describe('AC-RFC-0183-3 — desktop tooltip width pinned to 320px', () => {
+    it('injects --myio-tooltip-width-desktop = 320px on render (default)', () => {
+      createHeaderComponent({ container: mountEl });
+      const styleEl = document.getElementById('myio-header-tooltip-width-vars');
+      expect(styleEl).not.toBeNull();
+      expect(styleEl!.textContent).toContain('--myio-tooltip-width-desktop: 320px');
+    });
+
+    it('honors a custom tooltipWidth value', () => {
+      createHeaderComponent({ container: mountEl, tooltipWidth: 400 });
+      const styleEl = document.getElementById('myio-header-tooltip-width-vars');
+      expect(styleEl!.textContent).toContain('--myio-tooltip-width-desktop: 400px');
+    });
+  });
+
+  describe('getAlarmCount — reads from AlarmServiceOrchestrator', () => {
+    it('returns the deduplicated total alarm count across all devices', () => {
+      (window as unknown as { AlarmServiceOrchestrator?: unknown }).AlarmServiceOrchestrator =
+        fakeAlarmOrch({
+          'gcdr-A': [{ id: 'a1' }, { id: 'a2' }],
+          'gcdr-B': [{ id: 'a3' }],
+        });
+
+      const header = createHeaderComponent({ container: mountEl });
+      expect(header.getAlarmCount()).toBe(3);
+    });
+
+    it('deduplicates alarms that appear under multiple devices (id-keyed)', () => {
+      (window as unknown as { AlarmServiceOrchestrator?: unknown }).AlarmServiceOrchestrator =
+        fakeAlarmOrch({
+          'gcdr-A': [{ id: 'shared-1' }, { id: 'a2' }],
+          'gcdr-B': [{ id: 'shared-1' }, { id: 'a3' }], // shared-1 dedup'd
+        });
+
+      const header = createHeaderComponent({ container: mountEl });
+      expect(header.getAlarmCount()).toBe(3); // a2, a3, shared-1
+    });
+
+    it('returns 0 when AlarmServiceOrchestrator is not set', () => {
+      const header = createHeaderComponent({ container: mountEl });
+      expect(header.getAlarmCount()).toBe(0);
+    });
+  });
+
+  describe('isInternalSupportRule — filters internal-support entries', () => {
+    it('filters out alarms with internal_support tag when rule is enabled', () => {
+      (window as unknown as { AlarmServiceOrchestrator?: unknown }).AlarmServiceOrchestrator =
+        fakeAlarmOrch({
+          'gcdr-A': [
+            { id: 'a1' },
+            { id: 'a2', tags: ['internal_support'] },
+            { id: 'a3', category: 'internal_support' },
+          ],
+        });
+
+      const header = createHeaderComponent({
+        container: mountEl,
+        isInternalSupportRule: true,
+      });
+      // Only a1 should be counted (a2 + a3 are internal-support).
+      expect(header.getAlarmCount()).toBe(1);
+    });
+
+    it('does not filter when isInternalSupportRule = false (default)', () => {
+      (window as unknown as { AlarmServiceOrchestrator?: unknown }).AlarmServiceOrchestrator =
+        fakeAlarmOrch({
+          'gcdr-A': [
+            { id: 'a1' },
+            { id: 'a2', tags: ['internal_support'] },
+            { id: 'a3', category: 'internal_support' },
+          ],
+        });
+
+      const header = createHeaderComponent({ container: mountEl }); // default = false
+      expect(header.getAlarmCount()).toBe(3);
+    });
+  });
+});


### PR DESCRIPTION
## Scope
Implements RFC-0201 Phase-1 work-list rows #8–#15. Depends on Pod F0 (gcdrDeviceId + itemsBase, merged in PR #63).

## Changes
- `src/components/alarms/createAlarmServiceOrchestrator.ts` — new factory: deviceAlarmMap, getAlarmCountForDevice, getAlarmsForDevice, refresh (with closed-alarm diff dispatching `myio:alarm-closed`).
- `src/components/header/createHeaderComponent.ts` + `types.ts` — alarm tooltip width 320px, count from orchestrator, isInternalSupportRule filter.
- `src/components/telemetry-grid-shopping/TelemetryGridShoppingView.ts` — alarm badge slot (top-right, 6px inset, red bell, superscript count); reads `window.AlarmServiceOrchestrator?.getAlarmCountForDevice(item.gcdrDeviceId)`; re-renders on `myio:alarm-closed`.
- `src/index.ts` — re-export `createAlarmServiceOrchestrator` + types.
- `src/thingsboard/main-dashboard-shopping/v-5.4.0/controller.js` — wired via `myio:data-ready` listener post-`_prefetchCustomerAlarms`.

## ACs satisfied
- AC-RFC-0183-1 (3 alarms / 2 devices: badges show correct counts, others show none)
- AC-RFC-0183-2 (showOfflineAlarms gating)
- AC-RFC-0183-3 (Header tooltip 320px width)

## Test results
\`\`\`
Test Files  2 passed (2)
     Tests  15 passed (15)
\`\`\`

## controller.js LOC delta
+32 lines (myio:data-ready listener + orchestrator construction).

## Notes
- `isInternalSupportRule` semantic: defaults to checking `alarm.tags.includes('internal_support') || alarm.category === 'internal_support'`. Documented in code comment for follow-up if v-5.2.0 has a different rule definition.