### PR TITLE
RFC-0201 Phase 2 -- Reports menu + AllReportModal orchIdSet filter + buildItemsList (pod E)

### DIFF
--- a/src/components/menu-shopping/MenuShoppingView.ts
+++ b/src/components/menu-shopping/MenuShoppingView.ts
@@ -21,7 +21,8 @@ type ViewEventType =
   | 'settings-click'
   | 'shopping-selector-click'
   | 'logout-click'
-  | 'hamburger-click';
+  | 'hamburger-click'
+  | 'reports-click';
 
 type ViewEventHandler = (...args: unknown[]) => void;
 
@@ -44,6 +45,9 @@ export class MenuShoppingView {
   private settingsBtn: HTMLButtonElement | null = null;
   private shoppingSelectorBtn: HTMLButtonElement | null = null;
   private logoutBtn: HTMLButtonElement | null = null;
+  // RFC-0181 / RFC-0201 Phase-2 #19
+  private reportsBtn: HTMLButtonElement | null = null;
+  private reportsMenuEl: HTMLElement | null = null;
 
   constructor(configTemplate?: MenuShoppingConfigTemplate, themeMode?: ThemeMode) {
     this.config = { ...DEFAULT_MENU_SHOPPING_CONFIG, ...configTemplate };
@@ -143,6 +147,12 @@ export class MenuShoppingView {
             : ''
         }
 
+        <!-- RFC-0181 / RFC-0201 Phase-2 #19 — Reports footer button -->
+        <button class="${PREFIX}-footer-btn reports" title="Relatórios" data-reports-btn="true" aria-haspopup="menu" aria-expanded="false">
+          <span class="${PREFIX}-footer-btn-icon">📊</span>
+          <span class="${PREFIX}-footer-btn-label">Relatórios</span>
+        </button>
+
         ${
           showSettingsButton
             ? `
@@ -165,6 +175,8 @@ export class MenuShoppingView {
             : ''
         }
       </div>
+
+      ${this.buildReportsMenuHTML()}
 
       ${
         showLibraryVersion
@@ -195,6 +207,94 @@ export class MenuShoppingView {
     this.settingsBtn = this.root.querySelector(`.${PREFIX}-footer-btn.settings`);
     this.shoppingSelectorBtn = this.root.querySelector(`.${PREFIX}-footer-btn.shopping-selector`);
     this.logoutBtn = this.root.querySelector(`.${PREFIX}-footer-btn.logout`);
+    // RFC-0181 / RFC-0201 Phase-2 #19
+    this.reportsBtn = this.root.querySelector(`.${PREFIX}-footer-btn.reports`);
+    this.reportsMenuEl = this.root.querySelector(`.${PREFIX}-reports-menu`);
+  }
+
+  /**
+   * RFC-0181 / RFC-0201 Phase-2 #19 — Build the Reports submenu HTML.
+   *
+   * Mirrors the structure of `MenuView.buildReportsMenuHTML` from the
+   * toolbar Menu component (RFC-0114). Group keys map to
+   * `MenuShoppingReportsGroup` and ultimately to
+   * `ItemsListGroup` from `src/utils/buildItemsList.ts`.
+   */
+  private buildReportsMenuHTML(): string {
+    type Section = {
+      domain: 'energy' | 'water' | 'temperature';
+      title: string;
+      items: { group: string; label: string; icon: string }[];
+    };
+
+    const sections: Section[] = [
+      {
+        domain: 'energy',
+        title: '⚡ Energia',
+        items: [
+          { group: 'lojas', label: 'Lojas', icon: '🏬' },
+          { group: 'entrada', label: 'Entrada', icon: '📥' },
+          { group: 'area_comum', label: 'Área Comum', icon: '🏢' },
+          { group: 'todos', label: 'Todos os Dispositivos', icon: '📋' },
+        ],
+      },
+      {
+        domain: 'water',
+        title: '💧 Água',
+        items: [
+          { group: 'entrada', label: 'Entrada', icon: '📥' },
+          { group: 'lojas', label: 'Lojas', icon: '🏬' },
+          { group: 'banheiros', label: 'Banheiros', icon: '🚻' },
+          { group: 'area_comum', label: 'Área Comum', icon: '🏢' },
+          { group: 'todos', label: 'Todos os Hidrômetros', icon: '📋' },
+        ],
+      },
+      {
+        domain: 'temperature',
+        title: '🌡️ Temperatura',
+        items: [
+          { group: 'climatizavel', label: 'Ambientes Climatizáveis', icon: '❄️' },
+          { group: 'nao_climatizavel', label: 'Ambientes Não Climatizáveis', icon: '🌤️' },
+          { group: 'todos', label: 'Todos os Ambientes', icon: '📋' },
+        ],
+      },
+    ];
+
+    const sectionHTML = sections
+      .map(
+        (section) => `
+        <div class="${PREFIX}-reports-section" data-domain="${section.domain}">
+          <div class="${PREFIX}-reports-section-title">${section.title}</div>
+          <div class="${PREFIX}-reports-section-items">
+            ${section.items
+              .map(
+                (item) => `
+              <button
+                type="button"
+                class="${PREFIX}-reports-item"
+                data-domain="${section.domain}"
+                data-group="${item.group}"
+                data-reports-item="true"
+              >
+                <span class="${PREFIX}-reports-item-ico">${item.icon}</span>
+                <span class="${PREFIX}-reports-item-label">${item.label}</span>
+              </button>`,
+              )
+              .join('')}
+          </div>
+        </div>`,
+      )
+      .join('');
+
+    return `
+      <div
+        class="${PREFIX}-reports-menu"
+        role="menu"
+        aria-hidden="true"
+      >
+        <div class="${PREFIX}-reports-menu-content">${sectionHTML}</div>
+      </div>
+    `;
   }
 
   /**
@@ -237,8 +337,66 @@ export class MenuShoppingView {
       this.emit('logout-click');
     });
 
+    // RFC-0181 / RFC-0201 Phase-2 #19 — Reports menu wiring
+    this.bindReportsMenuEvents();
+
     // Setup tooltips for collapsed mode
     this.setupCollapsedTooltips();
+  }
+
+  /**
+   * RFC-0181 / RFC-0201 Phase-2 #19 — Bind Reports button + submenu.
+   */
+  private bindReportsMenuEvents(): void {
+    if (!this.reportsBtn || !this.reportsMenuEl) return;
+
+    const btn = this.reportsBtn;
+    const menu = this.reportsMenuEl;
+
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const isOpen = menu.classList.toggle('is-open');
+      menu.setAttribute('aria-hidden', String(!isOpen));
+      btn.setAttribute('aria-expanded', String(isOpen));
+    });
+
+    // Item click — emit reports-click
+    menu.querySelectorAll('[data-reports-item]').forEach((item) => {
+      item.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const el = item as HTMLElement;
+        const group = el.dataset.group;
+        const domain = el.dataset.domain;
+        if (!group) return;
+
+        menu.classList.remove('is-open');
+        menu.setAttribute('aria-hidden', 'true');
+        btn.setAttribute('aria-expanded', 'false');
+
+        this.emit('reports-click', group, domain);
+      });
+    });
+
+    // Close on outside click
+    document.addEventListener('click', (e) => {
+      if (!menu.classList.contains('is-open')) return;
+      const target = e.target as Node | null;
+      if (target && (menu.contains(target) || btn.contains(target))) return;
+      menu.classList.remove('is-open');
+      menu.setAttribute('aria-hidden', 'true');
+      btn.setAttribute('aria-expanded', 'false');
+    });
+
+    // Close on Escape
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && menu.classList.contains('is-open')) {
+        menu.classList.remove('is-open');
+        menu.setAttribute('aria-hidden', 'true');
+        btn.setAttribute('aria-expanded', 'false');
+      }
+    });
   }
 
   /**

--- a/src/components/menu-shopping/createMenuShoppingComponent.ts
+++ b/src/components/menu-shopping/createMenuShoppingComponent.ts
@@ -57,6 +57,9 @@ export function createMenuShoppingComponent(params: MenuShoppingParams): MenuSho
   let collapsed = config.collapsed;
   let themeMode: ThemeMode = initialThemeMode || 'light';
 
+  // RFC-0181 / RFC-0201 Phase-2 #19
+  const onReportsClick = params.onReportsClick;
+
   // Event handlers
   const eventHandlers = new Map<MenuShoppingEventType, Set<MenuShoppingEventHandler>>();
 
@@ -167,6 +170,13 @@ export function createMenuShoppingComponent(params: MenuShoppingParams): MenuSho
     view.on('logout-click', () => {
       emitEvent('logout-click');
       onLogoutClick?.();
+    });
+
+    // RFC-0181 / RFC-0201 Phase-2 #19 — Reports click
+    view.on('reports-click', (group: unknown, _domain: unknown) => {
+      const groupKey = group as import('./types').MenuShoppingReportsGroup;
+      emitEvent('reports-click', groupKey);
+      onReportsClick?.(groupKey);
     });
   }
 

--- a/src/components/menu-shopping/styles.ts
+++ b/src/components/menu-shopping/styles.ts
@@ -430,6 +430,102 @@ export const MENU_SHOPPING_STYLES = `
   direction: ltr;
   -webkit-font-smoothing: antialiased;
 }
+
+/* ==========================================================================
+   RFC-0181 / RFC-0201 Phase-2 #19 — Reports submenu
+   ========================================================================== */
+.${PREFIX}-container { position: relative; }
+
+.${PREFIX}-reports-menu {
+  position: absolute;
+  left: calc(100% + 8px);
+  bottom: 16px;
+  display: none;
+  z-index: 10000;
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 12px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.18);
+  width: min(640px, 92vw);
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+.${PREFIX}-container[data-theme='dark'] .${PREFIX}-reports-menu {
+  background: #1f2937;
+  border-color: rgba(255, 255, 255, 0.1);
+  color: #f3f4f6;
+}
+
+.${PREFIX}-reports-menu.is-open { display: block; }
+
+.${PREFIX}-reports-menu-content {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.${PREFIX}-reports-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.${PREFIX}-reports-section-title {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #64748b;
+  padding: 4px 8px;
+}
+
+.${PREFIX}-reports-section-items {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 6px;
+}
+
+.${PREFIX}-reports-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 10px;
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  color: inherit;
+  text-align: left;
+  transition: all 0.15s ease;
+}
+
+.${PREFIX}-reports-item:hover {
+  background: rgba(99, 102, 241, 0.08);
+  border-color: rgba(99, 102, 241, 0.4);
+}
+
+.${PREFIX}-container[data-theme='dark'] .${PREFIX}-reports-item {
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.${PREFIX}-reports-item-ico { font-size: 16px; flex-shrink: 0; }
+
+.${PREFIX}-reports-item-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.${PREFIX}-footer-btn.reports {
+  /* same shape as other footer btns; default colors inherited */
+}
 `;
 
 let stylesInjected = false;

--- a/src/components/menu-shopping/types.ts
+++ b/src/components/menu-shopping/types.ts
@@ -99,6 +99,22 @@ export const DEFAULT_MENU_SHOPPING_CONFIG: Required<MenuShoppingConfigTemplate> 
 };
 
 /**
+ * RFC-0181 / RFC-0201 Phase-2 #19 — Group keys for the Reports menu in
+ * MenuShopping. Mirrors `ReportsGroup` from the toolbar Menu component
+ * (`src/components/menu/types.ts`) — kept locally to avoid a cyclic
+ * import between the two menu families.
+ */
+export type MenuShoppingReportsGroup =
+  | 'lojas'
+  | 'stores'
+  | 'entrada'
+  | 'area_comum'
+  | 'todos'
+  | 'banheiros'
+  | 'climatizavel'
+  | 'nao_climatizavel';
+
+/**
  * Parameters for creating the component
  */
 export interface MenuShoppingParams {
@@ -122,6 +138,12 @@ export interface MenuShoppingParams {
   onLogoutClick?: () => void;
   /** Callback when hamburger toggle clicked */
   onToggleCollapse?: (collapsed: boolean) => void;
+  /**
+   * RFC-0181 / RFC-0201 Phase-2 #19 — Called when the user picks an item
+   * from the Reports submenu. The argument is the group key (e.g.
+   * `'lojas'`, `'entrada'`, `'climatizavel'`).
+   */
+  onReportsClick?: (group: MenuShoppingReportsGroup) => void;
 }
 
 /**
@@ -167,7 +189,8 @@ export type MenuShoppingEventType =
   | 'shopping-selector-click'
   | 'logout-click'
   | 'collapse-toggle'
-  | 'domain-changed';
+  | 'domain-changed'
+  | 'reports-click';
 
 /**
  * Event handler type

--- a/src/components/menu/MenuController.ts
+++ b/src/components/menu/MenuController.ts
@@ -177,6 +177,21 @@ export class MenuController implements MenuComponentInstance {
         console.log('[MenuController] Theme changed:', themeMode);
       }
     });
+
+    // RFC-0181 / RFC-0201 Phase-2 #19 — Reports click
+    this.view.on('reports-click', (data: unknown) => {
+      const { group, domain } = data as {
+        group: import('./types').ReportsGroup;
+        domain?: 'energy' | 'water' | 'temperature';
+      };
+
+      this.params.onReportsClick?.(group);
+      this.dispatchCustomEvent('myio:reports-click', { group, domain });
+
+      if (this.config.enableDebugMode) {
+        console.log('[MenuController] Reports clicked:', { group, domain });
+      }
+    });
   }
 
   /**

--- a/src/components/menu/MenuView.ts
+++ b/src/components/menu/MenuView.ts
@@ -13,6 +13,7 @@ import {
   TabConfig,
   ContextOption,
   Shopping,
+  ReportsGroup,
   DEFAULT_CONFIG_TEMPLATE,
   DEFAULT_LIGHT_THEME,
   DEFAULT_DARK_THEME,
@@ -176,6 +177,7 @@ export class MenuView {
   background: transparent;
   padding: 0 12px; /* RFC-0114: Align with Header (12px) and TelemetryGrid (12px) horizontal padding */
   box-sizing: border-box;
+  position: relative; /* RFC-0181: anchor for the reports menu */
 }
 
 /* ==========================================
@@ -463,6 +465,102 @@ export class MenuView {
 
 .myio-toolbar-item--goals:hover {
   background: var(--menu-goals-hover-bg, #d97706);
+}
+
+/* ==========================================
+   Reports Button + Submenu (RFC-0181 / RFC-0201 Phase-2 #19)
+   ========================================== */
+
+.myio-toolbar-item--reports {
+  background: var(--menu-reports-bg, #1565c0);
+  color: var(--menu-reports-color, #ffffff);
+}
+
+.myio-toolbar-item--reports:hover {
+  background: var(--menu-reports-hover-bg, #0d47a1);
+}
+
+.myio-reports-menu {
+  position: absolute;
+  right: 12px;
+  top: 100%;
+  margin-top: 6px;
+  display: none;
+  z-index: 9998;
+  background: var(--menu-modal-bg, #fff);
+  border: 1px solid var(--menu-modal-border, #e2e8f0);
+  border-radius: 12px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.18);
+  width: min(640px, 92vw);
+  max-height: 70vh;
+  overflow-y: auto;
+}
+
+.myio-reports-menu.is-open {
+  display: block;
+}
+
+.myio-reports-menu-content {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.myio-reports-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.myio-reports-section-title {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--menu-modal-desc, #64748b);
+  padding: 4px 8px;
+}
+
+.myio-reports-section-items {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 6px;
+}
+
+.myio-reports-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--menu-modal-border, #e2e8f0);
+  border-radius: 10px;
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--menu-modal-text, #1c2743);
+  text-align: left;
+  transition: all 0.15s ease;
+}
+
+.myio-reports-item:hover {
+  background: var(--menu-option-hover-bg, #f1f5f9);
+  border-color: var(--menu-option-active-border, #3b82f6);
+}
+
+.myio-reports-item .ico {
+  font-size: 16px;
+  flex-shrink: 0;
+}
+
+.myio-reports-item .label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* ==========================================
@@ -1536,6 +1634,8 @@ export class MenuView {
     const showFilter = this.params.showFilterButton !== false;
     const showLoad = this.params.showLoadButton !== false;
     const showClear = this.params.showClearButton !== false;
+    // RFC-0181 — Reports button (default: shown).
+    const showReports = this.params.showReportsButton !== false;
 
     return `
       <section class="myio-toolbar-root">
@@ -1576,11 +1676,17 @@ export class MenuView {
 
           ${showGoals ? '<div class="myio-toolbar-divider"></div>' : ''}
 
+          <!-- Reports (RFC-0181 / RFC-0201 Phase-2 #19) -->
+          ${showReports ? this.buildReportsButtonHTML() : ''}
+
+          ${showReports ? '<div class="myio-toolbar-divider"></div>' : ''}
+
           <!-- Theme Toggle -->
           ${this.buildThemeToggleHTML()}
         </div>
 
         ${this.buildUnifiedContextModalHTML()}
+        ${showReports ? this.buildReportsMenuHTML() : ''}
       </section>
 
       <!-- Mobile Menu Overlay -->
@@ -1899,6 +2005,130 @@ export class MenuView {
   }
 
   /**
+   * RFC-0181 / RFC-0201 Phase-2 #19 — Reports toolbar button.
+   *
+   * Triggers the Reports submenu (`#menuReportsMenu`) which lists the
+   * report groups for the active domain. Selection fires the `reports-click`
+   * view event with the selected `ReportsGroup`.
+   */
+  private buildReportsButtonHTML(): string {
+    return `
+      <button
+        id="menuReportsBtn"
+        class="myio-toolbar-item myio-toolbar-item--reports"
+        type="button"
+        title="Relatórios"
+        aria-haspopup="menu"
+        aria-expanded="false"
+      >
+        <span class="ico">📊</span>
+        <span>Relatórios</span>
+        <span class="dropdown-arrow">▼</span>
+      </button>
+    `;
+  }
+
+  /**
+   * RFC-0181 / RFC-0201 Phase-2 #19 — Reports submenu listing the
+   * group items per domain. Hidden by default; toggled by `#menuReportsBtn`.
+   *
+   * Group keys correspond to `ReportsGroup` (mirrors v-5.2.0
+   * `_renderReportsPicker.DOMAINS`):
+   * - Energy: lojas, climatizacao(area_comum), elevadores(area_comum),
+   *   escadas_rolantes(area_comum), outros(area_comum), entrada, area_comum, todos
+   * - Water: entrada, lojas, banheiros, area_comum, todos
+   * - Temperature: climatizavel, nao_climatizavel, todos
+   *
+   * The granular "Climatização / Elevadores / Escadas Rolantes / Outros"
+   * subdivisions of energy area_comum are surfaced as duplicate `area_comum`
+   * actions for now; widget can refine to RFC-0128 sub-keys later.
+   */
+  private buildReportsMenuHTML(): string {
+    type Section = {
+      domain: 'energy' | 'water' | 'temperature';
+      title: string;
+      icon: string;
+      items: { group: ReportsGroup; label: string; icon: string }[];
+    };
+
+    const sections: Section[] = [
+      {
+        domain: 'energy',
+        title: '⚡ Energia',
+        icon: '⚡',
+        items: [
+          { group: 'lojas', label: 'Lojas', icon: '🏬' },
+          { group: 'entrada', label: 'Entrada', icon: '📥' },
+          { group: 'area_comum', label: 'Área Comum', icon: '🏢' },
+          { group: 'todos', label: 'Todos os Dispositivos', icon: '📋' },
+        ],
+      },
+      {
+        domain: 'water',
+        title: '💧 Água',
+        icon: '💧',
+        items: [
+          { group: 'entrada', label: 'Entrada', icon: '📥' },
+          { group: 'lojas', label: 'Lojas', icon: '🏬' },
+          { group: 'banheiros', label: 'Banheiros', icon: '🚻' },
+          { group: 'area_comum', label: 'Área Comum', icon: '🏢' },
+          { group: 'todos', label: 'Todos os Hidrômetros', icon: '📋' },
+        ],
+      },
+      {
+        domain: 'temperature',
+        title: '🌡️ Temperatura',
+        icon: '🌡️',
+        items: [
+          { group: 'climatizavel', label: 'Ambientes Climatizáveis', icon: '❄️' },
+          { group: 'nao_climatizavel', label: 'Ambientes Não Climatizáveis', icon: '🌤️' },
+          { group: 'todos', label: 'Todos os Ambientes', icon: '📋' },
+        ],
+      },
+    ];
+
+    const sectionHTML = sections
+      .map(
+        (section) => `
+        <div class="myio-reports-section" data-domain="${section.domain}">
+          <div class="myio-reports-section-title">${section.title}</div>
+          <div class="myio-reports-section-items">
+            ${section.items
+              .map(
+                (item) => `
+              <button
+                type="button"
+                class="myio-reports-item"
+                data-domain="${section.domain}"
+                data-group="${item.group}"
+                data-reports-item="true"
+              >
+                <span class="ico">${item.icon}</span>
+                <span class="label">${item.label}</span>
+              </button>`,
+              )
+              .join('')}
+          </div>
+        </div>`,
+      )
+      .join('');
+
+    return `
+      <div
+        id="menuReportsMenu"
+        class="myio-reports-menu"
+        role="menu"
+        aria-labelledby="menuReportsBtn"
+        aria-hidden="true"
+      >
+        <div class="myio-reports-menu-content">
+          ${sectionHTML}
+        </div>
+      </div>
+    `;
+  }
+
+  /**
    * Build Filter button HTML
    */
   private buildFilterButtonHTML(): string {
@@ -2141,6 +2371,9 @@ export class MenuView {
     if (goalsBtn) {
       goalsBtn.addEventListener('click', () => this.emit('goals'));
     }
+
+    // RFC-0181 / RFC-0201 Phase-2 #19 — Reports button + submenu
+    this.bindReportsMenuEvents();
 
     // Filter button
     const filterBtn = this.root.querySelector('#menuFilterBtn');
@@ -2816,6 +3049,73 @@ export class MenuView {
     if (!confirmed) {
       this.pendingTabId = null;
     }
+  }
+
+  /**
+   * RFC-0181 / RFC-0201 Phase-2 #19 — Bind Reports button + submenu.
+   *
+   * - Toggle submenu visibility on `#menuReportsBtn` click.
+   * - Close on outside click or Escape.
+   * - On `.myio-reports-item` click, emit `reports-click` with the group
+   *   key (forwarded by `MenuController` → `params.onReportsClick`).
+   */
+  private bindReportsMenuEvents(): void {
+    const reportsBtn = this.root.querySelector('#menuReportsBtn') as HTMLElement | null;
+    const reportsMenu = this.root.querySelector('#menuReportsMenu') as HTMLElement | null;
+
+    if (!reportsBtn || !reportsMenu) return;
+
+    // Toggle on button click
+    reportsBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const isOpen = reportsMenu.classList.toggle('is-open');
+      reportsMenu.setAttribute('aria-hidden', String(!isOpen));
+      reportsBtn.setAttribute('aria-expanded', String(isOpen));
+    });
+
+    // Item click — emit reports-click with the group key
+    this.root.querySelectorAll('[data-reports-item]').forEach((item) => {
+      item.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const el = item as HTMLElement;
+        const group = el.dataset.group as ReportsGroup | undefined;
+        const domain = el.dataset.domain as 'energy' | 'water' | 'temperature' | undefined;
+        if (!group) return;
+
+        // Close the submenu
+        reportsMenu.classList.remove('is-open');
+        reportsMenu.setAttribute('aria-hidden', 'true');
+        reportsBtn.setAttribute('aria-expanded', 'false');
+
+        // Emit event — controller forwards to params.onReportsClick
+        this.emit('reports-click', { group, domain });
+
+        if (this.configTemplate.enableDebugMode) {
+          console.log('[MenuView] Reports item clicked:', { group, domain });
+        }
+      });
+    });
+
+    // Close on outside click
+    document.addEventListener('click', (e) => {
+      if (!reportsMenu.classList.contains('is-open')) return;
+      const target = e.target as Node | null;
+      if (target && (reportsMenu.contains(target) || reportsBtn.contains(target))) return;
+      reportsMenu.classList.remove('is-open');
+      reportsMenu.setAttribute('aria-hidden', 'true');
+      reportsBtn.setAttribute('aria-expanded', 'false');
+    });
+
+    // Close on Escape
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && reportsMenu.classList.contains('is-open')) {
+        reportsMenu.classList.remove('is-open');
+        reportsMenu.setAttribute('aria-hidden', 'true');
+        reportsBtn.setAttribute('aria-expanded', 'false');
+      }
+    });
   }
 
   /**

--- a/src/components/menu/index.ts
+++ b/src/components/menu/index.ts
@@ -26,6 +26,8 @@ export type {
   MenuEventType,
   MenuEventHandler,
   MenuState,
+  // RFC-0181 / RFC-0201 Phase-2 #19
+  ReportsGroup,
 } from './types';
 
 // Default configurations

--- a/src/components/menu/types.ts
+++ b/src/components/menu/types.ts
@@ -491,6 +491,13 @@ export interface MenuComponentParams {
   showLoadButton?: boolean;
   /** Show clear button (default: true) */
   showClearButton?: boolean;
