### PR TITLE
fix(header): rfc198 ticket button spinner spins forever when tickets disabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "myio-js-library",
-  "version": "0.1.513",
+  "version": "0.1.514",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "myio-js-library",
-      "version": "0.1.513",
+      "version": "0.1.514",
       "license": "MIT",
       "dependencies": {
         "jspdf": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myio-js-library",
-  "version": "0.1.513",
+  "version": "0.1.514",
   "description": "A clean, standalone JS SDK for MYIO projects",
   "license": "MIT",
   "repository": "github:gh-myio/myio-js-library",

--- a/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/HEADER/controller.js
+++ b/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/HEADER/controller.js
@@ -2180,8 +2180,19 @@ self.onInit = async function ({ strt: presetStart, end: presetEnd } = {}) {
         });
       }
     }
-    // Fast path: already enabled at init time (e.g. cached from previous onDataUpdated)
-    _setupTicketButton();
+    // Apply current gate state at init. The myio:tickets-gate-changed event may have
+    // been dispatched by MAIN_VIEW BEFORE this listener was registered (HEADER inits
+    // after MAIN_VIEW computes the gate), so we must read the current state directly
+    // instead of relying solely on the event.
+    if (window.MyIOUtils?.ticketsEnabled === true) {
+      _setupTicketButton();
+    } else if (btnTicketNotif) {
+      // Fail-closed: tickets disabled/unknown → remove the default loading spinner
+      // and hide the button (otherwise it spins forever — RFC-0198 follow-up).
+      btnTicketNotif.classList.remove('is-loading');
+      btnTicketNotif.removeAttribute('aria-busy');
+      btnTicketNotif.style.display = 'none';
+    }
 
     function _updateTicketNotifBadge(count) {
       const badge = document.getElementById('tbx-ticket-notif-badge');


### PR DESCRIPTION
## Problema

O botão de Chamados (FreshDesk) no HEADER do widget Shopping v-5.2.0 nasce com spinner de loading (`is-loading`). O HEADER inicializa **depois** do MAIN_VIEW computar o gate de tickets, então o evento `myio:tickets-gate-changed` pode ser disparado **antes** deste listener ser registrado. Confiar somente no evento deixava o botão preso girando para sempre quando tickets estavam desabilitados/desconhecidos (caso Plaza Macaé).

## Fix (fail-closed)

No init, lê o estado atual do gate direto de `window.MyIOUtils.ticketsEnabled` em vez de depender só do evento:

- `true` → `_setupTicketButton()`
- senão → **fail-closed**: remove `is-loading`/`aria-busy` e esconde o botão (`display:none`).

## Escopo

- 1 arquivo: `HEADER/controller.js` (+13/-2)
- A mudança de classificação de energia (MAIN_VIEW) foi **revertida** — os deviceProfiles estão corretos na origem; o `3F_MEDIDOR` fixo era no dataKeys do datasource do ThingsBoard e se resolve lá.

🤖 Generated with [Claude Code](https://claude.com/claude-code)