### PR TITLE
feat(premium-modals): RFC-0205 premium dialog - openConfirmDialog/openMessageDialog

### DIFF
--- a/showcase/index.html
+++ b/showcase/index.html
@@ -379,6 +379,25 @@
                 </div>
             </article>
 
+            <!-- Premium Dialog (RFC-0205) -->
+            <article class="category-card">
+                <div class="category-header">
+                    <div class="category-icon modal">💬</div>
+                    <h3 class="category-title">Premium Dialog</h3>
+                </div>
+                <p class="category-description">
+                    Diálogo premium de confirmação/mensagem (RFC-0205): promise-based, botões parametrizáveis, severidades, light/dark.
+                </p>
+                <div class="exports-list">
+                    <span class="export-tag">openConfirmDialog</span>
+                    <span class="export-tag">openMessageDialog</span>
+                </div>
+                <div class="category-actions">
+                    <a href="premium-dialog.html" class="btn btn-primary">Ver Demo</a>
+                    <a href="../src/docs/rfcs/RFC-0205-PremiumDialog-ExportedConfirmMessageModal.md" class="btn btn-secondary">RFC</a>
+                </div>
+            </article>
+
             <!-- MYIO Components -->
             <article class="category-card">
                 <div class="category-header">

--- a/showcase/premium-dialog.html
+++ b/showcase/premium-dialog.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Premium Dialog (RFC-0205) - MYIO JS Library Showcase</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'Nunito', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      min-height: 100vh;
+      padding: 40px 20px;
+      color: #1f2937;
+    }
+    .page {
+      max-width: 1000px;
+      margin: 0 auto;
+    }
+    .hero {
+      text-align: center;
+      color: #fff;
+      margin-bottom: 32px;
+    }
+    .hero h1 { font-size: 2rem; margin-bottom: 8px; text-shadow: 0 2px 4px rgba(0,0,0,0.2); }
+    .hero p { opacity: 0.9; }
+    .hero a { color: #fff; }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+      gap: 20px;
+    }
+    .card {
+      background: #fff;
+      border-radius: 12px;
+      padding: 20px;
+      box-shadow: 0 8px 24px rgba(0,0,0,0.15);
+    }
+    .card h3 { font-size: 15px; margin-bottom: 6px; }
+    .card p { font-size: 13px; color: #4b5563; margin-bottom: 14px; line-height: 1.5; }
+    .card button {
+      font-family: inherit;
+      font-size: 13px;
+      font-weight: 600;
+      padding: 8px 16px;
+      border-radius: 8px;
+      border: none;
+      cursor: pointer;
+      background: #7C3AED;
+      color: #fff;
+      margin-right: 6px;
+      margin-bottom: 6px;
+    }
+    .card button:hover { filter: brightness(0.92); }
+    .card button.secondary { background: #fff; color: #374151; border: 1px solid #d1d5db; }
+    .card button.danger { background: #dc2626; }
+    .card button.success { background: #16a34a; }
+    .card button.warning { background: #d97706; }
+    .log {
+      background: #111827;
+      color: #a7f3d0;
+      border-radius: 12px;
+      padding: 16px 20px;
+      margin-top: 24px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 12.5px;
+      line-height: 1.7;
+      min-height: 120px;
+      max-height: 260px;
+      overflow-y: auto;
+    }
+    .log .title { color: #9ca3af; font-weight: 700; margin-bottom: 6px; }
+    .log .null { color: #fca5a5; }
+  </style>
+</head>
+<body>
+  <div class="page">
+    <div class="hero">
+      <h1>🪟 Premium Dialog</h1>
+      <p>
+        RFC-0205 — <code>openConfirmDialog</code> / <code>openMessageDialog</code> ·
+        promise-based, botões parametrizáveis, Nunito, light/dark ·
+        <a href="../src/docs/rfcs/RFC-0205-PremiumDialog-ExportedConfirmMessageModal.md">spec</a>
+      </p>
+    </div>
+
+    <div class="grid">
+      <div class="card">
+        <h3>Confirmação destrutiva</h3>
+        <p><code>buttons: [secondary, danger]</code> — resolve com o <code>value</code> do botão ou <code>null</code> no dismissal (Esc / backdrop / ×).</p>
+        <button class="danger" id="demo-danger">Excluir anotação…</button>
+      </div>
+
+      <div class="card">
+        <h3>Três opções</h3>
+        <p>Qualquer quantidade de botões, em ordem; <code>autoFocus</code> marca o botão que recebe foco e responde Enter.</p>
+        <button id="demo-three">Aplicar setpoint…</button>
+      </div>
+
+      <div class="card">
+        <h3>Não-dismissível</h3>
+        <p><code>dismissible: false</code> — sem ×, Esc e backdrop ignorados. O usuário precisa escolher.</p>
+        <button class="warning" id="demo-blocking">Decisão obrigatória…</button>
+      </div>
+
+      <div class="card">
+        <h3>Tema dark</h3>
+        <p><code>theme: 'dark'</code> — mesma API, paleta escura.</p>
+        <button class="secondary" id="demo-dark">Abrir em dark…</button>
+      </div>
+
+      <div class="card">
+        <h3>Mensagens por severidade</h3>
+        <p><code>openMessageDialog</code> — título e ícone derivados do <code>severity</code>; botão único de OK.</p>
+        <button id="demo-info">info</button>
+        <button class="success" id="demo-success">success</button>
+        <button class="warning" id="demo-warning">warning</button>
+        <button class="danger" id="demo-error">error</button>
+      </div>
+
+      <div class="card">
+        <h3>Auto-close</h3>
+        <p><code>autoCloseMs: 3000</code> — fecha sozinho; a promise resolve do mesmo jeito.</p>
+        <button class="success" id="demo-autoclose">Salvar (toastão 3s)…</button>
+      </div>
+
+      <div class="card">
+        <h3>Conteúdo escapado</h3>
+        <p>Título/mensagem/labels são sempre HTML-escapados; <code>\n</code> vira quebra de linha.</p>
+        <button class="secondary" id="demo-escape">Tentar injetar HTML…</button>
+      </div>
+
+      <div class="card">
+        <h3>Largura custom + stacking</h3>
+        <p><code>width: 560</code>; abrir um diálogo a partir de outro empilha por z-index.</p>
+        <button id="demo-stacked">Abrir empilhados…</button>
+      </div>
+    </div>
+
+    <div class="log" id="log">
+      <div class="title">// resultado das promises</div>
+    </div>
+  </div>
+
+  <!-- Build da lib primeiro: npm run build (gera dist/myio-js-library.umd.js) -->
+  <script src="../dist/myio-js-library.umd.js"></script>
+  <script>
+    const { openConfirmDialog, openMessageDialog } = window.MyIOLibrary;
+    const logEl = document.getElementById('log');
+
+    function log(label, value) {
+      const line = document.createElement('div');
+      const shown = value === null ? '<span class="null">null (dismissal)</span>'
+        : value === undefined ? '<span>void</span>'
+        : `'${value}'`;
+      line.innerHTML = `${label} &rarr; ${shown}`;
+      logEl.appendChild(line);
+      logEl.scrollTop = logEl.scrollHeight;
+    }
+
+    document.getElementById('demo-danger').onclick = async () => {
+      const r = await openConfirmDialog({
+        title: 'Excluir anotação',
+        message: 'Esta ação não pode ser desfeita. Deseja continuar?',
+        buttons: [
+          { label: 'Cancelar', variant: 'secondary', value: 'cancel' },
+          { label: 'Excluir', variant: 'danger', value: 'confirm', autoFocus: true },
+        ],
+      });
+      log('confirm destrutivo', r);
+    };
+
+    document.getElementById('demo-three').onclick = async () => {
+      const r = await openConfirmDialog({
+        title: 'Aplicar para todos?',
+        message: 'O setpoint de 23°C será enviado para os 12 fancoils do andar.',
+        buttons: [
+          { label: 'Cancelar', variant: 'secondary', value: 'cancel' },
+          { label: 'Somente este', variant: 'secondary', value: 'one' },
+          { label: 'Aplicar a todos', variant: 'primary', value: 'all', autoFocus: true },
+        ],
+      });
+      log('três opções', r);
+    };
+
+    document.getElementById('demo-blocking').onclick = async () => {
+      const r = await openConfirmDialog({
+        title: 'Conflito de agendamento',
+        message: 'Já existe um agendamento para este horário.\nO que deseja fazer?',
+        dismissible: false,
+        buttons: [
+          { label: 'Manter existente', variant: 'secondary', value: 'keep' },
+          { label: 'Substituir', variant: 'primary', value: 'replace', autoFocus: true },
+        ],
+      });
+      log('não-dismissível', r);
+    };
+
+    document.getElementById('demo-dark').onclick = async () => {
+      const r = await openConfirmDialog({
+        title: 'Tema escuro',
+        message: 'Mesma API, paleta dark — consistente com os widgets em dark mode.',
+        theme: 'dark',
+        buttons: [
+          { label: 'Fechar', variant: 'secondary', value: 'close' },
+          { label: 'Legal!', variant: 'primary', value: 'nice', autoFocus: true },
+        ],
+      });
+      log('dark', r);
+    };
+
+    const sev = (severity, message) => async () => {
+      await openMessageDialog({ message, severity });
+      log(`message ${severity}`, undefined);
+    };
+    document.getElementById('demo-info').onclick = sev('info', 'A sincronização roda a cada 15 minutos.');
+    document.getElementById('demo-success').onclick = sev('success', 'Configurações salvas com sucesso.');
+    document.getElementById('demo-warning').onclick = sev('warning', '3 dispositivos estão sem telemetria há mais de 24h.');
+    document.getElementById('demo-error').onclick = sev('error', 'Falha ao salvar: a API retornou HTTP 500.');
+
+    document.getElementById('demo-autoclose').onclick = async () => {
+      await openMessageDialog({
+        message: 'Relatório gerado. Este aviso fecha sozinho em 3 segundos.',
+        severity: 'success',
+        autoCloseMs: 3000,
+      });
+      log('auto-close', undefined);
+    };
+
+    document.getElementById('demo-escape').onclick = async () => {
+      const r = await openConfirmDialog({
+        title: '<b>Título com HTML</b>',
+        message: 'Primeira linha\nSegunda linha com <script>alert(1)</' + 'script> escapado.',
+        buttons: [{ label: '<i>label com tag</i>', variant: 'primary', value: 'ok', autoFocus: true }],
+      });
+      log('escapado', r);
+    };
+
+    document.getElementById('demo-stacked').onclick = () => {
+      openConfirmDialog({
+        title: 'Primeiro diálogo (width: 560)',
+        message: 'Um segundo diálogo abre por cima deste em instantes — feche os dois em qualquer ordem.',
+        width: 560,
+        buttons: [{ label: 'Fechar o primeiro', variant: 'secondary', value: 'close-1' }],
+      }).then((r) => log('empilhado #1', r));
+
+      setTimeout(() => {
+        openConfirmDialog({
+          title: 'Segundo diálogo',
+          message: 'Este está acima do primeiro (z-index incremental).',
+          buttons: [{ label: 'Fechar o segundo', variant: 'primary', value: 'close-2', autoFocus: true }],
+        }).then((r) => log('empilhado #2', r));
+      }, 500);
+    };
+  </script>
+</body>
+</html>

--- a/src/components/premium-modals/dialog/index.ts
+++ b/src/components/premium-modals/dialog/index.ts
@@ -1,0 +1,12 @@
+/**
+ * RFC-0205: Premium Dialog — exported confirm/message modal.
+ */
+
+export { openConfirmDialog, openMessageDialog } from './openDialog';
+export type {
+  ConfirmDialogParams,
+  MessageDialogParams,
+  MessageDialogSeverity,
+  DialogButton,
+  DialogButtonVariant,
+} from './types';

--- a/src/components/premium-modals/dialog/openDialog.ts
+++ b/src/components/premium-modals/dialog/openDialog.ts
@@ -1,0 +1,203 @@
+/**
+ * RFC-0205: Premium Dialog — exported confirm/message modal with
+ * parameterizable buttons.
+ *
+ * Promise semantics: exactly one resolution per call. Button click resolves
+ * with its `value`; dismissal (Esc/backdrop/×) resolves with `null`. The
+ * promise never rejects from user interaction — programmer errors (empty
+ * `buttons`) throw synchronously.
+ */
+
+import { injectDialogStyles } from './styles';
+import type {
+  ConfirmDialogParams,
+  DialogButton,
+  MessageDialogParams,
+  MessageDialogSeverity,
+} from './types';
+
+// Stacks above the premium-modals baseline; bumped per dialog so concurrent
+// dialogs layer in open order.
+const BASE_Z_INDEX = 10500;
+let openCount = 0;
+
+function escapeHtml(value: string): string {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/** Escaped text with newlines rendered as line breaks. */
+function escapeMessage(value: string): string {
+  return escapeHtml(value).replace(/\n/g, '<br>');
+}
+
+function cssWidth(width: ConfirmDialogParams['width']): string {
+  if (width == null) return '420px';
+  return typeof width === 'number' ? `${width}px` : width;
+}
+
+const SEVERITY_META: Record<MessageDialogSeverity, { title: string; icon: string }> = {
+  info: { title: 'Informação', icon: 'ℹ️' },
+  success: { title: 'Sucesso', icon: '✅' },
+  warning: { title: 'Atenção', icon: '⚠️' },
+  error: { title: 'Erro', icon: '❌' },
+};
+
+interface InternalDialogOptions extends ConfirmDialogParams {
+  /** Modifier class for the dialog shell (severity accent). */
+  modifier?: string;
+  /** Icon shown before the title. */
+  icon?: string;
+  autoCloseMs?: number;
+}
+
+function openDialog(params: InternalDialogOptions): Promise<string | null> {
+  if (!Array.isArray(params.buttons) || params.buttons.length === 0) {
+    throw new Error('[openConfirmDialog] params.buttons must contain at least one button');
+  }
+
+  injectDialogStyles();
+
+  const dismissible = params.dismissible ?? true;
+  const theme = params.theme ?? 'light';
+  const idBase = `myio-dialog-${++openCount}`;
+
+  const overlay = document.createElement('div');
+  overlay.className = `myio-dialog-overlay${theme === 'dark' ? ' myio-dialog-overlay--dark' : ''}`;
+  overlay.style.zIndex = String(BASE_Z_INDEX + openCount);
+
+  const buttonsHtml = params.buttons
+    .map((btn, i) => {
+      const variant = btn.variant ?? 'secondary';
+      return `<button type="button" class="myio-dialog__btn myio-dialog__btn--${variant}" data-index="${i}">${escapeHtml(btn.label)}</button>`;
+    })
+    .join('');
+
+  overlay.innerHTML = `
+    <div class="myio-dialog${params.modifier ? ` ${params.modifier}` : ''}"
+         role="dialog" aria-modal="true"
+         aria-labelledby="${idBase}-title" aria-describedby="${idBase}-message"
+         style="width:${cssWidth(params.width)}">
+      <div class="myio-dialog__accent"></div>
+      <div class="myio-dialog__header">
+        ${params.icon ? `<span class="myio-dialog__icon" aria-hidden="true">${params.icon}</span>` : ''}
+        <h3 class="myio-dialog__title" id="${idBase}-title">${escapeHtml(params.title)}</h3>
+        ${dismissible ? `<button type="button" class="myio-dialog__close" aria-label="Fechar">✕</button>` : ''}
+      </div>
+      <p class="myio-dialog__message" id="${idBase}-message">${escapeMessage(params.message)}</p>
+      <div class="myio-dialog__footer">${buttonsHtml}</div>
+    </div>
+  `;
+
+  const previousFocus = document.activeElement as HTMLElement | null;
+  const target = params.container ?? document.body;
+  target.appendChild(overlay);
+
+  // All lookups scoped to the overlay root — never document.getElementById
+  // (shadow-DOM pitfall, see CLAUDE.md "Shadow DOM Button Binding").
+  const root = overlay.querySelector<HTMLElement>('.myio-dialog')!;
+  const buttonEls = Array.from(root.querySelectorAll<HTMLButtonElement>('.myio-dialog__btn'));
+
+  return new Promise<string | null>((resolve) => {
+    let settled = false;
+    let autoCloseTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const close = (result: string | null) => {
+      if (settled) return;
+      settled = true;
+      if (autoCloseTimer) clearTimeout(autoCloseTimer);
+      document.removeEventListener('keydown', onKeydown, true);
+      overlay.remove();
+      if (previousFocus && previousFocus.isConnected) previousFocus.focus();
+      resolve(result);
+    };
+
+    const onKeydown = (e: KeyboardEvent) => {
+      // Only react while this dialog is the topmost mounted overlay.
+      if (!overlay.isConnected) return;
+      if (e.key === 'Escape' && dismissible) {
+        e.stopPropagation();
+        close(null);
+        return;
+      }
+      if (e.key === 'Tab') {
+        // Focus trap: cycle through the dialog's own focusable elements.
+        const focusables = Array.from(
+          root.querySelectorAll<HTMLElement>('button:not([disabled])'),
+        );
+        if (focusables.length === 0) return;
+        const first = focusables[0];
+        const last = focusables[focusables.length - 1];
+        const active = document.activeElement;
+        if (!root.contains(active)) {
+          e.preventDefault();
+          first.focus();
+        } else if (e.shiftKey && active === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && active === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    buttonEls.forEach((el) => {
+      el.addEventListener('click', () => {
+        const index = Number(el.dataset.index);
+        close(params.buttons[index].value);
+      });
+    });
+
+    if (dismissible) {
+      overlay
+        .querySelector<HTMLButtonElement>('.myio-dialog__close')
+        ?.addEventListener('click', () => close(null));
+      overlay.addEventListener('click', (e) => {
+        if (e.target === overlay) close(null);
+      });
+    }
+
+    document.addEventListener('keydown', onKeydown, true);
+
+    const autoFocusIndex = params.buttons.findIndex((b: DialogButton) => b.autoFocus);
+    (buttonEls[autoFocusIndex >= 0 ? autoFocusIndex : buttonEls.length - 1] ?? buttonEls[0]).focus();
+
+    if (params.autoCloseMs && params.autoCloseMs > 0) {
+      autoCloseTimer = setTimeout(() => close(null), params.autoCloseMs);
+    }
+  });
+}
+
+/**
+ * Opens a premium confirmation dialog and resolves with the `value` of the
+ * clicked button, or `null` when dismissed (Esc/backdrop/×).
+ */
+export function openConfirmDialog(params: ConfirmDialogParams): Promise<string | null> {
+  return openDialog(params);
+}
+
+/**
+ * Opens a premium single-button message dialog (acknowledgment). Resolves
+ * when the user closes it — or automatically after `autoCloseMs`.
+ */
+export function openMessageDialog(params: MessageDialogParams): Promise<void> {
+  const severity = params.severity ?? 'info';
+  const meta = SEVERITY_META[severity];
+  return openDialog({
+    title: params.title ?? meta.title,
+    message: params.message,
+    buttons: [
+      { label: params.buttonLabel ?? 'OK', variant: 'primary', value: 'ok', autoFocus: true },
+    ],
+    theme: params.theme,
+    container: params.container,
+    modifier: severity !== 'info' ? `myio-dialog--${severity}` : undefined,
+    icon: meta.icon,
+    autoCloseMs: params.autoCloseMs,
+  }).then(() => undefined);
+}

--- a/src/components/premium-modals/dialog/styles.ts
+++ b/src/components/premium-modals/dialog/styles.ts
@@ -1,0 +1,157 @@
+/**
+ * RFC-0205: Premium Dialog — scoped styles.
+ *
+ * Every selector is prefixed with `myio-dialog` so nothing can leak into the
+ * host page (no bare element or generic class selectors — see the
+ * `.card-checkbox` global-leak lesson referenced in the RFC).
+ */
+
+const FONT_LINK_ID = 'myio-dialog-font-nunito';
+const STYLE_ID = 'myio-dialog-styles';
+
+export function injectDialogStyles(): void {
+  if (!document.getElementById(FONT_LINK_ID)) {
+    const link = document.createElement('link');
+    link.id = FONT_LINK_ID;
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap';
+    document.head.appendChild(link);
+  }
+  if (document.getElementById(STYLE_ID)) return;
+
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+.myio-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(17, 24, 39, 0.55);
+  font-family: 'Nunito', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+.myio-dialog {
+  background: #ffffff;
+  color: #1f2937;
+  border-radius: 12px;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.3);
+  max-width: 90vw;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.myio-dialog__accent {
+  height: 4px;
+  background: #7C3AED;
+}
+.myio-dialog__header {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 16px 20px 0 20px;
+}
+.myio-dialog__icon {
+  font-size: 20px;
+  line-height: 1.3;
+}
+.myio-dialog__title {
+  flex: 1;
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1.35;
+}
+.myio-dialog__close {
+  border: none;
+  background: transparent;
+  color: #9ca3af;
+  font-size: 18px;
+  line-height: 1;
+  padding: 2px 6px;
+  margin: -2px -8px 0 0;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.myio-dialog__close:hover {
+  background: rgba(0, 0, 0, 0.06);
+  color: #4b5563;
+}
+.myio-dialog__message {
+  margin: 0;
+  padding: 10px 20px 4px 20px;
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: #4b5563;
+  overflow-y: auto;
+}
+.myio-dialog__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 16px 20px;
+}
+.myio-dialog__btn {
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 8px 16px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: filter 0.15s ease, background 0.15s ease;
+}
+.myio-dialog__btn:hover {
+  filter: brightness(0.94);
+}
+.myio-dialog__btn:focus-visible {
+  outline: 2px solid #7C3AED;
+  outline-offset: 2px;
+}
+.myio-dialog__btn--primary {
+  background: #7C3AED;
+  color: #ffffff;
+}
+.myio-dialog__btn--secondary {
+  background: #ffffff;
+  color: #374151;
+  border-color: #d1d5db;
+}
+.myio-dialog__btn--danger {
+  background: #dc2626;
+  color: #ffffff;
+}
+.myio-dialog__btn--success {
+  background: #16a34a;
+  color: #ffffff;
+}
+
+/* Severity accents (message dialog) */
+.myio-dialog--success .myio-dialog__accent { background: #16a34a; }
+.myio-dialog--warning .myio-dialog__accent { background: #d97706; }
+.myio-dialog--error   .myio-dialog__accent { background: #dc2626; }
+
+/* ── Dark theme ── */
+.myio-dialog-overlay--dark .myio-dialog {
+  background: #1f2937;
+  color: #f3f4f6;
+}
+.myio-dialog-overlay--dark .myio-dialog__message {
+  color: #d1d5db;
+}
+.myio-dialog-overlay--dark .myio-dialog__close {
+  color: #9ca3af;
+}
+.myio-dialog-overlay--dark .myio-dialog__close:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: #e5e7eb;
+}
+.myio-dialog-overlay--dark .myio-dialog__btn--secondary {
+  background: #1f2937;
+  color: #e5e7eb;
+  border-color: #4b5563;
+}
+`;
+  document.head.appendChild(style);
+}

--- a/src/components/premium-modals/dialog/types.ts
+++ b/src/components/premium-modals/dialog/types.ts
@@ -1,0 +1,53 @@
+/**
+ * RFC-0205: Premium Dialog — public types.
+ */
+
+export type DialogButtonVariant = 'primary' | 'secondary' | 'danger' | 'success';
+
+export interface DialogButton {
+  /** Visible label. Rendered as text (HTML-escaped). */
+  label: string;
+  /** Visual style. Default: 'secondary'. */
+  variant?: DialogButtonVariant;
+  /** Value the promise resolves with when this button is clicked. */
+  value: string;
+  /** Receives initial keyboard focus and responds to Enter. At most one. */
+  autoFocus?: boolean;
+}
+
+export interface ConfirmDialogParams {
+  title: string;
+  /** Plain text; rendered HTML-escaped (newlines become line breaks). */
+  message: string;
+  buttons: DialogButton[];
+  /** Default: 'light'. */
+  theme?: 'light' | 'dark';
+  /**
+   * Dismissal policy. When true (default), Esc/backdrop/× resolve with null.
+   * When false, the user must pick a button (no ×, Esc/backdrop ignored).
+   */
+  dismissible?: boolean;
+  /** Width override, e.g. 420 or '32rem'. Default: 420px, max 90vw. */
+  width?: number | string;
+  /** Mount target. Default: document.body. Required for shadow-DOM hosts. */
+  container?: HTMLElement;
+}
+
+export type MessageDialogSeverity = 'info' | 'success' | 'warning' | 'error';
+
+export interface MessageDialogParams {
+  /** Default derived from severity ('Informação', 'Sucesso', 'Atenção', 'Erro'). */
+  title?: string;
+  /** Plain text; rendered HTML-escaped (newlines become line breaks). */
+  message: string;
+  /** Default: 'info'. */
+  severity?: MessageDialogSeverity;
+  /** Default: 'OK'. */
+  buttonLabel?: string;
+  /** Default: 'light'. */
+  theme?: 'light' | 'dark';
+  /** Auto-close after N ms. 0/undefined = no auto-close. */
+  autoCloseMs?: number;
+  /** Mount target. Default: document.body. */
+  container?: HTMLElement;
+}

--- a/src/docs/rfcs/RFC-0205-PremiumDialog-ExportedConfirmMessageModal.md
+++ b/src/docs/rfcs/RFC-0205-PremiumDialog-ExportedConfirmMessageModal.md
@@ -1,0 +1,274 @@
+# RFC-0205: Premium Dialog — Exported Confirm/Message Modal with Parameterizable Buttons
+
+- Feature Name: `premium_dialog`
+- Start Date: 2026-06-12
+- RFC PR: (leave this empty)
+- Tracking Issue: (leave this empty)
+
+## Summary
+
+Add a small, public, promise-based dialog primitive to `myio-js-library`:
+`openConfirmDialog(params)` (and a thin `openMessageDialog(params)` convenience)
+rendered in the **premium-modals visual style** (Nunito font, MyIO palette,
+light/dark themes), with a fully **parameterizable button list**. The call
+resolves with the `value` of the button the user picked:
+
+```ts
+const choice = await MyIOLibrary.openConfirmDialog({
+  title: 'Excluir anotação',
+  message: 'Esta ação não pode ser desfeita. Deseja continuar?',
+  buttons: [
+    { label: 'Cancelar', variant: 'secondary', value: 'cancel' },
+    { label: 'Excluir', variant: 'danger', value: 'confirm' },
+  ],
+  theme: 'light',
+});
+if (choice === 'confirm') { /* ... */ }
+```
+
+This RFC specifies the API and behavior only. No implementation is included.
+
+## Motivation
+
+The library currently has **no exported, generic confirmation/message modal**.
+What exists today:
+
+| Where | Status | Limitation |
+| --- | --- | --- |
+| `scheduling-shared/view-helpers.ts` → exported as `schedShowConfirmModal` / `schedShowNotificationModal` (`src/index.ts:1442-1443`) | public | Hardcoded "Cancelar"/"Confirmar" buttons, scheduling CSS prefix, requires `injectSchedulingSharedStyles()`, not premium-styled |
+| `premium-modals/alarm-bundle-map/openAlarmBundleMapModal.ts:400` `showConfirmModal` | private | Premium look, but inaccessible outside the component |
+| `fancoil-remote/FancoilRemoteController.ts:177` `showConfirmModal` | private | Component-local duplicate |
+| `solenoid-control/SolenoidControlController.ts:113` `showConfirmModal` | private | Component-local duplicate |
+| `MyIOToast` (`src/index.ts:306`) | public | Toast, not a blocking dialog — cannot collect a decision |
+
+That is **four parallel implementations** of the same UX primitive, three of
+them private, none with parameterizable buttons. Every new feature that needs
+"are you sure?" either copies the pattern again (drift in style, behavior,
+accessibility, escaping) or abuses `window.confirm`, which breaks the premium
+look and is blocked in some ThingsBoard embedding contexts.
+
+Consolidating into one exported primitive follows the same single-source
+strategy the library already applied to device icons (RFC-0200) and device
+type config (RFC-0202).
+
+## Guide-level explanation
+
+### Confirm dialog
+
+`openConfirmDialog(params): Promise<string | null>` opens a centered modal
+over a dimmed backdrop and returns a promise:
+
+- Resolves with the `value` of the clicked button.
+- Resolves with `null` when dismissed without a choice (Esc key, backdrop
+  click, or the optional × close button) — never rejects for user actions.
+
+```ts
+import { openConfirmDialog } from 'myio-js-library';
+
+const result = await openConfirmDialog({
+  title: 'Aplicar para todos?',
+  message: 'O setpoint será enviado para os 12 fancoils do andar.',
+  buttons: [
+    { label: 'Somente este', variant: 'secondary', value: 'one' },
+    { label: 'Aplicar a todos', variant: 'primary', value: 'all' },
+  ],
+});
+```
+
+Buttons render in array order (left → right). Any number of buttons is
+allowed; two or three is the expected use. Variants map to the premium-modals
+palette: `primary` (brand purple), `secondary` (neutral/outline), `danger`
+(destructive red), `success` (green).
+
+### Message dialog
+
+`openMessageDialog(params): Promise<void>` is sugar for the single-button
+case (an "OK"/"Fechar" acknowledgment), mirroring what
+`schedShowNotificationModal` does today but premium-styled and not
+auto-injected with scheduling CSS. An optional `severity`
+(`info | success | warning | error`) selects the title icon/accent.
+
+### Theming and typography
+
+- `theme: 'light' | 'dark'` (default `'light'`), consistent with the
+  `themeMode` convention used across premium-modals.
+- Typography is **Nunito**, the standard premium-modals font. The dialog
+  reuses the same font-loading approach as the other premium modals (no new
+  font pipeline).
+
+### Where it lives
+
+`src/components/premium-modals/dialog/` alongside the other premium modals,
+exported from `src/index.ts` and therefore available on
+`window.MyIOLibrary.openConfirmDialog` in ThingsBoard widgets.
+
+## Reference-level explanation
+
+### Public API
+
+```ts
+export type DialogButtonVariant = 'primary' | 'secondary' | 'danger' | 'success';
+
+export interface DialogButton {
+  /** Visible label. Rendered as text (HTML-escaped). */
+  label: string;
+  /** Visual style. Default: 'secondary'. */
+  variant?: DialogButtonVariant;
+  /** Value the promise resolves with when this button is clicked. */
+  value: string;
+  /** Receives initial keyboard focus and responds to Enter. At most one. */
+  autoFocus?: boolean;
+}
+
+export interface ConfirmDialogParams {
+  title: string;
+  /** Plain text by default; rendered HTML-escaped. */
+  message: string;
+  buttons: DialogButton[];
+  /** Default: 'light'. */
+  theme?: 'light' | 'dark';
+  /**
+   * Dismissal policy. When true (default), Esc/backdrop/× resolve with null.
+   * When false, the user must pick a button (no ×, Esc/backdrop ignored).
+   */
+  dismissible?: boolean;
+  /** Width override, e.g. 420 or '32rem'. Default: 420px, max 90vw. */
+  width?: number | string;
+  /** Mount target. Default: document.body. Required for shadow-DOM hosts. */
+  container?: HTMLElement;
+}
+
+export interface MessageDialogParams {
+  title?: string;            // default derived from severity ('Sucesso', 'Erro', ...)
+  message: string;
+  severity?: 'info' | 'success' | 'warning' | 'error'; // default 'info'
+  buttonLabel?: string;      // default 'OK'
+  theme?: 'light' | 'dark';
+  autoCloseMs?: number;      // 0/undefined = no auto-close
+  container?: HTMLElement;
+}
+
+export function openConfirmDialog(params: ConfirmDialogParams): Promise<string | null>;
+export function openMessageDialog(params: MessageDialogParams): Promise<void>;
+```
+
+`src/index.ts` exports: `openConfirmDialog`, `openMessageDialog`, and the
+types `ConfirmDialogParams`, `MessageDialogParams`, `DialogButton`,
+`DialogButtonVariant`.
+
+### Behavior contract
+
+1. **Promise semantics.** Exactly one resolution per call. Button click →
+   `value`; dismissal → `null` (confirm) / resolve (message). The promise
+   never rejects from user interaction; programmer errors (e.g. empty
+   `buttons`) throw synchronously.
+2. **DOM lifecycle.** The overlay is appended to `params.container ??
+   document.body` and fully removed on close. No singleton state; concurrent
+   dialogs stack with incrementing z-index above the premium-modals baseline.
+3. **Event binding inside shadow DOM.** All lookups use the dialog's own root
+   element (`root.querySelector`), never `document.getElementById` — the known
+   premium-modals shadow-DOM pitfall (see CLAUDE.md "Shadow DOM Button
+   Binding").
+4. **Keyboard.** `Esc` dismisses when `dismissible`. `Tab` is trapped inside
+   the dialog. `Enter` activates the `autoFocus` button when one is declared.
+5. **Accessibility.** `role="dialog"`, `aria-modal="true"`,
+   `aria-labelledby` → title, `aria-describedby` → message. Focus returns to
+   the previously focused element on close.
+6. **Escaping.** `title`, `message` and button labels are HTML-escaped.
+   (A `messageHtml` opt-in is listed under Future possibilities, not in v1.)
+7. **Styles.** CSS is injected once per page under a `myio-dialog` prefix,
+   scoped so it cannot leak into host-page elements (no bare element or
+   generic class selectors — lesson from the `.card-checkbox` global-leak bug
+   found in MAIN_BAS review). Nunito loaded the same way other premium modals
+   load it; if the font fails to load, system fallback applies silently.
+8. **ThingsBoard.** No dependency on widget context (`self.ctx`); usable from
+   any controller via `window.MyIOLibrary`.
+
+### Migration (follow-up work, not part of this RFC's deliverable)
+
+Once shipped, the four existing implementations become consumers:
+
+| Call site | Replacement |
+| --- | --- |
+| `alarm-bundle-map` private `showConfirmModal` | `openConfirmDialog` (danger variant) |
+| `fancoil-remote` private `showConfirmModal` | `openConfirmDialog` |
+| `solenoid-control` private `showConfirmModal` | `openConfirmDialog` |
+| `scheduling-shared` `showConfirmModal` / `showNotificationModal` | delegate internally; keep exports as deprecated aliases for one minor cycle |
+
+Each migration is an independent, low-risk PR; none blocks the primitive.
+
+### Size budget
+
+The component must respect the enforced bundle limits (ESM/CJS ≤ 50 KB, UMD
+≤ 60 KB, min ≤ 25 KB). Expected cost is ~2-3 KB minified (markup template +
+scoped CSS + focus trap); no new dependencies are allowed.
+
+## Drawbacks
+
+- One more modal system in a library that already has several bespoke modal
+  shells (premium-modals, scheduling, alarm panel). Until migrations land,
+  this is a fifth implementation, not a consolidation.
+- A generic primitive invites scope creep (forms, inputs, async buttons);
+  guarding the API surface requires discipline in review.
+- Promise-resolving-`null` on dismissal is a convention callers must learn
+  (vs. a `{ dismissed, value }` object).
+
+## Rationale and alternatives
+
+- **Why promise-based instead of callback params?** Matches how every current
+  private implementation is already consumed (`const ok = await
+  showConfirmModal(...)`) and composes naturally with controller `async`
+  flows.
+- **Why `value: string` instead of generic `<T>`?** Keeps the UMD/window
+  consumption story trivial (ThingsBoard controllers are plain JS). A future
+  generic overload remains possible without breaking changes.
+- **Why resolve `null` instead of rejecting on dismissal?** Rejection forces
+  try/catch at every call site for a non-exceptional outcome; `null` keeps
+  the happy path linear. Alternative `{ dismissed: boolean; value?: string }`
+  was considered and rejected as heavier for the common two-button case.
+- **Why not extend `schedShowConfirmModal`?** Its CSS prefix, style injection
+  contract and exported signature are scheduling-specific; retrofitting
+  parameterizable buttons and premium styling there would break its existing
+  consumers' look or fork its behavior anyway.
+- **Why not adopt a third-party dialog lib?** Bundle budget is tight
+  (≤ 25 KB min total) and the premium visual identity (Nunito, MyIO palette)
+  would still require a full restyle.
+
+## Prior art
+
+- The four in-repo implementations listed in Motivation define the de-facto
+  behavior (overlay + backdrop + 2 buttons + promise) this RFC standardizes.
+- RFC-0200 (deviceIcons) and RFC-0202 (deviceTypeConfig): consolidation of
+  duplicated in-repo primitives into one exported source of truth.
+- Native `<dialog>`/`window.confirm`: rejected for styling and ThingsBoard
+  embedding constraints, but the keyboard/focus semantics mirror native
+  `<dialog>` behavior intentionally.
+- Web ecosystem analogues (`sweetalert2`, MUI `Dialog`, Ant `Modal.confirm`)
+  validate the `{ title, message, buttons[] } → promise` shape.
+
+## Unresolved questions
+
+- Should v1 ship a `messageHtml` (trusted HTML) escape hatch, or is escaped
+  text + `\n` → `<br>` enough for current consumers?
+- Stacking policy when a dialog opens another dialog (queue vs. stack) — v1
+  proposes simple stacking; confirm with the first real nested use case.
+- Should `openMessageDialog` auto-close (parity with
+  `schedShowNotificationModal`'s 6 s default) or default to explicit
+  acknowledgment? v1 proposes **no auto-close** unless `autoCloseMs` is set.
+- Exact Nunito loading mechanism in widgets where no premium modal has loaded
+  the font yet (inherit from `premium-modals` shared loader vs. local
+  `@font-face`).
+
+## Future possibilities
+
+- `messageHtml` / slot for custom body content (e.g. a checkbox "don't ask
+  again").
+- Input dialogs (`openPromptDialog`) reusing the same shell.
+- Async button actions: `onClick: () => Promise<void>` with built-in spinner
+  and double-click guard.
+- `danger` confirmation pattern with type-to-confirm (GitHub-style) for
+  destructive bulk operations.
+- Generic `openConfirmDialog<T extends string>` typing for stricter consumer
+  unions.
+- Adoption inside AlarmDetailsModal batch actions and HeaderAnnotationsPanel
+  archive/delete flows once migrated.

--- a/src/index.ts
+++ b/src/index.ts
@@ -760,6 +760,16 @@ export type { InferredDeviceType } from './classify/deviceType';
 // RFC-0109: Upsell Post-Setup Modal
 export { openUpsellModal } from './components/premium-modals/upsell';
 
+// RFC-0205: Premium Dialog — exported confirm/message modal
+export { openConfirmDialog, openMessageDialog } from './components/premium-modals/dialog';
+export type {
+  ConfirmDialogParams,
+  MessageDialogParams,
+  MessageDialogSeverity,
+  DialogButton,
+  DialogButtonVariant,
+} from './components/premium-modals/dialog';
+
 // RFC-0190: User Management Modal
 export { openUserManagementModal } from './components/premium-modals/user-management';
 export type {

--- a/tests/premiumDialog.test.ts
+++ b/tests/premiumDialog.test.ts
@@ -1,0 +1,209 @@
+// RFC-0205: Premium Dialog — openConfirmDialog / openMessageDialog
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  openConfirmDialog,
+  openMessageDialog,
+} from '../src/components/premium-modals/dialog';
+
+function overlay(): HTMLElement | null {
+  return document.querySelector('.myio-dialog-overlay');
+}
+
+function clickButtonByLabel(label: string): void {
+  const buttons = Array.from(document.querySelectorAll<HTMLButtonElement>('.myio-dialog__btn'));
+  const btn = buttons.find((b) => b.textContent === label);
+  if (!btn) throw new Error(`button not found: ${label}`);
+  btn.click();
+}
+
+afterEach(() => {
+  document.querySelectorAll('.myio-dialog-overlay').forEach((el) => el.remove());
+  vi.useRealTimers();
+});
+
+describe('openConfirmDialog', () => {
+  it('resolves with the value of the clicked button and removes the overlay', async () => {
+    const promise = openConfirmDialog({
+      title: 'Excluir',
+      message: 'Tem certeza?',
+      buttons: [
+        { label: 'Cancelar', variant: 'secondary', value: 'cancel' },
+        { label: 'Excluir', variant: 'danger', value: 'confirm' },
+      ],
+    });
+
+    expect(overlay()).not.toBeNull();
+    clickButtonByLabel('Excluir');
+
+    await expect(promise).resolves.toBe('confirm');
+    expect(overlay()).toBeNull();
+  });
+
+  it('resolves null on Esc when dismissible (default)', async () => {
+    const promise = openConfirmDialog({
+      title: 'T',
+      message: 'M',
+      buttons: [{ label: 'OK', value: 'ok' }],
+    });
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await expect(promise).resolves.toBeNull();
+  });
+
+  it('resolves null on backdrop click and on the × button', async () => {
+    const p1 = openConfirmDialog({
+      title: 'T',
+      message: 'M',
+      buttons: [{ label: 'OK', value: 'ok' }],
+    });
+    overlay()!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await expect(p1).resolves.toBeNull();
+
+    const p2 = openConfirmDialog({
+      title: 'T',
+      message: 'M',
+      buttons: [{ label: 'OK', value: 'ok' }],
+    });
+    document.querySelector<HTMLButtonElement>('.myio-dialog__close')!.click();
+    await expect(p2).resolves.toBeNull();
+  });
+
+  it('ignores Esc/backdrop and renders no × when dismissible is false', async () => {
+    const onResolve = vi.fn();
+    const promise = openConfirmDialog({
+      title: 'T',
+      message: 'M',
+      dismissible: false,
+      buttons: [{ label: 'OK', value: 'ok' }],
+    });
+    promise.then(onResolve);
+
+    expect(document.querySelector('.myio-dialog__close')).toBeNull();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    overlay()!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
+    expect(onResolve).not.toHaveBeenCalled();
+    expect(overlay()).not.toBeNull();
+
+    clickButtonByLabel('OK');
+    await expect(promise).resolves.toBe('ok');
+  });
+
+  it('throws synchronously when buttons is empty', () => {
+    expect(() =>
+      openConfirmDialog({ title: 'T', message: 'M', buttons: [] }),
+    ).toThrow();
+    expect(overlay()).toBeNull();
+  });
+
+  it('HTML-escapes title, message and button labels; renders \\n as <br>', async () => {
+    const promise = openConfirmDialog({
+      title: '<b>Bold</b>',
+      message: 'line1\nline2 <script>alert(1)</script>',
+      buttons: [{ label: '<i>Go</i>', value: 'go' }],
+    });
+
+    const root = document.querySelector('.myio-dialog')!;
+    expect(root.querySelector('.myio-dialog__title')!.innerHTML).toContain('&lt;b&gt;');
+    const messageHtml = root.querySelector('.myio-dialog__message')!.innerHTML;
+    expect(messageHtml).toContain('line1<br>line2');
+    expect(messageHtml).not.toContain('<script>');
+    expect(root.querySelector('.myio-dialog__btn')!.innerHTML).toContain('&lt;i&gt;');
+
+    clickButtonByLabel('<i>Go</i>');
+    await promise;
+  });
+
+  it('focuses the autoFocus button on open', async () => {
+    const promise = openConfirmDialog({
+      title: 'T',
+      message: 'M',
+      buttons: [
+        { label: 'A', value: 'a' },
+        { label: 'B', value: 'b', autoFocus: true },
+        { label: 'C', value: 'c' },
+      ],
+    });
+
+    expect((document.activeElement as HTMLElement).textContent).toBe('B');
+    clickButtonByLabel('A');
+    await promise;
+  });
+
+  it('stacks concurrent dialogs with increasing z-index', async () => {
+    const p1 = openConfirmDialog({ title: '1', message: 'M', buttons: [{ label: 'A', value: 'a' }] });
+    const p2 = openConfirmDialog({ title: '2', message: 'M', buttons: [{ label: 'B', value: 'b' }] });
+
+    const overlays = Array.from(document.querySelectorAll<HTMLElement>('.myio-dialog-overlay'));
+    expect(overlays).toHaveLength(2);
+    expect(Number(overlays[1].style.zIndex)).toBeGreaterThan(Number(overlays[0].style.zIndex));
+
+    clickButtonByLabel('A');
+    clickButtonByLabel('B');
+    await Promise.all([p1, p2]);
+  });
+
+  it('mounts into a custom container when provided', async () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const promise = openConfirmDialog({
+      title: 'T',
+      message: 'M',
+      container: host,
+      buttons: [{ label: 'OK', value: 'ok' }],
+    });
+
+    expect(host.querySelector('.myio-dialog-overlay')).not.toBeNull();
+    clickButtonByLabel('OK');
+    await promise;
+    expect(host.querySelector('.myio-dialog-overlay')).toBeNull();
+    host.remove();
+  });
+
+  it('applies the dark theme modifier', async () => {
+    const promise = openConfirmDialog({
+      title: 'T',
+      message: 'M',
+      theme: 'dark',
+      buttons: [{ label: 'OK', value: 'ok' }],
+    });
+    expect(overlay()!.classList.contains('myio-dialog-overlay--dark')).toBe(true);
+    clickButtonByLabel('OK');
+    await promise;
+  });
+});
+
+describe('openMessageDialog', () => {
+  it('resolves void when the acknowledgment button is clicked', async () => {
+    const promise = openMessageDialog({ message: 'Salvo com sucesso', severity: 'success' });
+
+    expect(document.querySelector('.myio-dialog--success')).not.toBeNull();
+    expect(document.querySelector('.myio-dialog__title')!.textContent).toBe('Sucesso');
+
+    clickButtonByLabel('OK');
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it('uses custom title and buttonLabel when provided', async () => {
+    const promise = openMessageDialog({
+      title: 'Custom',
+      message: 'M',
+      buttonLabel: 'Entendi',
+    });
+    expect(document.querySelector('.myio-dialog__title')!.textContent).toBe('Custom');
+    clickButtonByLabel('Entendi');
+    await promise;
+  });
+
+  it('auto-closes after autoCloseMs', async () => {
+    vi.useFakeTimers();
+    const promise = openMessageDialog({ message: 'M', autoCloseMs: 3000 });
+
+    expect(overlay()).not.toBeNull();
+    vi.advanceTimersByTime(3000);
+
+    await expect(promise).resolves.toBeUndefined();
+    expect(overlay()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Implementacao do RFC-0205 — Premium Dialog

Primitivo de dialogo publico e promise-based com botoes parametrizaveis, estilo premium-modals (Nunito, light/dark) e CSS escopado sob o prefixo `myio-dialog`.

```ts
const choice = await MyIOLibrary.openConfirmDialog({
  title: 'Excluir anotacao',
  message: 'Esta acao nao pode ser desfeita. Deseja continuar?',
  buttons: [
    { label: 'Cancelar', variant: 'secondary', value: 'cancel' },
    { label: 'Excluir', variant: 'danger', value: 'confirm', autoFocus: true },
  ],
}); // value do botao, ou null em dismissal (Esc/backdrop/x)
```

### Contrato (conforme RFC)
- Promise **nunca rejeita** por acao do usuario; `buttons: []` lanca erro sincrono
- `dismissible: false` remove o x e ignora Esc/backdrop
- `openMessageDialog`: severidades info/success/warning/error com titulo default, botao unico, `autoCloseMs` opcional
- Focus trap (Tab ciclico), `autoFocus`, foco devolvido no close, ARIA completo
- HTML-escape em titulo/mensagem/labels; `\n` vira `<br>`
- Stacking por z-index incremental (base 10500); lookups via `root.querySelector` (shadow-DOM safe)
- Variants: `primary` (#7C3AED), `secondary`, `danger`, `success`

### Entregas
- `src/components/premium-modals/dialog/` (types, styles, openDialog, barrel)
- Exports em `src/index.ts`: `openConfirmDialog`, `openMessageDialog` + tipos
- **13 testes vitest** cobrindo o contrato (valores, dismissal, dismissible:false, escape, autoFocus, stacking, container custom, dark, autoClose) — todos passando
- **Showcase**: `showcase/premium-dialog.html` (8 cenarios + log de promises, carrega o UMD de `dist/`) + card novo em `showcase/index.html`

### Validacao
- 13/13 testes novos passando; falhas pre-existentes da suite reproduzidas identicas sem este diff (NODE-RED/deviceStatus)
- `npm run build` completo OK (tsup + UMD + min + verify-dts)
- Custo de bundle ~3 KB (dentro do esperado pelo RFC)

### Base
A branch parte de `rfc/0205-premium-dialog`, entao este PR inclui tambem o doc do RFC (PR #90). Se o #90 mergear primeiro, este diff reduz para implementacao apenas — ou o #90 pode ser fechado em favor deste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)