+  /**
+   * RFC-0181 / RFC-0201 Phase-2 #19 — Show the Reports button in the toolbar.
+   * Default: true. The Reports button opens a per-domain dropdown listing
+   * the report groups (Lojas, Climatização, Entrada, Área Comum, etc.) and
+   * fires `onReportsClick(group)` on selection.
+   */
+  showReportsButton?: boolean;
 
   // Callbacks
   /** Called when a tab is clicked */
@@ -511,7 +518,44 @@ export interface MenuComponentParams {
   onShoppingsReady?: (shoppings: Shopping[]) => void;
   /** Called when theme mode changes */
   onThemeChange?: (themeMode: MenuThemeMode) => void;
+  /**
+   * RFC-0181 / RFC-0201 Phase-2 #19 — Called when the user picks an item
+   * from the Reports submenu. The argument is the group key (e.g.
+   * `'stores'`, `'lojas'`, `'entrada'`, `'climatizavel'`) — match the
+   * vocabulary defined in `src/utils/buildItemsList.ts::ItemsListGroup`.
+   *
+   * The widget is expected to wire this to:
+   *
+   * ```ts
+   * (group) => {
+   *   const items = buildItemsList(domain, group, window.STATE.itemsBase);
+   *   const orchIdSet = new Set(items.map(i => String(i.id)));
+   *   openDashboardPopupAllReport({ ... itemsList: items, orchIdSet });
+   * }
+   * ```
+   */
+  onReportsClick?: (group: ReportsGroup) => void;
 }
