### PR TITLE
RFC-0201 Phase 2 — Info-cards click-by-group + Erro calc (pod F)

### DIFF
--- a/src/components/telemetry-info-shopping/TelemetryInfoShoppingView.ts
+++ b/src/components/telemetry-info-shopping/TelemetryInfoShoppingView.ts
@@ -20,12 +20,21 @@ import {
   formatWater,
   formatPercentage,
   CategoryType,
+  FilterGroup,
 } from './types';
 import { injectStyles } from './styles';
 
 // Chart.js type (loaded externally)
 type ChartInstance = {
-  data: { labels: string[]; datasets: { data: number[]; backgroundColor: string[] }[] };
+  data: {
+    labels: string[];
+    datasets: {
+      data: number[];
+      backgroundColor: string[];
+      borderColor?: string[];
+      borderWidth?: number | number[];
+    }[];
+  };
   update: () => void;
   destroy: () => void;
 };
@@ -36,7 +45,12 @@ type ChartConstructor = new (
     type: string;
     data: {
       labels: string[];
-      datasets: { data: number[]; backgroundColor: string[]; borderWidth?: number }[];
+      datasets: {
+        data: number[];
+        backgroundColor: string[];
+        borderColor?: string[];
+        borderWidth?: number | number[];
+      }[];
     };
     options: Record<string, unknown>;
   }