+
+/**
+ * RFC-0181 — Group keys for the Reports submenu callback.
+ *
+ * Mirrors a subset of `ItemsListGroup` from `src/utils/buildItemsList.ts`.
+ * Kept narrow on purpose: the MenuView surfaces only the canonical groups
+ * exposed by the v-5.2.0 Reports picker (no internal RFC-0111 context aliases).
+ */
+export type ReportsGroup =
+  // Energy
+  | 'lojas'
+  | 'stores'
+  | 'entrada'
+  | 'area_comum'
+  | 'todos'
+  // Water
+  | 'banheiros'
+  // Temperature
+  | 'climatizavel'
+  | 'nao_climatizavel';
 
 /**
  * Menu Component instance returned by createMenuComponent
@@ -578,7 +622,8 @@ export type MenuEventType =
   | 'clear'
   | 'goals'
   | 'shoppings-ready'
-  | 'theme-change';
+  | 'theme-change'
+  | 'reports-click';
 
 /**
  * Event handler function type

--- a/src/components/premium-modals/report-all/AllReportModal.ts
+++ b/src/components/premium-modals/report-all/AllReportModal.ts
@@ -900,10 +900,15 @@ export class AllReportModal {
       return [];
     }
 
-    // 2a) When no itemsList is provided (undefined/null), map directly from the API array.
+    // 2a) When no itemsList AND no orchIdSet is provided, map directly from the API array.
     //     An explicitly provided empty itemsList means the group has no devices → return [].
-    if (!this.params.itemsList) {
-      this.debugLog('📋 No itemsList provided — mapping directly from API array');
+    //     An explicitly provided empty orchIdSet (size 0) does NOT trigger filtering — falls
+    //     back to direct mapping for backwards compatibility.
+    const hasItemsList = !!this.params.itemsList;
+    const hasOrchIdSet = this.params.orchIdSet instanceof Set && this.params.orchIdSet.size > 0;
+
+    if (!hasItemsList && !hasOrchIdSet) {
+      this.debugLog('📋 No itemsList / orchIdSet provided — mapping directly from API array');
       return apiArray.map((item) => ({
         identifier: item.assetName || this.resolveStoreIdentifierFromApi(item) || item.id || '',
         name: item.name || item.assetName || item.id || '',
@@ -915,10 +920,18 @@ export class AllReportModal {
     //     Discards API items that don't belong to this group (e.g. area_comum filters out lojas,
     //     entrada, etc. from the full 271-device energy response).
     //     Uses total_value from the API item (picked via pickConsumption).
+    //
+    //     RFC-0201 Phase-2 #18 — `orchIdSet` (when provided) takes precedence over rebuilding
+    //     a Set from `itemsList`. Metadata (label/identifier/groupLabel) still comes from
+    //     `itemsList` when available; otherwise the API response shape is used as fallback.
 
-    // Build O(1) lookup structures from itemsList
-    const orchIdSet = new Set(this.params.itemsList.map((item) => String(item.id)));
-    const orchMeta  = new Map(this.params.itemsList.map((item) => [String(item.id), item]));
+    const orchIdSet = hasOrchIdSet
+      ? (this.params.orchIdSet as Set<string>)
+      : new Set((this.params.itemsList ?? []).map((item) => String(item.id)));
+
+    const orchMeta = new Map(
+      (this.params.itemsList ?? []).map((item) => [String(item.id), item]),
+    );
 
     this.debugLog('[AllReportModal] API-driven filter — orchestrator devices:', orchIdSet.size);
     this.debugLog('[AllReportModal] API-driven filter — API total devices:', apiArray.length);

--- a/src/components/premium-modals/types.ts
+++ b/src/components/premium-modals/types.ts
@@ -76,6 +76,23 @@ export interface OpenAllReportParams {
   ui?: BaseUiCfg;
   api: BaseApiCfg;
   itemsList?: StoreItem[]; // RFC-0182: Optional — if absent, maps directly from API response
+  /**
+   * RFC-0182 / RFC-0201 Phase-2 #18 — Server-side ingestionId allow-list.
+   *
+   * When provided, the modal filters the API response so only rows whose
+   * `id` is present in `orchIdSet` are kept. This is the API-driven filter
+   * counterpart to `itemsList`: callers can pass a pre-built `Set<string>`
+   * built from `itemsList.map(i => String(i.id))` to avoid the modal
+   * rebuilding it on every render.
+   *
+   * If both `itemsList` and `orchIdSet` are provided, `orchIdSet` takes
+   * precedence for the API-response filter (label/identifier/groupLabel
+   * still come from `itemsList`).
+   *
+   * If `orchIdSet` is `undefined` or empty AND `itemsList` is also absent,
+   * the modal falls back to mapping every API item directly.
+   */
+  orchIdSet?: Set<string>;
   fetcher?: CustomerTotalsFetcher; // Optional dependency injection for testing
   debug?: 1 | 0; // Optional debug logging flag (1 = enabled, 0 = disabled)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -794,7 +794,13 @@ export type {
   MenuEventType,
   MenuEventHandler,
   MenuState,
+  // RFC-0181 / RFC-0201 Phase-2 #19
+  ReportsGroup,
 } from './components/menu';
+
+// RFC-0182 / RFC-0201 Phase-2 #17 — Items list helper for AllReportModal.
+export { buildItemsList } from './utils/buildItemsList';
+export type { ItemsListDomain, ItemsListGroup } from './utils/buildItemsList';
 
 export { DEFAULT_MENU_CONFIG, DEFAULT_TABS } from './components/menu';
 

--- a/src/thingsboard/main-dashboard-shopping/v-5.4.0/controller.js
+++ b/src/thingsboard/main-dashboard-shopping/v-5.4.0/controller.js
@@ -622,6 +622,50 @@ function createComponents() {
         switchContentState(domain);
       },
       onToggleCollapse: handleMenuCollapse,
+      // RFC-0181 / RFC-0182 / RFC-0201 Phase-2 #20 — Reports submenu wiring.
+      // Builds the StoreItem[] for (domain, group) using STATE.itemsBase, derives
+      // the orchIdSet (API allow-list), and opens the AllReportModal.
+      onReportsClick: (group) => {
+        const itemsBase = window.STATE?.itemsBase ?? [];
+        if (!Array.isArray(itemsBase) || itemsBase.length === 0) {
+          LogHelper.warn('[MAIN] onReportsClick: STATE.itemsBase empty — aborting');
+          return;
+        }
+
+        const items = lib.buildItemsList?.(_currentDomain, group, itemsBase) ?? [];
+        const orchIdSet = new Set(items.map((item) => String(item.id)));
+
+        LogHelper.log('[MAIN] onReportsClick →', {
+          domain: _currentDomain,
+          group,
+          items: items.length,
+          orchIdSetSize: orchIdSet.size,
+        });
+
+        if (!lib.openDashboardPopupAllReport) {
+          LogHelper.warn('[MAIN] openDashboardPopupAllReport not available on lib');
+          return;
+        }
+
+        const customerId = _credentials?.ingestionId || '';
+        const ingestionToken =
+          window.MyIOOrchestrator?.tokenManager?.getToken?.('ingestionToken') || '';
+
+        lib.openDashboardPopupAllReport({
+          customerId,
+          domain: _currentDomain,
+          group,
+          itemsList: items,
+          orchIdSet,
+          api: {
+            clientId: _credentials?.clientId || '',
+            clientSecret: _credentials?.clientSecret || '',
+            dataApiBaseUrl: DATA_API_HOST,
+            ingestionToken,
+          },
+          ui: { theme: _currentThemeMode },
+        });
+      },
     });
     LogHelper.log('Menu created with theme:', _currentThemeMode);
   }