@@ -69,6 +83,14 @@ export class TelemetryInfoShoppingView {
   private isMaximized = false;
   private originalParent: HTMLElement | null = null;
   private originalNextSibling: Node | null = null;
+
+  // RFC-0196 — last group activated by a slice click (null when no
+  // active filter). Used for the toggle behaviour: clicking the same
+  // slice twice clears the filter.
+  private activeSliceGroup: FilterGroup | null = null;
+  // Parallel arrays shared between the main chart and the click handler
+  // (rebuilt on every refreshChart).
+  private chartGroups: FilterGroup[] = [];
 
   constructor(params: TelemetryInfoShoppingParams) {
     this.params = params;
@@ -249,6 +271,24 @@ export class TelemetryInfoShoppingView {
           <div class="tis-stat-row tis-main-stat">
             <span class="tis-stat-value" id="areaComumTotal">0,00 kWh</span>
             <span class="tis-stat-perc" id="areaComumPerc">(0%)</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="tis-card tis-erro-card" data-category="erro">
+        <div class="tis-card-header">
+          <span class="tis-card-icon">${config.erro.icon}</span>
+          <h3 class="tis-card-title">${config.erro.label}</h3>
+          ${
+            config.erro.tooltip
+              ? `<span class="tis-tooltip" title="${config.erro.tooltip}">ℹ️</span>`
+              : ''
+          }
+        </div>
+        <div class="tis-card-body">
+          <div class="tis-stat-row tis-main-stat">
+            <span class="tis-stat-value" id="erroTotal">—</span>
+            <span class="tis-stat-perc" id="erroPerc"></span>
           </div>
         </div>
       </div>
@@ -507,6 +547,7 @@ export class TelemetryInfoShoppingView {
               {
                 data: [1],
                 backgroundColor: ['#e0e0e0'],
+                borderColor: ['#ffffff'],
                 borderWidth: 0,
               },
             ],
@@ -514,13 +555,29 @@ export class TelemetryInfoShoppingView {
           options: {
             responsive: true,
             maintainAspectRatio: true,
+            // RFC-0196 — click on slice fires onSliceClick + dispatches
+            // myio:filter-applied. The handler computes the group from
+            // `chartGroups` (parallel to dataset.data) and toggles
+            // visual feedback (4px white ring on active slice; 60%
+            // opacity on siblings).
+            onClick: (_evt: unknown, elements: Array<{ index: number }>) => {
+              if (!elements || elements.length === 0) return;
+              const index = elements[0].index;
+              const group = this.chartGroups[index];
+              if (!group) return;
+              this.handleSliceClick(group);
+            },
             plugins: {
               legend: { display: false },
               tooltip: {
                 callbacks: {
-                  label: (context: { label: string; parsed: number }) => {
+                  // RFC-0196 hover tooltip: percentage + absolute value
+                  // (kWh for energy, m³ for water).
+                  label: (context: { label: string; parsed: number; dataset: { data: number[] } }) => {
                     const formatter = this.domain === 'energy' ? formatEnergy : formatWater;
-                    return `${context.label}: ${formatter(context.parsed)}`;
+                    const total = (context.dataset.data || []).reduce((a, b) => a + b, 0);
+                    const perc = total > 0 ? (context.parsed / total) * 100 : 0;
+                    return `${context.label}: ${formatPercentage(perc)} · ${formatter(context.parsed)}`;
                   },
                 },
               },
@@ -566,6 +623,7 @@ export class TelemetryInfoShoppingView {
             {
               data: [],
               backgroundColor: [],
+              borderColor: [],
               borderWidth: 0,
             },
           ],
@@ -573,13 +631,23 @@ export class TelemetryInfoShoppingView {
         options: {
           responsive: true,
           maintainAspectRatio: false,
+          // RFC-0196 — modal pie also dispatches slice click events.
+          onClick: (_evt: unknown, elements: Array<{ index: number }>) => {
+            if (!elements || elements.length === 0) return;
+            const index = elements[0].index;
+            const group = this.chartGroups[index];
+            if (!group) return;
+            this.handleSliceClick(group);
+          },
           plugins: {
             legend: { display: false },
             tooltip: {
               callbacks: {
-                label: (context: { label: string; parsed: number }) => {
+                label: (context: { label: string; parsed: number; dataset: { data: number[] } }) => {
                   const formatter = this.domain === 'energy' ? formatEnergy : formatWater;
-                  return `${context.label}: ${formatter(context.parsed)}`;
+                  const total = (context.dataset.data || []).reduce((a, b) => a + b, 0);
+                  const perc = total > 0 ? (context.parsed / total) * 100 : 0;
+                  return `${context.label}: ${formatPercentage(perc)} · ${formatter(context.parsed)}`;
                 },
               },
             },
@@ -593,10 +661,24 @@ export class TelemetryInfoShoppingView {
     const chartData = this.getChartData();
     this.log('Refreshing chart with data:', chartData);
 
+    // RFC-0196 — keep chartGroups in sync with the slice order so
+    // onClick can map index → group identifier.
+    this.chartGroups = chartData.groups;
+
+    // RFC-0196 — visual feedback: 4px white ring on the active slice;
+    // siblings fade to 60% opacity. When no slice is active all
+    // borders are 0px and colors are unmodified.
+    const { borderColors, borderWidths, fadedColors } = this.computeSliceVisuals(
+      chartData.colors,
+      chartData.groups
+    );
+
     if (this.mainChart) {
       this.mainChart.data.labels = chartData.labels;
       this.mainChart.data.datasets[0].data = chartData.values;
-      this.mainChart.data.datasets[0].backgroundColor = chartData.colors;
+      this.mainChart.data.datasets[0].backgroundColor = fadedColors;
+      this.mainChart.data.datasets[0].borderColor = borderColors;
+      this.mainChart.data.datasets[0].borderWidth = borderWidths;
       this.mainChart.update();
       this.log('Main chart updated');
     } else {
@@ -606,7 +688,9 @@ export class TelemetryInfoShoppingView {
     if (this.modalChart) {
       this.modalChart.data.labels = chartData.labels;
       this.modalChart.data.datasets[0].data = chartData.values;
-      this.modalChart.data.datasets[0].backgroundColor = chartData.colors;
+      this.modalChart.data.datasets[0].backgroundColor = fadedColors;
+      this.modalChart.data.datasets[0].borderColor = borderColors;
+      this.modalChart.data.datasets[0].borderWidth = borderWidths;
       this.modalChart.update();
       this.log('Modal chart updated');
     }
@@ -616,55 +700,223 @@ export class TelemetryInfoShoppingView {
     this.updateLegend('modalChartLegend', chartData);
   }
 
-  private getChartData(): { labels: string[]; values: number[]; colors: string[] } {
+  /**
+   * RFC-0196 — compute per-slice border + fade arrays based on the
+   * current `activeSliceGroup`. Active slice gets a 4px white border
+   * and full opacity; siblings get 0px border and 60% opacity (via
+   * background colour modification — Chart.js doesn't expose a
+   * per-slice opacity API, so we mutate the colour string).
+   */
+  private computeSliceVisuals(
+    colors: string[],
+    groups: FilterGroup[]
+  ): { borderColors: string[]; borderWidths: number[]; fadedColors: string[] } {
+    const active = this.activeSliceGroup;
+    const borderColors: string[] = [];
+    const borderWidths: number[] = [];
+    const fadedColors: string[] = [];
+
+    for (let i = 0; i < colors.length; i++) {
+      const isActive = active != null && groups[i] === active;
+      borderColors.push('#ffffff');
+      borderWidths.push(isActive ? 4 : 0);
+      if (active != null && !isActive) {
+        // 60% opacity for non-active slices.
+        fadedColors.push(this.fadeColor(colors[i], 0.6));
+      } else {
+        fadedColors.push(colors[i]);
+      }
+    }
+
+    return { borderColors, borderWidths, fadedColors };
+  }
+
+  /** Apply alpha to a hex (#rrggbb / #rgb) or rgb()/rgba() colour. */
+  private fadeColor(color: string, alpha: number): string {
+    const c = color.trim();
+    if (c.startsWith('#')) {
+      const hex = c.slice(1);
+      const full =
+        hex.length === 3
+          ? hex.split('').map((ch) => ch + ch).join('')
+          : hex.length === 6
+          ? hex
+          : null;
+      if (!full) return c;
+      const r = parseInt(full.slice(0, 2), 16);
+      const g = parseInt(full.slice(2, 4), 16);
+      const b = parseInt(full.slice(4, 6), 16);
+      return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+    }
+    if (c.startsWith('rgb(')) {
+      return c.replace('rgb(', 'rgba(').replace(')', `, ${alpha})`);
+    }
+    if (c.startsWith('rgba(')) {
+      return c.replace(/rgba\(([^)]+),\s*[\d.]+\)/, (_m, body) => `rgba(${body}, ${alpha})`);
+    }
+    return c;
+  }
+
+  /**
+   * RFC-0196 — public slice-click entry point. Toggles the active
+   * group (clicking the same slice twice clears the filter), updates
+   * the visual ring/fade, fires the `onSliceClick` callback, and
+   * dispatches `myio:filter-applied`.
+   *
+   * Exposed (via the bound `bindEvents` legend hook below) so the
+   * legend chips and tests can simulate slice activations without
+   * needing a Chart.js click event.
+   */
+  handleSliceClick(group: FilterGroup): void {
+    this.log('handleSliceClick:', group, 'previous:', this.activeSliceGroup);
+
+    // Toggle: same slice twice clears the filter.
+    const wasActive = this.activeSliceGroup === group;
+    this.activeSliceGroup = wasActive ? null : group;
+
+    // Re-run refreshChart to apply the visual ring/fade.
+    this.refreshChart();
+    // Re-apply card visual state to keep the corresponding card highlighted.
+    this.updateCardActiveState();
+
+    // Fire callback BEFORE the global event so subscribers see the
+    // same payload twice without duplication risk.
+    this.params.onSliceClick?.(group);
+
+    // RFC-0196 — `myio:filter-applied` event for the dashboard
+    // controller. `deviceIds` is intentionally an empty array here —
+    // the controller resolves device ids from `window.STATE.itemsBase`
+    // since this view does not own the device list.
+    if (typeof window !== 'undefined') {
+      const detail = {
+        domain: this.domain,
+        group: this.activeSliceGroup, // null when toggled off
+        deviceIds: [] as string[],
+      };
+      window.dispatchEvent(new CustomEvent('myio:filter-applied', { detail }));
+    }
+  }
+
+  /**
+   * RFC-0196 — apply CSS class `tis-card--active` to the card whose
+   * `data-category` matches the current filter group, and
+   * `tis-card--faded` to siblings. Group→card mapping bridges
+   * snake_case filter groups to the camelCase card data-category.
+   */
+  private updateCardActiveState(): void {
+    const groupToCard: Partial<Record<FilterGroup, string>> = {
+      entrada: 'entrada',
+      lojas: 'lojas',
+      climatizacao: 'climatizacao',
+      elevadores: 'elevadores',
+      escadas_rolantes: 'escadasRolantes',
+      outros: 'outros',
+      erro: 'erro',
+      banheiros: 'banheiros',
+      areaComum: 'areaComum',
+    };
+
+    const activeCard =
+      this.activeSliceGroup != null ? groupToCard[this.activeSliceGroup] : null;
+
+    this.root.querySelectorAll('.tis-card[data-category]').forEach((el) => {
+      const card = el as HTMLElement;
+      const cat = card.dataset.category || '';
+      if (activeCard == null) {
+        card.classList.remove('tis-card--active');
+        card.classList.remove('tis-card--faded');
+        return;
+      }
+      if (cat === activeCard) {
+        card.classList.add('tis-card--active');
+        card.classList.remove('tis-card--faded');
+      } else if (cat === 'total') {
+        // The "Total Consumidores" card is informational only — do not fade.
+        card.classList.remove('tis-card--active');
+        card.classList.remove('tis-card--faded');
+      } else {
+        card.classList.add('tis-card--faded');
+        card.classList.remove('tis-card--active');
+      }
+    });
+  }
+
+  /**
+   * RFC-0196 — `groups` parallels `labels/values/colors` and gives each
+   * slice the canonical filter-group identifier dispatched on click.
+   * Energy uses snake_case (`escadas_rolantes`) for cross-component
+   * consistency with `buildEquipmentCategorySummary` (RFC-0128). The
+   * `erro` slice is included whenever the residual is strictly > 0.
+   */
+  private getChartData(): {
+    labels: string[];
+    values: number[];
+    colors: string[];
+    groups: FilterGroup[];
+  } {
     const labels: string[] = [];
     const values: number[] = [];
     const colors: string[] = [];
+    const groups: FilterGroup[] = [];
 
     if (this.domain === 'energy' && this.energyState) {
       const state = this.energyState;
       const categories = [
-        { key: 'climatizacao', data: state.consumidores.climatizacao },
-        { key: 'elevadores', data: state.consumidores.elevadores },
-        { key: 'escadasRolantes', data: state.consumidores.escadasRolantes },
-        { key: 'lojas', data: state.consumidores.lojas },
-        { key: 'outros', data: state.consumidores.outros },
-        { key: 'areaComum', data: state.consumidores.areaComum },
+        { key: 'climatizacao', group: 'climatizacao', data: state.consumidores.climatizacao },
+        { key: 'elevadores', group: 'elevadores', data: state.consumidores.elevadores },
+        { key: 'escadasRolantes', group: 'escadas_rolantes', data: state.consumidores.escadasRolantes },
+        { key: 'lojas', group: 'lojas', data: state.consumidores.lojas },
+        { key: 'outros', group: 'outros', data: state.consumidores.outros },
       ] as const;
 
-      categories.forEach(({ key, data }) => {
+      categories.forEach(({ key, group, data }) => {
         if (data.total > 0) {
           const config = ENERGY_CATEGORY_CONFIG[key];
           labels.push(config.label);
           values.push(data.total);
           colors.push(this.chartColors[key]);
+          groups.push(group as FilterGroup);
         }
       });
+
+      // RFC-0196 — Erro slice (only when residual > 0).
+      if (state.erro.total > 0) {
+        const cfg = ENERGY_CATEGORY_CONFIG.erro;
+        labels.push(cfg.label);
+        values.push(state.erro.total);
+        colors.push(cfg.color);
+        groups.push('erro');
+      }
     } else if (this.domain === 'water' && this.waterState) {
       const state = this.waterState;
       const categories = [
-        { key: 'lojas' as const, data: state.lojas },
-        { key: 'banheiros' as const, data: state.banheiros },
-        { key: 'areaComum' as const, data: state.areaComum },
-        { key: 'pontosNaoMapeados' as const, data: state.pontosNaoMapeados },
+        { key: 'lojas' as const, group: 'lojas' as FilterGroup, data: state.lojas },
+        { key: 'banheiros' as const, group: 'banheiros' as FilterGroup, data: state.banheiros },
+        { key: 'areaComum' as const, group: 'areaComum' as FilterGroup, data: state.areaComum },
+        // pontosNaoMapeados has no canonical filter group — treated as
+        // residual visualisation only.
+        { key: 'pontosNaoMapeados' as const, group: null as FilterGroup | null, data: state.pontosNaoMapeados },
       ];
 
-      categories.forEach(({ key, data }) => {
+      categories.forEach(({ key, group, data }) => {
         if (data.total > 0) {
           const config = WATER_CATEGORY_CONFIG[key];
           labels.push(config.label);
           values.push(data.total);
           colors.push(this.chartColors[key]);
+          // Use 'areaComum' as the filter-group fallback when no canonical
+          // group is defined (pontosNaoMapeados is non-clickable for filter).
+          groups.push((group as FilterGroup) || 'areaComum');
         }
       });
     }
 
-    return { labels, values, colors };
+    return { labels, values, colors, groups };
   }
 
   private updateLegend(
     elementId: string,
-    chartData: { labels: string[]; values: number[]; colors: string[] }
+    chartData: { labels: string[]; values: number[]; colors: string[]; groups: FilterGroup[] }
   ): void {
     const legendEl = this.root.querySelector(`#${elementId}`);
     if (!legendEl) return;
@@ -674,7 +926,7 @@ export class TelemetryInfoShoppingView {
     legendEl.innerHTML = chartData.labels
       .map(
         (label, i) => `
-      <div class="tis-legend-item">
+      <div class="tis-legend-item" data-group="${chartData.groups[i] || ''}">
         <span class="tis-legend-color" style="background-color: ${chartData.colors[i]}"></span>
         <span class="tis-legend-label">${label}</span>
         <span class="tis-legend-value">${formatter(chartData.values[i])}</span>
@@ -682,6 +934,22 @@ export class TelemetryInfoShoppingView {
     `
       )
       .join('');
+
+    // RFC-0196 — clicking a legend chip is equivalent to clicking the
+    // matching slice. Useful for keyboard-only flows and as a
+    // Chart.js-free fallback when the canvas hasn't initialised
+    // (e.g. unit tests without Chart.js).
+    legendEl.querySelectorAll('.tis-legend-item').forEach((item) => {
+      const el = item as HTMLElement;
+      const group = el.dataset.group as FilterGroup | undefined;
+      if (!group) return;
+      if (el.hasAttribute('data-bound')) return;
+      el.setAttribute('data-bound', 'true');
+      el.style.cursor = 'pointer';
+      el.addEventListener('click', () => {
+        this.handleSliceClick(group);
+      });
+    });
   }
 
   // =========================================================================
@@ -701,6 +969,17 @@ export class TelemetryInfoShoppingView {
     const totalConsumidores = lojas + climatizacao + elevadores + escadasRolantes + outros;
     const areaComum = Math.max(0, entrada - totalConsumidores);
 
+    // RFC-0196 — calculated residual:
+    //   erro = Entrada − (Lojas + Climatização + Elevadores + Esc. Rolantes + Outros)
+    // When `erro <= 0` the slice is omitted from the pie and the card
+    // renders the placeholder `'—'`.
+    const erroFromSummary = summary.erro?.total;
+    const erroComputed = entrada - totalConsumidores;
+    const erro =
+      typeof erroFromSummary === 'number' && Number.isFinite(erroFromSummary)
+        ? erroFromSummary
+        : erroComputed;
+
     const calcPerc = (val: number) => (entrada > 0 ? (val / entrada) * 100 : 0);
 
     this.energyState = {
@@ -715,6 +994,7 @@ export class TelemetryInfoShoppingView {
         totalGeral: totalConsumidores + areaComum,
       },
       grandTotal: entrada,
+      erro: { total: erro, perc: calcPerc(Math.max(0, erro)) },
     };
 
     this.updateEnergyUI();
@@ -742,6 +1022,18 @@ export class TelemetryInfoShoppingView {
     this.updateElement('#outrosPerc', `(${formatPercentage(state.consumidores.outros.perc)})`);
     this.updateElement('#areaComumTotal', formatEnergy(state.consumidores.areaComum.total));
     this.updateElement('#areaComumPerc', `(${formatPercentage(state.consumidores.areaComum.perc)})`);
+
+    // RFC-0196 — Erro card. When `erro <= 0` the placeholder `'—'` is
+    // shown and the percentage cell is cleared (the slice is also
+    // omitted from the pie via `getChartData`).
+    if (state.erro.total > 0) {
+      this.updateElement('#erroTotal', formatEnergy(state.erro.total));
+      this.updateElement('#erroPerc', `(${formatPercentage(state.erro.perc)})`);
+    } else {
+      this.updateElement('#erroTotal', '—');
+      this.updateElement('#erroPerc', '');
+    }
+
     this.updateElement('#consumidoresTotal', formatEnergy(state.consumidores.totalGeral));
   }
 
@@ -803,6 +1095,9 @@ export class TelemetryInfoShoppingView {
   clearData(): void {
     this.energyState = null;
     this.waterState = null;
+    // RFC-0196 — reset filter state when data is cleared.
+    this.activeSliceGroup = null;
+    this.updateCardActiveState();
 
     // Reset all values to zero
     this.root.querySelectorAll('.tis-stat-value').forEach((el) => {
@@ -861,6 +1156,9 @@ export class TelemetryInfoShoppingView {
       this.domain = domain;
       this.root.setAttribute('data-domain', domain);
 
+      // RFC-0196 — clear filter state when domain switches.
+      this.activeSliceGroup = null;
+
       // Re-render the grid with new domain cards
       const gridEl = this.root.querySelector('#infoGrid');
       if (gridEl) {
@@ -884,6 +1182,11 @@ export class TelemetryInfoShoppingView {
 
   getDomain(): TelemetryDomain {
     return this.domain;
+  }
+
+  /** RFC-0196 — current active filter group, or null when no filter. */
+  getActiveGroup(): FilterGroup | null {
+    return this.activeSliceGroup;
   }
 
   setThemeMode(mode: ThemeMode): void {

--- a/src/components/telemetry-info-shopping/createTelemetryInfoShoppingComponent.ts
+++ b/src/components/telemetry-info-shopping/createTelemetryInfoShoppingComponent.ts
@@ -12,6 +12,7 @@ import {
   WaterSummary,
   EnergyState,
   WaterState,
+  FilterGroup,
 } from './types';
 import { TelemetryInfoShoppingView } from './TelemetryInfoShoppingView';
 
@@ -155,6 +156,16 @@ export function createTelemetryInfoShoppingComponent(
     view.refreshChart();
   }
 
+  // RFC-0196 — slice click
+  function triggerSliceClick(group: FilterGroup): void {
+    log('triggerSliceClick called:', group);
+    view.handleSliceClick(group);
+  }
+
+  function getActiveGroup(): FilterGroup | null {
+    return view.getActiveGroup();
+  }
+
   function destroy(): void {
     log('destroy called');
     view.destroy();
@@ -188,6 +199,10 @@ export function createTelemetryInfoShoppingComponent(
 
     // Chart
     refreshChart,
+
+    // RFC-0196 — slice click
+    triggerSliceClick,
+    getActiveGroup,
 
     // Lifecycle
     destroy,

--- a/src/components/telemetry-info-shopping/index.ts
+++ b/src/components/telemetry-info-shopping/index.ts
@@ -20,6 +20,10 @@ export type {
   CategoryData,
   ChartColors,
   CategoryConfig,
+  // RFC-0196
+  EnergyGroup,
+  WaterGroup,
+  FilterGroup,
 } from './types';
 
 export {

--- a/src/components/telemetry-info-shopping/styles.ts
+++ b/src/components/telemetry-info-shopping/styles.ts
@@ -676,6 +676,28 @@ export const TELEMETRY_INFO_SHOPPING_STYLES = `
     gap: 12px !important;
   }
 }
+
+/* ========== RFC-0196: SLICE CLICK VISUAL FEEDBACK ========== */
+/* Active card: solid 2px ring (matches the 4px white ring on the chart slice). */
+.telemetry-info-root .tis-card--active {
+  outline: 2px solid var(--tis-primary) !important;
+  outline-offset: 1px !important;
+  transition: outline 120ms ease, opacity 120ms ease !important;
+}
+
+/* Faded sibling: 60% opacity per Sally's Visual-Parity spec. */
+.telemetry-info-root .tis-card--faded {
+  opacity: 0.6 !important;
+  transition: opacity 120ms ease !important;
+}
+
+/* RFC-0196 — Erro card stylings (red accent). */
+.telemetry-info-root .tis-erro-card .tis-card-title {
+  color: #C62828 !important;
+}
+.telemetry-info-root .tis-erro-card .tis-stat-value {
+  color: #C62828 !important;
+}
 `;
 
 export function injectStyles(_container?: HTMLElement): void {

--- a/src/components/telemetry-info-shopping/types.ts
+++ b/src/components/telemetry-info-shopping/types.ts
@@ -22,7 +22,8 @@ export type EnergyCategoryType =
   | 'escadasRolantes'
   | 'lojas'
   | 'outros'
-  | 'areaComum';
+  | 'areaComum'
+  | 'erro';
 
 export type WaterCategoryType =
   | 'entrada'
@@ -32,6 +33,30 @@ export type WaterCategoryType =
   | 'pontosNaoMapeados';
 
 export type CategoryType = EnergyCategoryType | WaterCategoryType;
+
+/**
+ * RFC-0196 — Group identifier dispatched on `myio:filter-applied`.
+ *
+ * Energy groups follow the canonical
+ * `buildEquipmentCategorySummary` keys (with `escadas_rolantes` and
+ * `area_comum` underscored) for cross-component compatibility. The
+ * `erro` slice is a calculated residual; clicks on it dispatch the
+ * filter event but the controller treats it as a no-op (no devices).
+ *
+ * Water groups mirror the existing component key set (camelCase).
+ */
+export type EnergyGroup =
+  | 'entrada'
+  | 'lojas'
+  | 'climatizacao'
+  | 'elevadores'
+  | 'escadas_rolantes'
+  | 'outros'
+  | 'erro';
+
+export type WaterGroup = 'entrada' | 'lojas' | 'banheiros' | 'areaComum';
+
+export type FilterGroup = EnergyGroup | WaterGroup;
 
 // ============================================
 // CATEGORY DATA
@@ -55,6 +80,15 @@ export interface EnergyState {
     totalGeral: number;
   };
   grandTotal: number;
+  /**
+   * RFC-0196 — calculated residual:
+   * `Entrada − (Lojas + Climatização + Elevadores + Esc. Rolantes + Outros)`.
+   *
+   * When `value > 0` the chart includes a dedicated "Erro" slice. When
+   * `value <= 0` the slice is omitted entirely (placeholder rendered in
+   * card UI as `'—'`).
+   */
+  erro: CategoryData;
 }
 
 export interface WaterState {
@@ -129,6 +163,14 @@ export const ENERGY_CATEGORY_CONFIG: Record<EnergyCategoryType, CategoryConfig> 
     color: '#4CAF50',
     tooltip: 'Entrada - (Lojas + Climatização + Elevadores + Esc. Rolantes + Outros)',
   },
+  // RFC-0196 — calculated residual when the sum of mapped consumers exceeds
+  // the Entrada total (typically a measurement or classification error).
+  erro: {
+    label: 'Erro',
+    icon: '⚠️',
+    color: '#E53935',
+    tooltip: 'Resíduo calculado: Entrada − (Lojas + Climatização + Elevadores + Esc. Rolantes + Outros)',
+  },
 };
 
 export const WATER_CATEGORY_CONFIG: Record<WaterCategoryType, CategoryConfig> = {
@@ -170,6 +212,20 @@ export interface TelemetryInfoShoppingParams {
   // Callbacks
   onCategoryClick?: (category: CategoryType) => void;
   onExpandClick?: () => void;
+  /**
+   * RFC-0196 — fires when the user clicks a pie-chart slice.
+   *
+   * `group` is the canonical group identifier (see `EnergyGroup` /
+   * `WaterGroup`). The component also dispatches a global
+   * `myio:filter-applied` CustomEvent on the `window` object so the
+   * dashboard controller can narrow grids without a direct callback wire.
+   *
+   * Implementations should treat the same-slice-clicked-twice case as a
+   * filter-clear (toggle behaviour) — the component fires the callback
+   * with the same group on both clicks; the controller is responsible
+   * for tracking activation.
+   */
+  onSliceClick?: (group: FilterGroup) => void;
 }
 
 // ============================================
@@ -184,6 +240,12 @@ export interface EnergySummary {
   escadasRolantes?: { total: number; perc?: number };
   outros?: { total: number; perc?: number };
   areaComum?: { total: number; perc?: number };
+  /**
+   * RFC-0196 — optional pre-calculated residual. When omitted the
+   * component computes `erro = entrada − (lojas + climatizacao +
+   * elevadores + escadasRolantes + outros)` itself.
+   */
+  erro?: { total: number; perc?: number };
 }
 
 export interface WaterSummary {
@@ -207,7 +269,7 @@ export interface TelemetryInfoShoppingInstance {
   clearData: () => void;
 
   // State
-  getState: () => EnergyState | WaterState;
+  getState: () => EnergyState | WaterState | null;
   getDomain: () => TelemetryDomain;
 
   // Config
@@ -222,6 +284,17 @@ export interface TelemetryInfoShoppingInstance {
 
   // Chart
   refreshChart: () => void;
+
+  // RFC-0196 — slice activation
+  /**
+   * Trigger a slice click programmatically. Same toggle semantics as a
+   * user click on the pie: same group twice clears the filter.
+   *
+   * Fires `onSliceClick` and dispatches `myio:filter-applied`.
+   */
+  triggerSliceClick: (group: FilterGroup) => void;
+  /** Returns the currently-active filter group, or `null` when none. */
+  getActiveGroup: () => FilterGroup | null;
 
   // Lifecycle
   destroy: () => void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1027,6 +1027,10 @@ export type {
   WaterState as TelemetryInfoWaterState,
   CategoryType as TelemetryInfoCategoryType,
   ChartColors as TelemetryInfoChartColors,
+  // RFC-0196
+  EnergyGroup as TelemetryInfoEnergyGroup,
+  WaterGroup as TelemetryInfoWaterGroup,
+  FilterGroup as TelemetryInfoFilterGroup,
 } from './components/telemetry-info-shopping';
 
 export {

--- a/src/thingsboard/main-dashboard-shopping/v-5.4.0/controller.js
+++ b/src/thingsboard/main-dashboard-shopping/v-5.4.0/controller.js
@@ -315,6 +315,24 @@ function processDataAndDispatchEvents() {
   const tempValues = allTemp.map((d) => Number(d.temperature || 0)).filter((v) => v > 0);
   const tempAvg = tempValues.length > 0 ? tempValues.reduce((a, b) => a + b, 0) / tempValues.length : null;
 
+  // RFC-0201 Phase-2 / RFC-0196 — `byCategory` payload for the
+  // `myio:energy-summary-ready` event. Consumed by the Info component
+  // (pie chart) and the Header KPI tooltips. We hand back the canonical
+  // `buildEquipmentCategorySummary` result (snake_case keys:
+  // `entrada`, `lojas`, `climatizacao`, `elevadores`, `escadas_rolantes`,
+  // `outros`, `area_comum`). Falls back to `null` when the library is
+  // not available — listeners must handle the missing-field case.
+  const lib = window.MyIOLibrary;
+  let energyByCategory = null;
+  if (lib && typeof lib.buildEquipmentCategorySummary === 'function') {
+    try {
+      energyByCategory = lib.buildEquipmentCategorySummary(allEnergy);
+    } catch (err) {
+      LogHelper.warn('buildEquipmentCategorySummary failed:', err);
+      energyByCategory = null;
+    }
+  }
+
   // Dispatch events
   window.dispatchEvent(
     new CustomEvent('myio:data-ready', {
@@ -328,10 +346,20 @@ function processDataAndDispatchEvents() {
         totalDevices: allEnergy.length,
         totalConsumption: energyTotal,
         byStatus: buildByStatusFromDevices(allEnergy),
+        // RFC-0196 — required for Info-cards click-by-group + Header
+        // tooltip percentages. May be `null` when the helper is not
+        // available; listeners must handle that case.
+        byCategory: energyByCategory,
       },
     })
   );
 
+  // RFC-0196 — water has no canonical equipment-category summary
+  // because hidrômetros aren't subcategorized the way 3F_MEDIDOR
+  // equipment is (no Climatização/Elevadores/Esc.Rolantes/Outros split).
+  // The Info component derives water groups (entrada / lojas /
+  // banheiros / areaComum) directly from `classified.water.*` arrays
+  // via `updateTelemetryInfoComponents`, so we omit `byCategory` here.
   window.dispatchEvent(
     new CustomEvent('myio:water-summary-ready', {
       detail: {
@@ -723,6 +751,12 @@ function createEnergyGrids(lib) {
       showChart: true,
       showExpandButton: true,
       debugActive: DEBUG_ACTIVE,
+      // RFC-0196 — slice click → controller dispatches
+      // `myio:filter-applied` (already done by the component itself);
+      // the callback is kept for log/debug observability.
+      onSliceClick: (group) => {
+        LogHelper.log('[RFC-0196] Energy slice clicked:', group);
+      },
     });
     LogHelper.log('Energy Info created');
   }
@@ -787,6 +821,10 @@ function createWaterGrids(lib) {
       showChart: true,
       showExpandButton: true,
       debugActive: DEBUG_ACTIVE,
+      // RFC-0196 — slice click hook (parallel to energy panel).
+      onSliceClick: (group) => {
+        LogHelper.log('[RFC-0196] Water slice clicked:', group);
+      },
     });
     LogHelper.log('Water Info created');
   }
@@ -972,6 +1010,118 @@ window.addEventListener('myio:theme-change', (e) => {
     const settings = self.ctx?.settings || {};
     applyBackgroundToPage(_currentThemeMode, settings);
   }
+});
+
+// ============================================================================
+// RFC-0196 / RFC-0201 Phase-2 — Info-cards click-by-group filter wiring
+// ============================================================================
+// Listens for `myio:filter-applied` (dispatched by the
+// TelemetryInfoShopping component on slice click) and narrows the
+// visible domain grids to the matching device list. When `group` is
+// `null` (filter cleared via toggle) all grids are restored to their
+// classified baselines.
+//
+// NOTE: registered at module scope BEFORE `onInit` to avoid the
+// well-known "event fired during async onInit awaits" race (RFC-0126).
+
+/**
+ * RFC-0196 — match a device against a filter group within a domain.
+ * Energy uses snake_case group keys (mirrors `buildEquipmentCategorySummary`).
+ * Water uses camelCase group keys (mirrors the Info component).
+ */
+function _matchDeviceForGroup(device, domain, group) {
+  if (!device || !domain || !group) return false;
+
+  if (domain === 'energy') {
+    const lib = window.MyIOLibrary;
+    const classify = lib && lib.classifyEquipment;
+    if (!classify) return false;
+    const cat = classify(device); // returns snake_case key
+    if (group === 'erro') return false; // Erro is residual, no devices
+    return cat === group;
+  }
+
+  if (domain === 'water') {
+    // Water groups are derived from the original `classified.water.*`
+    // bucket (set on STATE.water.<group>.items by processDataAndDispatchEvents).
+    // We match by checking which bucket the device lives in.
+    const water = window.STATE?.water || {};
+    const bucketName =
+      group === 'lojas' ? 'lojas'
+      : group === 'banheiros' ? 'banheiros'
+      : group === 'areaComum' ? 'areacomum'
+      : group === 'entrada' ? 'entrada'
+      : null;
+    if (!bucketName) return false;
+    const bucket = water[bucketName];
+    if (!bucket || !Array.isArray(bucket.items)) return false;
+    return bucket.items.some((d) => d?.entityId === device.entityId);
+  }
+
+  return false;
+}
+
+/**
+ * RFC-0196 — narrow energy grids on filter, restore on clear.
+ * Mirror is symmetric for water.
+ */
+function _applyFilterToGrids(domain, group) {
+  const itemsBase = window.STATE?.itemsBase || [];
+
+  if (domain === 'energy') {
+    const matches = group
+      ? itemsBase.filter((d) => d?.domain === 'energy' && _matchDeviceForGroup(d, 'energy', group))
+      : null;
+
+    // When filter is cleared (group=null), restore each grid to its
+    // classified baseline. When set, push the matched subset to all
+    // three energy grids (the user clicked one slice — they want all
+    // visible energy grids to converge on those devices).
+    if (matches != null) {
+      _energyGridEntrada?.updateDevices?.(matches.filter((d) => window.STATE?.energy?.entrada?.items?.some((x) => x.entityId === d.entityId)));
+      _energyGridAreaComum?.updateDevices?.(matches.filter((d) => window.STATE?.energy?.areacomum?.items?.some((x) => x.entityId === d.entityId)));
+      _energyGridLojas?.updateDevices?.(matches.filter((d) => window.STATE?.energy?.lojas?.items?.some((x) => x.entityId === d.entityId)));
+    } else {
+      // Clear filter — restore baselines.
+      _energyGridEntrada?.updateDevices?.(window.STATE?.energy?.entrada?.items || []);
+      _energyGridAreaComum?.updateDevices?.(window.STATE?.energy?.areacomum?.items || []);
+      _energyGridLojas?.updateDevices?.(window.STATE?.energy?.lojas?.items || []);
+    }
+  } else if (domain === 'water') {
+    if (group) {
+      const matches = itemsBase.filter(
+        (d) => d?.domain === 'water' && _matchDeviceForGroup(d, 'water', group)
+      );
+      _waterGridEntrada?.updateDevices?.(matches.filter((d) => window.STATE?.water?.entrada?.items?.some((x) => x.entityId === d.entityId)));
+      _waterGridAreaComum?.updateDevices?.(matches.filter((d) => window.STATE?.water?.areacomum?.items?.some((x) => x.entityId === d.entityId)));
+      _waterGridLojas?.updateDevices?.(matches.filter((d) => window.STATE?.water?.lojas?.items?.some((x) => x.entityId === d.entityId)));
+    } else {
+      _waterGridEntrada?.updateDevices?.(window.STATE?.water?.entrada?.items || []);
+      _waterGridAreaComum?.updateDevices?.(window.STATE?.water?.areacomum?.items || []);
+      _waterGridLojas?.updateDevices?.(window.STATE?.water?.lojas?.items || []);
+    }
+  }
+}
+
+window.addEventListener('myio:filter-applied', (e) => {
+  const detail = e?.detail || {};
+  const domain = detail.domain;
+  const group = detail.group; // null when filter is toggled off
+  if (!domain) return;
+
+  // Resolve deviceIds from `STATE.itemsBase` and fold them into the
+  // detail object so downstream listeners (footer, settings) get a
+  // ready-to-use list. This is best-effort — when the Info component
+  // dispatches the event it leaves `deviceIds` empty; we patch it here.
+  const itemsBase = window.STATE?.itemsBase || [];
+  const matches = group
+    ? itemsBase.filter((d) => d?.domain === domain && _matchDeviceForGroup(d, domain, group))
+    : [];
+  detail.deviceIds = matches.map((d) => d.entityId).filter(Boolean);
+
+  LogHelper.log('[RFC-0196] myio:filter-applied:', { domain, group, count: detail.deviceIds.length });
+
+  _applyFilterToGrids(domain, group);
 });
 
 // ============================================================================

--- a/tests/components/telemetry-info-shopping/onSliceClick.test.ts
+++ b/tests/components/telemetry-info-shopping/onSliceClick.test.ts
@@ -1,0 +1,269 @@
+/**
+ * RFC-0201 Phase-2 / RFC-0196 — AC-RFC-0196-1, AC-RFC-0196-2.
+ *
+ * Verifies the TelemetryInfoShopping component:
+ *   - Fires `onSliceClick(group)` and dispatches `myio:filter-applied`
+ *     when the user activates a slice (legend item proxies the click,
+ *     since Chart.js is not loaded under jsdom). (AC-RFC-0196-1)
+ *   - Applies the visual ring class (`tis-card--active`) to the clicked
+ *     group's card and `tis-card--faded` to siblings. (AC-RFC-0196-1)
+ *   - Computes `Erro = Entrada − Σ(consumers)` and includes the slice
+ *     in the chart data + Erro card whenever the residual is strictly
+ *     positive. (AC-RFC-0196-2)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createTelemetryInfoShoppingComponent } from '../../../src/components/telemetry-info-shopping/createTelemetryInfoShoppingComponent';
+import type { TelemetryInfoShoppingInstance } from '../../../src/components/telemetry-info-shopping/types';
+
+/**
+ * Mount the component into a fresh container detached from <body> isn't
+ * enough — `injectStyles` writes to `document.head`, and the Chart.js
+ * canvas requires a parent in the document tree for `getBoundingClientRect`
+ * to return non-zero dimensions. We attach to `document.body` and clean
+ * up between tests.
+ */
+let container: HTMLElement;
+
+beforeEach(() => {
+  // Ensure each test starts from a clean DOM.
+  document.body.innerHTML = '';
+  container = document.createElement('div');
+  // jsdom defaults all element rects to zero — give the Info root a
+  // non-zero size so the chart-init dimension check passes (it doesn't
+  // matter much since Chart.js itself is undefined in this env).
+  container.style.width = '600px';
+  container.style.height = '400px';
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('TelemetryInfoShopping — onSliceClick (RFC-0196 / AC-RFC-0196-1)', () => {
+  it('fires onSliceClick("lojas") + dispatches myio:filter-applied + applies tis-card--active to the lojas card', () => {
+    const onSliceClick = vi.fn();
+    const filterEvents: CustomEvent[] = [];
+    const filterListener = (e: Event) => filterEvents.push(e as CustomEvent);
+    window.addEventListener('myio:filter-applied', filterListener);
+
+    let instance: TelemetryInfoShoppingInstance | null = null;
+    try {
+      instance = createTelemetryInfoShoppingComponent({
+        container,
+        domain: 'energy',
+        themeMode: 'light',
+        showChart: true,
+        showExpandButton: false,
+        debugActive: false,
+        onSliceClick,
+      });
+
+      // Seed energy data: every consumer + entrada is non-zero so the
+      // pie has every slice (and the legend has every chip).
+      instance.setEnergyData({
+        entrada: { total: 1000 },
+        lojas: { total: 400 },
+        climatizacao: { total: 200 },
+        elevadores: { total: 100 },
+        escadasRolantes: { total: 50 },
+        outros: { total: 50 },
+      });
+
+      // The pie can't be clicked under jsdom (Chart.js is not loaded),
+      // but the legend chips share the same `handleSliceClick` path.
+      // Find and click the Lojas chip via its data-group.
+      const lojasChip = container.querySelector(
+        '.tis-legend-item[data-group="lojas"]'
+      ) as HTMLElement | null;
+      expect(lojasChip).not.toBeNull();
+
+      lojasChip!.click();
+
+      // (1) Callback fired with the canonical group identifier.
+      expect(onSliceClick).toHaveBeenCalledTimes(1);
+      expect(onSliceClick).toHaveBeenCalledWith('lojas');
+
+      // (2) Global event dispatched with matching detail.
+      expect(filterEvents.length).toBe(1);
+      expect(filterEvents[0].detail).toMatchObject({
+        domain: 'energy',
+        group: 'lojas',
+      });
+      expect(Array.isArray(filterEvents[0].detail.deviceIds)).toBe(true);
+
+      // (3) Visual ring: the lojas card is active, siblings are faded.
+      const lojasCard = container.querySelector(
+        '.tis-card[data-category="lojas"]'
+      ) as HTMLElement | null;
+      const climatizacaoCard = container.querySelector(
+        '.tis-card[data-category="climatizacao"]'
+      ) as HTMLElement | null;
+      const totalCard = container.querySelector(
+        '.tis-card[data-category="total"]'
+      ) as HTMLElement | null;
+
+      expect(lojasCard?.classList.contains('tis-card--active')).toBe(true);
+      expect(lojasCard?.classList.contains('tis-card--faded')).toBe(false);
+      expect(climatizacaoCard?.classList.contains('tis-card--faded')).toBe(true);
+      expect(climatizacaoCard?.classList.contains('tis-card--active')).toBe(false);
+      // The "Total Consumidores" card is informational and should never fade.
+      expect(totalCard?.classList.contains('tis-card--faded')).toBe(false);
+
+      expect(instance.getActiveGroup()).toBe('lojas');
+    } finally {
+      window.removeEventListener('myio:filter-applied', filterListener);
+      instance?.destroy();
+    }
+  });
+
+  it('toggles the filter off when the same slice is clicked twice (group becomes null)', () => {
+    const onSliceClick = vi.fn();
+    const filterEvents: CustomEvent[] = [];
+    const filterListener = (e: Event) => filterEvents.push(e as CustomEvent);
+    window.addEventListener('myio:filter-applied', filterListener);
+
+    let instance: TelemetryInfoShoppingInstance | null = null;
+    try {
+      instance = createTelemetryInfoShoppingComponent({
+        container,
+        domain: 'energy',
+        themeMode: 'light',
+        showChart: true,
+        showExpandButton: false,
+        debugActive: false,
+        onSliceClick,
+      });
+
+      instance.setEnergyData({
+        entrada: { total: 1000 },
+        lojas: { total: 400 },
+        climatizacao: { total: 200 },
+        elevadores: { total: 100 },
+        escadasRolantes: { total: 50 },
+        outros: { total: 50 },
+      });
+
+      // First click — activates.
+      const lojasChip = container.querySelector(
+        '.tis-legend-item[data-group="lojas"]'
+      ) as HTMLElement;
+      lojasChip.click();
+      expect(instance.getActiveGroup()).toBe('lojas');
+
+      // Second click on the same chip — toggle off.
+      const lojasChipAgain = container.querySelector(
+        '.tis-legend-item[data-group="lojas"]'
+      ) as HTMLElement;
+      lojasChipAgain.click();
+
+      expect(instance.getActiveGroup()).toBeNull();
+      expect(onSliceClick).toHaveBeenCalledTimes(2);
+
+      // Last dispatched event should carry `group: null` (filter cleared).
+      expect(filterEvents.length).toBe(2);
+      expect(filterEvents[1].detail).toMatchObject({
+        domain: 'energy',
+        group: null,
+      });
+
+      // Visual: no card should be active or faded after toggle-off.
+      const lojasCard = container.querySelector(
+        '.tis-card[data-category="lojas"]'
+      ) as HTMLElement;
+      const climatizacaoCard = container.querySelector(
+        '.tis-card[data-category="climatizacao"]'
+      ) as HTMLElement;
+      expect(lojasCard.classList.contains('tis-card--active')).toBe(false);
+      expect(lojasCard.classList.contains('tis-card--faded')).toBe(false);
+      expect(climatizacaoCard.classList.contains('tis-card--faded')).toBe(false);
+    } finally {
+      window.removeEventListener('myio:filter-applied', filterListener);
+      instance?.destroy();
+    }
+  });
+});
+
+describe('TelemetryInfoShopping — Erro slice calculation (RFC-0196 / AC-RFC-0196-2)', () => {
+  it('seeds entrada=100 and Σ(consumers)=88 → Erro slice value 12 is included in the legend', () => {
+    let instance: TelemetryInfoShoppingInstance | null = null;
+    try {
+      instance = createTelemetryInfoShoppingComponent({
+        container,
+        domain: 'energy',
+        themeMode: 'light',
+        showChart: true,
+        showExpandButton: false,
+        debugActive: false,
+      });
+
+      // Σ(consumers) = 50 + 20 + 10 + 5 + 3 = 88 → Erro = 100 − 88 = 12.
+      instance.setEnergyData({
+        entrada: { total: 100 },
+        lojas: { total: 50 },
+        climatizacao: { total: 20 },
+        elevadores: { total: 10 },
+        escadasRolantes: { total: 5 },
+        outros: { total: 3 },
+      });
+
+      // (1) State carries the residual.
+      const state = instance.getState() as { erro?: { total: number } } | null;
+      expect(state).not.toBeNull();
+      expect(state?.erro).toBeDefined();
+      expect(state?.erro?.total).toBeCloseTo(12, 6);
+
+      // (2) Erro card text reflects the calculation.
+      const erroValueEl = container.querySelector('#erroTotal') as HTMLElement | null;
+      expect(erroValueEl).not.toBeNull();
+      expect(erroValueEl!.textContent).toMatch(/12,00/);
+
+      // (3) Pie chart legend includes the Erro slice with the same value.
+      const erroChip = container.querySelector(
+        '.tis-legend-item[data-group="erro"]'
+      ) as HTMLElement | null;
+      expect(erroChip).not.toBeNull();
+      const valueLabel = erroChip!.querySelector('.tis-legend-value');
+      expect(valueLabel?.textContent).toMatch(/12,00/);
+    } finally {
+      instance?.destroy();
+    }
+  });
+
+  it('renders the placeholder "—" and omits the slice when Σ(consumers) ≥ Entrada', () => {
+    let instance: TelemetryInfoShoppingInstance | null = null;
+    try {
+      instance = createTelemetryInfoShoppingComponent({
+        container,
+        domain: 'energy',
+        themeMode: 'light',
+        showChart: true,
+        showExpandButton: false,
+        debugActive: false,
+      });
+
+      // Σ(consumers) = 110 > Entrada = 100 → Erro = -10 (negative). Card
+      // shows the placeholder; chart legend has no `erro` chip.
+      instance.setEnergyData({
+        entrada: { total: 100 },
+        lojas: { total: 50 },
+        climatizacao: { total: 30 },
+        elevadores: { total: 20 },
+        escadasRolantes: { total: 5 },
+        outros: { total: 5 },
+      });
+
+      const state = instance.getState() as { erro?: { total: number } } | null;
+      expect(state?.erro?.total).toBeLessThanOrEqual(0);
+
+      const erroValueEl = container.querySelector('#erroTotal') as HTMLElement | null;
+      expect(erroValueEl?.textContent).toBe('—');
+
+      const erroChip = container.querySelector('.tis-legend-item[data-group="erro"]');
+      expect(erroChip).toBeNull();
+    } finally {
+      instance?.destroy();
+    }
+  });
+});

--- a/tests/v-5.4.0/byCategoryPayload.test.ts
+++ b/tests/v-5.4.0/byCategoryPayload.test.ts
@@ -1,0 +1,349 @@
+/**
+ * RFC-0201 Phase-2 / RFC-0196 — `myio:energy-summary-ready` byCategory.
+ *
+ * Verifies that after `processDataAndDispatchEvents` runs, the
+ * `myio:energy-summary-ready` event detail includes a `byCategory`
+ * field whose shape mirrors `buildEquipmentCategorySummary` (the six
+ * canonical category keys + `area_comum` residual).
+ *
+ * Strategy mirrors `processDataAndDispatchEvents.test.ts`: load the
+ * controller into a fresh vm context with mocked globals, capture
+ * dispatched events, run the function, assert the payload.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import vm from 'node:vm';
+
+const CONTROLLER_PATH = resolve(
+  __dirname,
+  '../../src/thingsboard/main-dashboard-shopping/v-5.4.0/controller.js'
+);
+
+function makeRow(
+  entityId: string,
+  entityName: string,
+  keyName: string,
+  value: any,
+  ts = 1714400000000,
+  aliasName = 'AllDevices'
+) {
+  return {
+    datasource: { entityId, entityName, entityLabel: entityName, aliasName },
+    dataKey: { name: keyName },
+    data: [[ts, value]],
+  };
+}
+
+interface CapturedEvent {
+  type: string;
+  detail: any;
+}
+
+interface ProcessedSandbox {
+  window: any;
+  events: CapturedEvent[];
+  run: () => boolean;
+}
+
+function loadController(ctxData: any[]): ProcessedSandbox {
+  const source = readFileSync(CONTROLLER_PATH, 'utf-8');
+
+  // Append a bridge so we can reach the closed-over function from outside.
+  const bridge = `
+    ;globalThis.__processDataAndDispatchEvents = processDataAndDispatchEvents;
+  `;
+
+  const events: CapturedEvent[] = [];
+
+  // Fake `buildEquipmentCategorySummary` mirroring the real return shape.
+  // Returns the six canonical keys + `area_comum`, computed from a
+  // simple sum over the seeded devices. The real implementation classifies
+  // each device by deviceType/Profile/identifier; for this test the
+  // controller passes us `allEnergy` (already classified by domain), so
+  // we just count by deviceProfile.
+  const fakeBuildEquipmentCategorySummary = (devices: any[]) => {
+    const init = () => ({ devices: [] as any[], count: 0, consumption: 0, percentage: 0, subcategories: {} });
+    const summary: Record<string, ReturnType<typeof init>> = {
+      entrada: init(),
+      lojas: init(),
+      climatizacao: init(),
+      elevadores: init(),
+      escadas_rolantes: init(),
+      outros: init(),
+      area_comum: init(),
+    };
+    for (const d of devices || []) {
+      const profile = String(d?.deviceProfile || '').toUpperCase();
+      const dtype = String(d?.deviceType || '').toUpperCase();
+      const value = Number(d?.value || 0);
+      let cat = 'outros';
+      if (['ENTRADA', 'RELOGIO', 'TRAFO', 'SUBESTACAO'].some((t) => profile.includes(t) || dtype.includes(t))) cat = 'entrada';
+      else if (dtype === '3F_MEDIDOR' && profile === '3F_MEDIDOR') cat = 'lojas';
+      else if (['CHILLER', 'FANCOIL', 'HVAC', 'AR_CONDICIONADO', 'BOMBA_CAG'].some((t) => profile.includes(t))) cat = 'climatizacao';
+      else if (profile.includes('ELEVADOR')) cat = 'elevadores';
+      else if (profile.includes('ESCADA')) cat = 'escadas_rolantes';
+      summary[cat].devices.push(d);
+      summary[cat].count++;
+      summary[cat].consumption += value;
+    }
+    const entrada = summary.entrada.consumption;
+    const mapped =
+      summary.lojas.consumption +
+      summary.climatizacao.consumption +
+      summary.elevadores.consumption +
+      summary.escadas_rolantes.consumption +
+      summary.outros.consumption;
+    summary.area_comum.consumption = Math.max(0, entrada - mapped);
+    return summary;
+  };
+
+  const mockWindow: any = {
+    MyIOLibrary: {
+      calculateDeviceStatusMasterRules: () => 'online',
+      getDomainFromDeviceType: (deviceType: string) => {
+        const t = String(deviceType || '').toUpperCase();
+        if (t.includes('HIDROMETRO')) return 'water';
+        if (t.includes('TERMOSTATO')) return 'temperature';
+        return 'energy';
+      },
+      detectContext: (_device: any, domain: string) => {
+        if (domain === 'water') return 'hidrometro';
+        if (domain === 'temperature') return 'termostato';
+        return 'equipments';
+      },
+      buildEquipmentCategorySummary: fakeBuildEquipmentCategorySummary,
+    },
+    MyIOUtils: {
+      temperatureLimits: { minTemperature: 18, maxTemperature: 26 },
+    },
+    STATE: {},
+    addEventListener: () => {},
+    dispatchEvent: (event: any) => {
+      events.push({ type: event?.type, detail: event?.detail });
+      return true;
+    },
+    CustomEvent: globalThis.CustomEvent ?? class {
+      detail: any;
+      type: string;
+      constructor(type: string, init?: { detail?: any }) {
+        this.type = type;
+        this.detail = init?.detail;
+      }
+    },
+    localStorage: {
+      getItem: () => null,
+      setItem: () => {},
+      removeItem: () => {},
+    },
+  };
+
+  const mockSelf: any = {
+    ctx: { data: ctxData, http: { getServerCredentials: () => null } },
+  };
+
+  class SandboxCustomEvent {
+    type: string;
+    detail: any;
+    constructor(type: string, init?: { detail?: any }) {
+      this.type = type;
+      this.detail = init?.detail;
+    }
+  }
+
+  const sandbox: any = {
+    window: mockWindow,
+    self: mockSelf,
+    document: { addEventListener: () => {} },
+    MyIOLibrary: mockWindow.MyIOLibrary,
+    localStorage: mockWindow.localStorage,
+    CustomEvent: SandboxCustomEvent,
+    console,
+    setTimeout,
+    clearTimeout,
+    fetch: async () => ({ ok: false, status: 0, json: async () => ({}) }),
+    globalThis: {} as any,
+  };
+  sandbox.globalThis = sandbox;
+
+  vm.createContext(sandbox);
+  vm.runInContext(source + bridge, sandbox);
+
+  return {
+    window: mockWindow,
+    events,
+    run: () => sandbox.__processDataAndDispatchEvents(),
+  };
+}
+
+describe('processDataAndDispatchEvents — RFC-0196 byCategory payload', () => {
+  let sandbox: ProcessedSandbox;
+
+  beforeEach(() => {
+    // Seed: 1 entrada + 1 loja + 1 chiller + 1 elevador + 1 escada + 1 outros + 1 water + 1 temperature.
+    // Each energy device has a distinct value so we can verify the
+    // category split end-to-end.
+    const rows = [
+      // ENTRADA — 50
+      makeRow('en-en', 'entrada', 'deviceType', 'ENTRADA'),
+      makeRow('en-en', 'entrada', 'deviceProfile', 'ENTRADA'),
+      makeRow('en-en', 'entrada', 'consumption', 50),
+      // LOJAS — 20
+      makeRow('en-lj', 'loja', 'deviceType', '3F_MEDIDOR'),
+      makeRow('en-lj', 'loja', 'deviceProfile', '3F_MEDIDOR'),
+      makeRow('en-lj', 'loja', 'consumption', 20),
+      // CLIMATIZACAO — 10
+      makeRow('en-cl', 'chiller', 'deviceType', '3F_MEDIDOR'),
+      makeRow('en-cl', 'chiller', 'deviceProfile', 'CHILLER'),
+      makeRow('en-cl', 'chiller', 'consumption', 10),
+      // ELEVADORES — 5
+      makeRow('en-elv', 'elv', 'deviceType', '3F_MEDIDOR'),
+      makeRow('en-elv', 'elv', 'deviceProfile', 'ELEVADOR'),
+      makeRow('en-elv', 'elv', 'consumption', 5),
+      // ESCADAS — 3
+      makeRow('en-esc', 'esc', 'deviceType', '3F_MEDIDOR'),
+      makeRow('en-esc', 'esc', 'deviceProfile', 'ESCADA_ROLANTE'),
+      makeRow('en-esc', 'esc', 'consumption', 3),
+      // OUTROS — 2
+      makeRow('en-out', 'out', 'deviceType', '3F_MEDIDOR'),
+      makeRow('en-out', 'out', 'deviceProfile', 'BOMBA_INCENDIO'),
+      makeRow('en-out', 'out', 'consumption', 2),
+      // WATER (used to verify water summary doesn't claim byCategory)
+      makeRow('wt-1', 'water', 'deviceType', 'HIDROMETRO'),
+      makeRow('wt-1', 'water', 'pulses', 99),
+    ];
+
+    sandbox = loadController(rows);
+  });
+
+  it('emits myio:energy-summary-ready with a non-null byCategory containing the 6 canonical keys + area_comum', () => {
+    sandbox.run();
+
+    const energyEvent = sandbox.events.find((e) => e.type === 'myio:energy-summary-ready');
+    expect(energyEvent).toBeDefined();
+    expect(energyEvent!.detail).toBeDefined();
+
+    // Required existing fields still present.
+    expect(typeof energyEvent!.detail.totalDevices).toBe('number');
+    expect(typeof energyEvent!.detail.totalConsumption).toBe('number');
+    expect(energyEvent!.detail.byStatus).toBeDefined();
+
+    // RFC-0196 — byCategory present and non-null.
+    expect(energyEvent!.detail.byCategory).toBeDefined();
+    expect(energyEvent!.detail.byCategory).not.toBeNull();
+
+    const byCategory = energyEvent!.detail.byCategory;
+    // Six canonical keys + area_comum residual.
+    expect(byCategory).toHaveProperty('entrada');
+    expect(byCategory).toHaveProperty('lojas');
+    expect(byCategory).toHaveProperty('climatizacao');
+    expect(byCategory).toHaveProperty('elevadores');
+    expect(byCategory).toHaveProperty('escadas_rolantes');
+    expect(byCategory).toHaveProperty('outros');
+    expect(byCategory).toHaveProperty('area_comum');
+  });
+
+  it('byCategory consumption values reflect seeded device totals', () => {
+    sandbox.run();
+    const energyEvent = sandbox.events.find((e) => e.type === 'myio:energy-summary-ready');
+    const byCategory = energyEvent!.detail.byCategory;
+
+    expect(byCategory.entrada.consumption).toBe(50);
+    expect(byCategory.lojas.consumption).toBe(20);
+    expect(byCategory.climatizacao.consumption).toBe(10);
+    expect(byCategory.elevadores.consumption).toBe(5);
+    expect(byCategory.escadas_rolantes.consumption).toBe(3);
+    expect(byCategory.outros.consumption).toBe(2);
+    // area_comum is residual = entrada − mapped = 50 − (20+10+5+3+2) = 10.
+    expect(byCategory.area_comum.consumption).toBe(10);
+  });
+
+  it('water-summary-ready does NOT include byCategory (intentional — no canonical hidrômetro split)', () => {
+    sandbox.run();
+    const waterEvent = sandbox.events.find((e) => e.type === 'myio:water-summary-ready');
+    expect(waterEvent).toBeDefined();
+    expect(waterEvent!.detail).toBeDefined();
+    // byCategory is intentionally undefined for water.
+    expect(waterEvent!.detail.byCategory).toBeUndefined();
+  });
+
+  it('falls back to byCategory=null when buildEquipmentCategorySummary is unavailable', () => {
+    // Re-load with the helper missing.
+    const source = readFileSync(CONTROLLER_PATH, 'utf-8');
+    const bridge = `;globalThis.__processDataAndDispatchEvents = processDataAndDispatchEvents;`;
+    const events: CapturedEvent[] = [];
+
+    const mockWindow: any = {
+      MyIOLibrary: {
+        calculateDeviceStatusMasterRules: () => 'online',
+        getDomainFromDeviceType: () => 'energy',
+        detectContext: () => 'equipments',
+        // buildEquipmentCategorySummary deliberately omitted.
+      },
+      MyIOUtils: { temperatureLimits: { minTemperature: 18, maxTemperature: 26 } },
+      STATE: {},
+      addEventListener: () => {},
+      dispatchEvent: (event: any) => {
+        events.push({ type: event?.type, detail: event?.detail });
+        return true;
+      },
+      CustomEvent: globalThis.CustomEvent ?? class {
+        detail: any;
+        type: string;
+        constructor(type: string, init?: { detail?: any }) {
+          this.type = type;
+          this.detail = init?.detail;
+        }
+      },
+      localStorage: { getItem: () => null, setItem: () => {}, removeItem: () => {} },
+    };
+
+    const mockSelf: any = {
+      ctx: {
+        data: [
+          makeRow('en-1', 'd', 'deviceType', '3F_MEDIDOR'),
+          makeRow('en-1', 'd', 'deviceProfile', '3F_MEDIDOR'),
+          makeRow('en-1', 'd', 'consumption', 1),
+        ],
+        http: { getServerCredentials: () => null },
+      },
+    };
+
+    class SandboxCustomEvent {
+      type: string;
+      detail: any;
+      constructor(type: string, init?: { detail?: any }) {
+        this.type = type;
+        this.detail = init?.detail;
+      }
+    }
+
+    const sb: any = {
+      window: mockWindow,
+      self: mockSelf,
+      document: { addEventListener: () => {} },
+      MyIOLibrary: mockWindow.MyIOLibrary,
+      localStorage: mockWindow.localStorage,
+      CustomEvent: SandboxCustomEvent,
+      console,
+      setTimeout,
+      clearTimeout,
+      fetch: async () => ({ ok: false, status: 0, json: async () => ({}) }),
+      globalThis: {} as any,
+    };
+    sb.globalThis = sb;
+
+    vm.createContext(sb);
+    vm.runInContext(source + bridge, sb);
+
+    sb.__processDataAndDispatchEvents();
+
+    const energyEvent = events.find((e) => e.type === 'myio:energy-summary-ready');
+    expect(energyEvent).toBeDefined();
+    // The contract: field is present, value is null, listeners must
+    // tolerate the missing-helper case.
+    expect(energyEvent!.detail).toHaveProperty('byCategory');
+    expect(energyEvent!.detail.byCategory).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Implements RFC-0201 Phase-2 work-list rows **#21** (Info-cards click) and **#22** (controller wiring), targeting RFC-0196.

- **`createTelemetryInfoShoppingComponent`**: new `onSliceClick(group)` prop; pie now includes a calculated **Erro** slice; clicking a slice applies a 4 px white border ring and fades siblings to 60 % opacity (per Sally's Visual-Parity spec). Hover tooltip now shows percentage + absolute value (kWh / m³).
- **`myio:filter-applied` event**: dispatched on slice click with `{ domain, group, deviceIds }`. Same-slice-twice toggles the filter off (`group: null`).
- **v-5.4.0 controller**:
  - Emits `byCategory` in `myio:energy-summary-ready` (via `lib.buildEquipmentCategorySummary`); falls back to `null` when the helper is missing.
  - Listens for `myio:filter-applied` and narrows the visible energy/water grids to the matched device subset; clearing restores classified baselines.
  - Wires `onSliceClick` callback on both energy and water Info instances.
- Water `myio:water-summary-ready` intentionally omits `byCategory` (no canonical hidrômetro split — documented inline).

### Boundaries respected

- v-5.2.0 untouched (read-only as required).
- `STATE.itemsBase` shape unchanged (Pod F0 contract preserved).
- Alarm orchestrator / Pod E reports menu / showcase / `package.json` untouched.

## Test plan

- [x] **AC-RFC-0196-1** — `tests/components/telemetry-info-shopping/onSliceClick.test.ts` mounts the component, seeds energy data, clicks the Lojas chip; asserts `onSliceClick('lojas')` fires, `myio:filter-applied` is dispatched with matching detail, and `tis-card--active` lands on the Lojas card while siblings get `tis-card--faded`.
- [x] **AC-RFC-0196-2** — same file: with `entrada=100` and `Σ(consumers)=88`, asserts the state's `erro.total === 12` and the chart legend includes the Erro chip with the same value. Companion test seeds Σ ≥ Entrada and verifies the `'—'` placeholder + omitted slice.
- [x] **byCategory payload** — `tests/v-5.4.0/byCategoryPayload.test.ts` exercises `processDataAndDispatchEvents` end-to-end via vm context (mirrors the Phase-1 Pod F0 pattern); asserts `myio:energy-summary-ready.detail.byCategory` is a non-null object with the six canonical keys + `area_comum`, with consumption values matching seeded devices, and that the helper-missing case falls back to `null`. Water summary asserted to *not* include `byCategory`.

```
npx vitest run tests/components/telemetry-info-shopping/onSliceClick.test.ts tests/v-5.4.0/byCategoryPayload.test.ts
# Test Files  2 passed (2)
#      Tests  8 passed (8)
```

Existing tests (`processDataAndDispatchEvents`, `createAlarmServiceOrchestrator`, header alarms tooltip) continue to pass — no regressions in Phase-1 territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)