--- a/src/utils/buildItemsList.ts
+++ b/src/utils/buildItemsList.ts
@@ -1,0 +1,265 @@
+/**
+ * RFC-0182 — Build the list of `StoreItem` for a given (domain, group) pair.
+ *
+ * Mirrors the v-5.2.0 production helper at
+ * `src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/MENU/controller.js
+ * ::_buildItemsList`, but operates on the canonical Phase-1 `STATE.itemsBase`
+ * instead of the v-5.2.0 orchestrator's `getEnergyGroups()/getWaterGroups()/
+ * getTemperatureGroups()` accessors.
+ *
+ * The returned `StoreItem.id` is the device `ingestionId` so the
+ * `AllReportModal` server-side filter (`orchIdSet`) can match the GCDR API
+ * response items by `api.item.id` (RFC-0182).
+ *
+ * Group-key vocabulary kept in sync with the MENU widget's `DOMAINS` table
+ * (`_renderReportsPicker`) and the per-domain `categorizeItemsByGroup*`
+ * functions in v-5.2.0/MAIN_VIEW.
+ *
+ * @public
+ */
+
+import type { BaseItem } from '../types/BaseItem';
+import type { StoreItem } from '../components/premium-modals/types';
+
+/** Domain bucket. */
+export type ItemsListDomain = 'energy' | 'water' | 'temperature';
+
+/**
+ * All group keys understood by `buildItemsList`. The canonical mapping to
+ * v-5.2.0 categorization (and to the `AllReportModal.resolveTitle()` table)
+ * is:
+ *
+ * Energy   — `entrada`, `lojas`, `area_comum`, `todos`
+ * Water    — `entrada`, `lojas`, `area_comum`, `banheiros`, `todos`
+ * Temperature — `climatizavel`, `nao_climatizavel`, `todos`
+ *
+ * For convenience and back-compat with the MenuView taxonomy this type also
+ * allows the lower-level RFC-0111 context names (`stores`, `equipments`,
+ * `hidrometro`, `hidrometro_entrada`, `hidrometro_area_comum`,
+ * `termostato`, `termostato_external`) — they resolve to the same group sets.
+ */
+export type ItemsListGroup =
+  // Cross-domain "all" bucket
+  | 'todos'
+  // Energy group keys (production: openReportsPickerModal)
+  | 'entrada'
+  | 'lojas'
+  | 'area_comum'
+  // Energy aliases (RFC-0111 context names, used by MenuView)
+  | 'stores'
+  | 'equipments'
+  // Water group keys (production)
+  | 'banheiros'
+  // Water aliases
+  | 'hidrometro_entrada'
+  | 'hidrometro_area_comum'
+  | 'hidrometro'
+  // Temperature group keys (production)
+  | 'climatizavel'
+  | 'nao_climatizavel'
+  // Temperature aliases
+  | 'termostato'
+  | 'termostato_external';
+
+/** Mapping from group key → human-readable section label (RFC-0182, used
+ *  when building the "todos" multi-section view in `AllReportModal`). */
+const GROUP_LABELS: Record<string, string> = {
+  lojas: 'Lojas',
+  entrada: 'Entrada',
+  area_comum: 'Área Comum',
+  banheiros: 'Banheiros',
+  climatizavel: 'Climatizável',
+  nao_climatizavel: 'Não Climatizável',
+};
+
+/** Normalize input to upper-cased string for safe `includes`/equality tests. */
+function up(value: unknown): string {
+  return String(value ?? '').toUpperCase();
+}
+
+/** Energy: entrada predicate — deviceProfile ∈ {ENTRADA, RELOGIO, TRAFO, SUBESTACAO}. */
+function isEnergyEntrada(item: BaseItem): boolean {
+  const dp = up(item.deviceProfile);
+  const dt = up(item.deviceType);
+  return (
+    dp === 'ENTRADA' ||
+    dp === 'RELOGIO' ||
+    dp === 'TRAFO' ||
+    dp === 'SUBESTACAO' ||
+    dt === 'ENTRADA' ||
+    dt === 'RELOGIO' ||
+    dt === 'TRAFO' ||
+    dt === 'SUBESTACAO'
+  );
+}
+
+/** Energy: lojas predicate — deviceProfile = `3F_MEDIDOR` exact match. */
+function isEnergyLojas(item: BaseItem): boolean {
+  return up(item.deviceProfile) === '3F_MEDIDOR';
+}
+
+/** Energy: area_comum predicate — anything that's energy and not entrada/lojas. */
+function isEnergyAreaComum(item: BaseItem): boolean {
+  return !isEnergyEntrada(item) && !isEnergyLojas(item);
+}
+
+/** Water: entrada predicate — deviceProfile = HIDROMETRO_SHOPPING. */
+function isWaterEntrada(item: BaseItem): boolean {
+  return up(item.deviceProfile) === 'HIDROMETRO_SHOPPING';
+}
+
+/** Water: area_comum predicate — deviceProfile = HIDROMETRO_AREA_COMUM. */
+function isWaterAreaComum(item: BaseItem): boolean {
+  return up(item.deviceProfile) === 'HIDROMETRO_AREA_COMUM';
+}
+
+/** Water: lojas predicate — deviceProfile = HIDROMETRO. */
+function isWaterLojas(item: BaseItem): boolean {
+  return up(item.deviceProfile) === 'HIDROMETRO';
+}
+
+/** Water: banheiros predicate — area-comum profile + identifier 'BANHEIROS'. */
+function isWaterBanheiros(item: BaseItem): boolean {
+  return up(item.deviceProfile) === 'HIDROMETRO_AREA_COMUM' && up(item.identifier) === 'BANHEIROS';
+}
+
+/** Temperature: climatizavel predicate (everything not external). */
+function isTemperatureClimatizavel(item: BaseItem): boolean {
+  return up(item.deviceProfile) !== 'TERMOSTATO_EXTERNAL';
+}
+
+/** Temperature: nao_climatizavel predicate. */
+function isTemperatureNaoClimatizavel(item: BaseItem): boolean {
+  return up(item.deviceProfile) === 'TERMOSTATO_EXTERNAL';
+}
+
+/** Convert a `BaseItem` to the `StoreItem` shape expected by `AllReportModal`. */
+function toStoreItem(item: BaseItem, groupLabel?: string): StoreItem {
+  const id = String(item.ingestionId || item.id || '');
+  const identifier = String(item.identifier || item.label || item.name || '');
+  const label = String(item.label || item.labelOrName || item.name || item.identifier || '');
+
+  const result: StoreItem = { id, identifier, label };
+  if (groupLabel) {
+    (result as StoreItem & { groupLabel?: string }).groupLabel = groupLabel;
+  }
+  return result;
+}
+
+/**
+ * Build the list of `StoreItem` for the requested (domain, group) pair from
+ * the canonical `STATE.itemsBase` baseline.
+ *
+ * Behaviour:
+ * - Filters `itemsBase` by `domain` first.
+ * - Applies the group predicate (or "all groups" when `group === 'todos'`).
+ * - Maps each surviving `BaseItem` to `StoreItem` with `id = ingestionId`.
+ *
+ * `'todos'` returns every item in the domain's recognised groups, each
+ * tagged with a `groupLabel` so `AllReportModal` can render section headers.
+ *
+ * @param domain  Target domain bucket (`'energy' | 'water' | 'temperature'`).
+ * @param group   Group key (see `ItemsListGroup`).
+ * @param itemsBase Canonical baseline from `window.STATE.itemsBase`.
+ * @returns `StoreItem[]` matching the (domain, group) pair.
+ *
+ * @public
+ */
+export function buildItemsList(
+  domain: ItemsListDomain,
+  group: ItemsListGroup,
+  itemsBase: BaseItem[],
+): StoreItem[] {
+  if (!Array.isArray(itemsBase) || itemsBase.length === 0) return [];
+
+  const inDomain = itemsBase.filter((it) => it && it.domain === domain);
+
+  // "todos" — every recognised group, tagged with its label.
+  if (group === 'todos') {
+    if (domain === 'energy') {
+      const out: StoreItem[] = [];
+      for (const item of inDomain) {
+        if (isEnergyEntrada(item)) out.push(toStoreItem(item, GROUP_LABELS.entrada));
+        else if (isEnergyLojas(item)) out.push(toStoreItem(item, GROUP_LABELS.lojas));
+        else out.push(toStoreItem(item, GROUP_LABELS.area_comum));
+      }
+      return out;
+    }
+    if (domain === 'water') {
+      const out: StoreItem[] = [];
+      for (const item of inDomain) {
+        if (isWaterEntrada(item)) out.push(toStoreItem(item, GROUP_LABELS.entrada));
+        else if (isWaterBanheiros(item)) out.push(toStoreItem(item, GROUP_LABELS.banheiros));
+        else if (isWaterAreaComum(item)) out.push(toStoreItem(item, GROUP_LABELS.area_comum));
+        else if (isWaterLojas(item)) out.push(toStoreItem(item, GROUP_LABELS.lojas));
+        else out.push(toStoreItem(item, GROUP_LABELS.area_comum));
+      }
+      return out;
+    }
+    // temperature
+    const out: StoreItem[] = [];
+    for (const item of inDomain) {
+      if (isTemperatureNaoClimatizavel(item)) {
+        out.push(toStoreItem(item, GROUP_LABELS.nao_climatizavel));
+      } else {
+        out.push(toStoreItem(item, GROUP_LABELS.climatizavel));
+      }
+    }
+    return out;
+  }
+
+  // Single-group filter — no groupLabel. Some keys are shared across domains
+  // (`entrada`, `lojas`, `area_comum`) so the predicate is domain-aware.
+  let predicate: (item: BaseItem) => boolean;
+
+  switch (group) {
+    // Shared keys — predicate selected by domain.
+    case 'entrada':
+      predicate = domain === 'water' ? isWaterEntrada : isEnergyEntrada;
+      break;
+    case 'lojas':
+    case 'stores':
+      predicate = domain === 'water' ? isWaterLojas : isEnergyLojas;
+      break;
+    case 'area_comum':
+      predicate = domain === 'water' ? isWaterAreaComum : isEnergyAreaComum;
+      break;
+
+    // Energy-only RFC-0111 alias.
+    case 'equipments':
+      // "everything that is not stores/entrada" — the v-5.2.0 area_comum bucket.
+      predicate = isEnergyAreaComum;
+      break;
+
+    // Water-only keys.
+    case 'banheiros':
+      predicate = isWaterBanheiros;
+      break;
+    case 'hidrometro_entrada':
+      predicate = isWaterEntrada;
+      break;
+    case 'hidrometro_area_comum':
+      predicate = isWaterAreaComum;
+      break;
+    case 'hidrometro':
+      predicate = isWaterLojas;
+      break;
+
+    // Temperature keys.
+    case 'climatizavel':
+    case 'termostato':
+      predicate = isTemperatureClimatizavel;
+      break;
+    case 'nao_climatizavel':
+    case 'termostato_external':
+      predicate = isTemperatureNaoClimatizavel;
+      break;
+
+    default: {
+      // Unknown group — be defensive and return [].
+      return [];
+    }
+  }
+
+  return inDomain.filter(predicate).map((item) => toStoreItem(item));
+}

--- a/tests/components/menu/MenuView.reports.test.ts
+++ b/tests/components/menu/MenuView.reports.test.ts
@@ -1,0 +1,136 @@
+/**
+ * RFC-0181 / RFC-0201 Phase-2 #19 — Reports submenu tests for MenuView.
+ *
+ * Covers AC-RFC-0181-1: clicking a Reports → "Lojas" item fires the
+ * `onReportsClick` callback with `'lojas'`.
+ *
+ * The MenuView is rendered into the JSDOM document (via the global setup)
+ * and clicked programmatically — no actual ThingsBoard widget context is
+ * required.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MenuView } from '../../../src/components/menu/MenuView';
+
+describe('MenuView — Reports submenu (RFC-0181 / RFC-0201 Phase-2 #19)', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  it('renders the Reports button by default', () => {
+    const view = new MenuView({ container });
+    container.appendChild(view.render());
+
+    const reportsBtn = container.querySelector('#menuReportsBtn');
+    expect(reportsBtn).not.toBeNull();
+  });
+
+  it('does not render the Reports button when showReportsButton=false', () => {
+    const view = new MenuView({ container, showReportsButton: false });
+    container.appendChild(view.render());
+
+    expect(container.querySelector('#menuReportsBtn')).toBeNull();
+  });
+
+  it('opens and closes the Reports submenu on button click', () => {
+    const view = new MenuView({ container });
+    container.appendChild(view.render());
+
+    const reportsBtn = container.querySelector('#menuReportsBtn') as HTMLButtonElement;
+    const reportsMenu = container.querySelector('#menuReportsMenu') as HTMLElement;
+
+    expect(reportsMenu.classList.contains('is-open')).toBe(false);
+
+    reportsBtn.click();
+    expect(reportsMenu.classList.contains('is-open')).toBe(true);
+    expect(reportsBtn.getAttribute('aria-expanded')).toBe('true');
+
+    reportsBtn.click();
+    expect(reportsMenu.classList.contains('is-open')).toBe(false);
+    expect(reportsBtn.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('AC-RFC-0181-1: emits reports-click with `lojas` when "Lojas" is clicked', () => {
+    const view = new MenuView({ container });
+    container.appendChild(view.render());
+
+    const captured: { group: string; domain?: string }[] = [];
+    view.on('reports-click', (data: unknown) => {
+      captured.push(data as { group: string; domain?: string });
+    });
+
+    // Open the submenu (some browsers may not require this — JSDOM renders display:none
+    // until the class is added; click handler doesn't gate emission on `.is-open`).
+    const reportsBtn = container.querySelector('#menuReportsBtn') as HTMLButtonElement;
+    reportsBtn.click();
+
+    // Click the Energy → Lojas item
+    const lojasItem = container.querySelector(
+      '[data-reports-item="true"][data-domain="energy"][data-group="lojas"]',
+    ) as HTMLButtonElement;
+
+    expect(lojasItem).not.toBeNull();
+
+    lojasItem.click();
+
+    expect(captured.length).toBe(1);
+    expect(captured[0].group).toBe('lojas');
+    expect(captured[0].domain).toBe('energy');
+  });
+
+  it('emits reports-click with the correct group for water/banheiros', () => {
+    const view = new MenuView({ container });
+    container.appendChild(view.render());
+
+    const spy = vi.fn();
+    view.on('reports-click', spy);
+
+    const banheirosItem = container.querySelector(
+      '[data-reports-item="true"][data-domain="water"][data-group="banheiros"]',
+    ) as HTMLButtonElement;
+
+    expect(banheirosItem).not.toBeNull();
+    banheirosItem.click();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith({ group: 'banheiros', domain: 'water' });
+  });
+
+  it('emits reports-click with `climatizavel` for temperature → Climatizáveis', () => {
+    const view = new MenuView({ container });
+    container.appendChild(view.render());
+
+    const spy = vi.fn();
+    view.on('reports-click', spy);
+
+    const item = container.querySelector(
+      '[data-reports-item="true"][data-domain="temperature"][data-group="climatizavel"]',
+    ) as HTMLButtonElement;
+
+    item.click();
+
+    expect(spy).toHaveBeenCalledWith({ group: 'climatizavel', domain: 'temperature' });
+  });
+
+  it('closes the submenu after item selection', () => {
+    const view = new MenuView({ container });
+    container.appendChild(view.render());
+
+    const reportsBtn = container.querySelector('#menuReportsBtn') as HTMLButtonElement;
+    const reportsMenu = container.querySelector('#menuReportsMenu') as HTMLElement;
+
+    reportsBtn.click();
+    expect(reportsMenu.classList.contains('is-open')).toBe(true);
+
+    const lojasItem = container.querySelector(
+      '[data-reports-item="true"][data-domain="energy"][data-group="lojas"]',
+    ) as HTMLButtonElement;
+    lojasItem.click();
+
+    expect(reportsMenu.classList.contains('is-open')).toBe(false);
+  });
+});

--- a/tests/components/premium-modals/AllReportModal.orchIdSet.test.ts
+++ b/tests/components/premium-modals/AllReportModal.orchIdSet.test.ts
@@ -1,0 +1,182 @@
+/**
+ * RFC-0182 / RFC-0201 Phase-2 #18 — AllReportModal `orchIdSet` filter tests.
+ *
+ * Covers AC-RFC-0182-1: given a mock API response with 50 devices and an
+ * `orchIdSet` of 12 ingestionIds, the modal keeps only those 12 rows.
+ *
+ * The test exercises the private `mapCustomerTotalsResponse` directly to
+ * avoid the DOM-heavy `loadData()` path (which depends on jQuery
+ * DateRangePicker and ModalPremiumShell — out of scope here).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { AllReportModal } from '../../../src/components/premium-modals/report-all/AllReportModal';
+import type {
+  OpenAllReportParams,
+  StoreItem,
+} from '../../../src/components/premium-modals/types';
+
+/**
+ * Build a minimal `OpenAllReportParams` for the modal constructor — only
+ * the fields actually read by `mapCustomerTotalsResponse` need to be valid.
+ */
+function makeParams(overrides: Partial<OpenAllReportParams> = {}): OpenAllReportParams {
+  return {
+    customerId: 'cust-1',
+    domain: 'energy',
+    group: 'lojas',
+    api: {
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      dataApiBaseUrl: 'https://example.invalid',
+      ingestionToken: 'token-123',
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * Mint a fake API row, like what the GCDR Customer Totals endpoint returns.
+ */
+function makeApiItem(id: string, total = 100, name?: string) {
+  return {
+    id,
+    name: name ?? `Device ${id}`,
+    assetName: `IDENT-${id}`,
+    total_value: total,
+  };
+}
+
+/**
+ * 50 mock API rows with predictable ids `api-001` … `api-050`.
+ */
+function makeApiResponse(count = 50) {
+  const data = Array.from({ length: count }, (_, i) =>
+    makeApiItem(`api-${String(i + 1).padStart(3, '0')}`, (i + 1) * 10),
+  );
+  return { data };
+}
+
+describe('AllReportModal.mapCustomerTotalsResponse — orchIdSet filter', () => {
+  it('AC-RFC-0182-1: filters API response by orchIdSet, keeping only matching rows', () => {
+    const apiResponse = makeApiResponse(50);
+
+    // Build allow-list of 12 ids — every 4th item (1, 5, 9, …, 45) plus the last.
+    const allowedIds = [
+      'api-001',
+      'api-005',
+      'api-009',
+      'api-013',
+      'api-017',
+      'api-021',
+      'api-025',
+      'api-029',
+      'api-033',
+      'api-037',
+      'api-041',
+      'api-050',
+    ];
+    const orchIdSet = new Set<string>(allowedIds);
+
+    // Provide itemsList so the resulting rows carry stable identifier/label
+    // metadata we can match against.
+    const itemsList: StoreItem[] = allowedIds.map((id) => ({
+      id,
+      identifier: `IDENT-${id}`,
+      label: `Loja ${id}`,
+    }));
+
+    const modal = new AllReportModal(makeParams({ orchIdSet, itemsList }));
+    const rows = (modal as any).mapCustomerTotalsResponse(apiResponse) as Array<{
+      identifier: string;
+      name: string;
+      consumption: number;
+    }>;
+
+    expect(rows).toHaveLength(12);
+
+    // Every kept row's source id (carried in identifier as `IDENT-<id>`) must
+    // be in the allow-list.
+    for (const row of rows) {
+      const sourceId = row.identifier.replace(/^IDENT-/, '');
+      expect(orchIdSet.has(sourceId)).toBe(true);
+    }
+  });
+
+  it('falls back to direct mapping when neither itemsList nor orchIdSet is provided', () => {
+    const apiResponse = makeApiResponse(5);
+
+    const modal = new AllReportModal(makeParams());
+    const rows = (modal as any).mapCustomerTotalsResponse(apiResponse) as unknown[];
+
+    // No filter — every API row passes through.
+    expect(rows).toHaveLength(5);
+  });
+
+  it('uses itemsList when orchIdSet is absent (backwards-compat path)', () => {
+    const apiResponse = makeApiResponse(10);
+
+    // Allow only 3 ids via itemsList — note `id` matches `api.item.id`
+    // (RFC-0182: StoreItem.id = device.ingestionId = api.item.id).
+    const itemsList: StoreItem[] = [
+      { id: 'api-002', identifier: 'IDENT-2', label: 'Loja 2' },
+      { id: 'api-005', identifier: 'IDENT-5', label: 'Loja 5' },
+      { id: 'api-008', identifier: 'IDENT-8', label: 'Loja 8' },
+    ];
+
+    const modal = new AllReportModal(makeParams({ itemsList }));
+    const rows = (modal as any).mapCustomerTotalsResponse(apiResponse) as Array<{
+      identifier: string;
+      name: string;
+      consumption: number;
+    }>;
+
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => r.name).sort()).toEqual(['Loja 2', 'Loja 5', 'Loja 8']);
+  });
+
+  it('orchIdSet takes precedence over itemsList for the API-response filter', () => {
+    const apiResponse = makeApiResponse(20);
+
+    // itemsList allows api-001..api-005 but orchIdSet allows only api-007 + api-008.
+    // The expected behaviour per RFC-0201 Phase-2 #18 is that orchIdSet wins.
+    const itemsList: StoreItem[] = [
+      { id: 'api-001', identifier: 'IDENT-1', label: 'Loja 1' },
+      { id: 'api-002', identifier: 'IDENT-2', label: 'Loja 2' },
+      { id: 'api-007', identifier: 'IDENT-7', label: 'Loja 7' },
+    ];
+    const orchIdSet = new Set(['api-007', 'api-008']);
+
+    const modal = new AllReportModal(makeParams({ itemsList, orchIdSet }));
+    const rows = (modal as any).mapCustomerTotalsResponse(apiResponse) as Array<{
+      identifier: string;
+      name: string;
+    }>;
+
+    expect(rows).toHaveLength(2);
+    const names = new Set(rows.map((r) => r.name));
+    // api-007 has metadata via itemsList — keeps the friendly label.
+    expect(names.has('Loja 7')).toBe(true);
+    // api-008 has no metadata — falls back to the API response `name`.
+    expect(names.has('Device api-008')).toBe(true);
+  });
+
+  it('returns [] when the API response is empty', () => {
+    const modal = new AllReportModal(
+      makeParams({ orchIdSet: new Set(['ing-1', 'ing-2']) }),
+    );
+    const rows = (modal as any).mapCustomerTotalsResponse({ data: [] }) as unknown[];
+
+    expect(rows).toEqual([]);
+  });
+
+  it('returns [] when orchIdSet has zero matches in the API response', () => {
+    const apiResponse = makeApiResponse(5);
+    const modal = new AllReportModal(
+      makeParams({ orchIdSet: new Set(['no-such-id-1', 'no-such-id-2']) }),
+    );
+    const rows = (modal as any).mapCustomerTotalsResponse(apiResponse) as unknown[];
+
+    expect(rows).toEqual([]);
+  });
+});

--- a/tests/utils/buildItemsList.test.ts
+++ b/tests/utils/buildItemsList.test.ts
@@ -1,0 +1,273 @@
+/**
+ * RFC-0182 / RFC-0201 Phase-2 #17 — buildItemsList helper tests.
+ *
+ * Covers AC-RFC-0182-2: given a mixed `STATE.itemsBase` baseline,
+ * `buildItemsList(domain, group, items)` returns only the devices that
+ * belong to that (domain, group) pair, with `id === ingestionId`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildItemsList } from '../../src/utils/buildItemsList';
+import type { BaseItem } from '../../src/types/BaseItem';
+
+/**
+ * Mint a `BaseItem` for the test fixtures. Keeps the noise out of test bodies.
+ */
+function makeItem(partial: Partial<BaseItem> & { id: string; ingestionId: string }): BaseItem {
+  return {
+    id: partial.id,
+    entityId: partial.entityId ?? partial.id,
+    name: partial.name ?? partial.id,
+    label: partial.label ?? partial.name ?? partial.id,
+    labelOrName: partial.labelOrName ?? partial.label ?? partial.name ?? partial.id,
+    deviceType: partial.deviceType ?? '',
+    deviceProfile: partial.deviceProfile ?? partial.deviceType ?? '',
+    identifier: partial.identifier ?? '',
+    centralName: partial.centralName ?? '',
+    slaveId: partial.slaveId ?? '',
+    centralId: partial.centralId ?? '',
+    customerId: partial.customerId ?? '',
+    ownerName: partial.ownerName ?? '',
+    ingestionId: partial.ingestionId,
+    consumption: partial.consumption ?? null,
+    val: partial.val ?? null,
+    value: partial.value ?? null,
+    pulses: partial.pulses,
+    temperature: partial.temperature,
+    connectionStatus: partial.connectionStatus ?? 'online',
+    deviceStatus: partial.deviceStatus ?? 'normal',
+    domain: partial.domain ?? 'energy',
+    lastActivityTime: partial.lastActivityTime,
+    lastConnectTime: partial.lastConnectTime,
+    gcdrDeviceId: partial.gcdrDeviceId ?? null,
+  };
+}
+
+/**
+ * Mixed-domain fixture covering each of the recognised groups so a single
+ * dataset can drive every assertion in this file.
+ */
+function buildMixedItemsBase(): BaseItem[] {
+  return [
+    // ENERGY — lojas (3F_MEDIDOR exact match)
+    makeItem({
+      id: 'e1',
+      ingestionId: 'ing-e1',
+      label: 'Loja A',
+      identifier: 'SCMAL001',
+      deviceType: '3F_MEDIDOR',
+      deviceProfile: '3F_MEDIDOR',
+      domain: 'energy',
+    }),
+    makeItem({
+      id: 'e2',
+      ingestionId: 'ing-e2',
+      label: 'Loja B',
+      identifier: 'SCMAL002',
+      deviceType: '3F_MEDIDOR',
+      deviceProfile: '3F_MEDIDOR',
+      domain: 'energy',
+    }),
+    // ENERGY — entrada (TRAFO)
+    makeItem({
+      id: 'e3',
+      ingestionId: 'ing-e3',
+      label: 'Trafo Principal',
+      deviceType: 'TRAFO',
+      deviceProfile: 'TRAFO',
+      domain: 'energy',
+    }),
+    // ENERGY — entrada (RELOGIO)
+    makeItem({
+      id: 'e4',
+      ingestionId: 'ing-e4',
+      label: 'Relógio',
+      deviceType: 'RELOGIO',
+      deviceProfile: 'RELOGIO',
+      domain: 'energy',
+    }),
+    // ENERGY — area_comum (chiller, not 3F_MEDIDOR, not entrada)
+    makeItem({
+      id: 'e5',
+      ingestionId: 'ing-e5',
+      label: 'Chiller Climatização',
+      deviceType: 'CHILLER',
+      deviceProfile: 'CHILLER',
+      domain: 'energy',
+    }),
+    // WATER — entrada (HIDROMETRO_SHOPPING)
+    makeItem({
+      id: 'w1',
+      ingestionId: 'ing-w1',
+      label: 'Hidrômetro Entrada',
+      deviceType: 'HIDROMETRO',
+      deviceProfile: 'HIDROMETRO_SHOPPING',
+      domain: 'water',
+    }),
+    // WATER — lojas (HIDROMETRO)
+    makeItem({
+      id: 'w2',
+      ingestionId: 'ing-w2',
+      label: 'Hidrômetro Loja',
+      deviceType: 'HIDROMETRO',
+      deviceProfile: 'HIDROMETRO',
+      domain: 'water',
+    }),
+    // WATER — banheiros (area_comum + identifier=BANHEIROS)
+    makeItem({
+      id: 'w3',
+      ingestionId: 'ing-w3',
+      label: 'Hidrômetro Banheiros',
+      identifier: 'BANHEIROS',
+      deviceType: 'HIDROMETRO',
+      deviceProfile: 'HIDROMETRO_AREA_COMUM',
+      domain: 'water',
+    }),
+    // WATER — area_comum (other than banheiros)
+    makeItem({
+      id: 'w4',
+      ingestionId: 'ing-w4',
+      label: 'Hidrômetro Área Comum',
+      identifier: 'AC-001',
+      deviceType: 'HIDROMETRO',
+      deviceProfile: 'HIDROMETRO_AREA_COMUM',
+      domain: 'water',
+    }),
+    // TEMPERATURE — climatizavel
+    makeItem({
+      id: 't1',
+      ingestionId: 'ing-t1',
+      label: 'Termostato Loja',
+      deviceType: 'TERMOSTATO',
+      deviceProfile: 'TERMOSTATO',
+      domain: 'temperature',
+    }),
+    // TEMPERATURE — nao_climatizavel
+    makeItem({
+      id: 't2',
+      ingestionId: 'ing-t2',
+      label: 'Termostato Externo',
+      deviceType: 'TERMOSTATO',
+      deviceProfile: 'TERMOSTATO_EXTERNAL',
+      domain: 'temperature',
+    }),
+  ];
+}
+
+describe('buildItemsList — RFC-0182 (Phase-2 #17)', () => {
+  describe('Energy domain', () => {
+    it('returns only 3F_MEDIDOR-as-store devices for (energy, lojas)', () => {
+      const items = buildItemsList('energy', 'lojas', buildMixedItemsBase());
+
+      expect(items.map((i) => i.id).sort()).toEqual(['ing-e1', 'ing-e2']);
+      expect(items[0].label).toBe('Loja A');
+      expect(items[0].identifier).toBe('SCMAL001');
+    });
+
+    it('returns the same set when called with the RFC-0111 alias `stores`', () => {
+      const a = buildItemsList('energy', 'lojas', buildMixedItemsBase()).map((i) => i.id);
+      const b = buildItemsList('energy', 'stores', buildMixedItemsBase()).map((i) => i.id);
+      expect(b.sort()).toEqual(a.sort());
+    });
+
+    it('returns TRAFO/RELOGIO devices for (energy, entrada)', () => {
+      const items = buildItemsList('energy', 'entrada', buildMixedItemsBase());
+      expect(items.map((i) => i.id).sort()).toEqual(['ing-e3', 'ing-e4']);
+    });
+
+    it('returns CHILLER (not 3F_MEDIDOR, not entrada) for (energy, area_comum)', () => {
+      const items = buildItemsList('energy', 'area_comum', buildMixedItemsBase());
+      expect(items.map((i) => i.id)).toEqual(['ing-e5']);
+    });
+
+    it('does NOT include water/temperature devices when domain=energy', () => {
+      const items = buildItemsList('energy', 'todos', buildMixedItemsBase());
+      const ids = items.map((i) => i.id);
+      expect(ids.every((id) => id.startsWith('ing-e'))).toBe(true);
+    });
+  });
+
+  describe('Water domain', () => {
+    it('returns HIDROMETRO_SHOPPING devices for (water, entrada)', () => {
+      const items = buildItemsList('water', 'entrada', buildMixedItemsBase());
+      expect(items.map((i) => i.id)).toEqual(['ing-w1']);
+    });
+
+    it('returns HIDROMETRO devices for (water, lojas)', () => {
+      const items = buildItemsList('water', 'lojas', buildMixedItemsBase());
+      expect(items.map((i) => i.id)).toEqual(['ing-w2']);
+    });
+
+    it('returns AREA_COMUM + identifier BANHEIROS for (water, banheiros)', () => {
+      const items = buildItemsList('water', 'banheiros', buildMixedItemsBase());
+      expect(items.map((i) => i.id)).toEqual(['ing-w3']);
+    });
+
+    it('returns area-comum profile for (water, area_comum) — both banheiros and other', () => {
+      const items = buildItemsList('water', 'area_comum', buildMixedItemsBase());
+      // Both w3 (banheiros) and w4 share HIDROMETRO_AREA_COMUM profile.
+      expect(items.map((i) => i.id).sort()).toEqual(['ing-w3', 'ing-w4']);
+    });
+  });
+
+  describe('Temperature domain', () => {
+    it('returns TERMOSTATO (non-external) for (temperature, climatizavel)', () => {
+      const items = buildItemsList('temperature', 'climatizavel', buildMixedItemsBase());
+      expect(items.map((i) => i.id)).toEqual(['ing-t1']);
+    });
+
+    it('returns TERMOSTATO_EXTERNAL for (temperature, nao_climatizavel)', () => {
+      const items = buildItemsList('temperature', 'nao_climatizavel', buildMixedItemsBase());
+      expect(items.map((i) => i.id)).toEqual(['ing-t2']);
+    });
+  });
+
+  describe('AC-RFC-0182-2 — id === ingestionId', () => {
+    it('every returned StoreItem.id matches the source device.ingestionId', () => {
+      const base = buildMixedItemsBase();
+      const items = buildItemsList('energy', 'todos', base);
+
+      for (const out of items) {
+        const source = base.find((b) => b.ingestionId === out.id);
+        expect(source).toBeDefined();
+        expect(out.id).toBe(source!.ingestionId);
+      }
+    });
+  });
+
+  describe('"todos" mode — section labels', () => {
+    it('tags each energy item with the matching groupLabel', () => {
+      const items = buildItemsList('energy', 'todos', buildMixedItemsBase());
+
+      // ing-e1, ing-e2 → Lojas
+      const lojas = items.find((i) => i.id === 'ing-e1') as { groupLabel?: string };
+      expect(lojas?.groupLabel).toBe('Lojas');
+      // ing-e3 → Entrada
+      const entrada = items.find((i) => i.id === 'ing-e3') as { groupLabel?: string };
+      expect(entrada?.groupLabel).toBe('Entrada');
+      // ing-e5 → Área Comum
+      const areaComum = items.find((i) => i.id === 'ing-e5') as { groupLabel?: string };
+      expect(areaComum?.groupLabel).toBe('Área Comum');
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('returns [] when itemsBase is empty', () => {
+      expect(buildItemsList('energy', 'lojas', [])).toEqual([]);
+    });
+
+    it('returns [] when itemsBase is not an array', () => {
+      expect(buildItemsList('energy', 'lojas', null as unknown as BaseItem[])).toEqual([]);
+    });
+
+    it('returns [] for an unknown group key', () => {
+      expect(
+        buildItemsList(
+          'energy',
+          'totally-unknown' as unknown as 'lojas',
+          buildMixedItemsBase(),
+        ),
+      ).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Scope
Implements RFC-0201 Phase-2 work-list rows #17, #18, #19, #20. Depends on Pod F0 (`STATE.itemsBase`, merged in Phase 1).

## Changes
**New files**
- `src/utils/buildItemsList.ts` (#17) — `buildItemsList(domain, group, itemsBase) -> StoreItem[]`. Mirrors v-5.2.0 `_buildItemsList` intent but operates on the canonical Phase-1 baseline. `StoreItem.id === device.ingestionId`.
- `tests/utils/buildItemsList.test.ts` — 16 tests covering AC-RFC-0182-2 (energy lojas/entrada/area_comum, water entrada/lojas/banheiros/area_comum, temperature climatizavel/nao_climatizavel, "todos" labels, edge cases).
- `tests/components/menu/MenuView.reports.test.ts` — 7 tests covering AC-RFC-0181-1 (Reports button + dropdown + group click emits `reports-click` with the right group key).
- `tests/components/premium-modals/AllReportModal.orchIdSet.test.ts` — 6 tests covering AC-RFC-0182-1 (50-row API + 12-id orchIdSet → exactly 12 rows; backwards-compat with itemsList; orchIdSet precedence; empty cases).

**Modified files**
- `src/components/premium-modals/types.ts` (#18) — added `orchIdSet?: Set<string>` to `OpenAllReportParams`.
- `src/components/premium-modals/report-all/AllReportModal.ts` (#18) — `mapCustomerTotalsResponse` honours `orchIdSet` with precedence over `itemsList`. Falls back to current behaviour when neither is provided.
- `src/components/menu/types.ts` (#19) — new `ReportsGroup` type, `onReportsClick`, `showReportsButton`, `reports-click` event.
- `src/components/menu/MenuView.ts` (#19) — Reports button on toolbar + dropdown panel with per-domain group items (Energia / Água / Temperatura). Open/close + outside-click + Esc handling.
- `src/components/menu/MenuController.ts` (#19) — wires `view.on('reports-click')` → `params.onReportsClick`.
- `src/components/menu-shopping/{types,MenuShoppingView,createMenuShoppingComponent,styles}.ts` (#19) — same Reports submenu added to the v-5.4.0 sidebar variant. `onReportsClick` exposed on `MenuShoppingParams`.
- `src/index.ts` — re-exports `buildItemsList`, `ItemsListDomain`, `ItemsListGroup`, `ReportsGroup`.
- `src/components/menu/index.ts` — re-exports `ReportsGroup`.
- `src/thingsboard/main-dashboard-shopping/v-5.4.0/controller.js` (#20) — `onReportsClick` callback inside `createComponents()` builds items from `STATE.itemsBase`, derives `orchIdSet`, opens `lib.openDashboardPopupAllReport({ ..., itemsList, orchIdSet })`.

**Untouched**
- No changes under `src/thingsboard/main-dashboard-shopping/v-5.2.0/` (read-only).
- No changes to `src/types/BaseItem.ts` (Pod F0).
- No changes to `src/components/alarms/createAlarmServiceOrchestrator.ts` (Pod A).
- No changes to `package.json` / `package-lock.json`.
- No changes to `showcase/` (Pod L will integrate).

## ACs satisfied
- AC-RFC-0181-1 — clicking Reports → "Lojas" fires `onReportsClick('lojas')`.
- AC-RFC-0182-1 — given a 50-row API response and a 12-id `orchIdSet`, the modal renders only those 12 rows.
- AC-RFC-0182-2 — `buildItemsList(domain, group, itemsBase)` returns `StoreItem[]` filtered by domain/group with `id === ingestionId`.

## Test results

```
Test Files  9 passed (9)
     Tests  85 passed (85)
```

(All tests under `tests/components`, `tests/v-5.4.0`, `tests/utils` — including 29 newly-added tests for this PR — pass.)

The 10 NODE-RED test failures observed under `src/NODE-RED/.../tests/func-004-TelemetryAdapter.test.js` are pre-existing (those files use `jest`, not `vitest`); confirmed by running them on the unmodified Phase-1 base.

## Notes / caveats
- **`menu/` vs. `menu-shopping/`**: the Reports submenu was added to BOTH families because v-5.4.0's `controller.js` wires `lib.createMenuShoppingComponent`, while the task instructions explicitly said to edit `src/components/menu/MenuView.ts`. Both surface the same `onReportsClick(group)` contract.
- **`ReportsGroup` vs. `ItemsListGroup`**: `ReportsGroup` (in `menu/types.ts`) is a narrower vocabulary surfaced by the menu UI; `ItemsListGroup` (in `utils/buildItemsList.ts`) accepts both the canonical group keys (`lojas`, `entrada`, `area_comum`, `banheiros`, `climatizavel`, `nao_climatizavel`, `todos`) and the lower-level RFC-0111 context aliases (`stores`, `equipments`, `hidrometro`, etc.) so it can be consumed directly from MenuView's existing tab vocabulary if needed.
- **Energy area_comum subdivisions** (Climatização / Elevadores / Escadas Rolantes / Outros) are NOT split in the Reports submenu yet — they all map to the single `area_comum` group key. Refining to RFC-0128 sub-keys is a follow-up if the widget needs per-subcategory reports.
- **`orchIdSet` precedence**: when both `itemsList` and `orchIdSet` are provided, `orchIdSet` drives the API filter while `itemsList` provides label/identifier/groupLabel metadata. Documented in the `OpenAllReportParams.orchIdSet` JSDoc and covered by an explicit unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)