### PR TITLE
feat(card-v6): actionSelectorOnCardClick - card click opens the action selector (BAS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "myio-js-library",
-  "version": "0.1.519-homolog.2",
+  "version": "0.1.519",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "myio-js-library",
-      "version": "0.1.519-homolog.2",
+      "version": "0.1.519",
       "license": "MIT",
       "dependencies": {
         "jspdf": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myio-js-library",
-  "version": "0.1.519-homolog.2",
+  "version": "0.1.519",
   "description": "A clean, standalone JS SDK for MYIO projects",
   "license": "MIT",
   "repository": "github:gh-myio/myio-js-library",

--- a/src/components/card-grid-panel/CardGridPanel.ts
+++ b/src/components/card-grid-panel/CardGridPanel.ts
@@ -129,6 +129,12 @@ export interface CardGridPanelOptions {
    * are shown. Applies to cardType='device' only. Default: false.
    */
   enableActionSelector?: boolean;
+  /**
+   * Requires enableActionSelector. When true, device cards render no action
+   * button at all — the selection modal opens on the card body click instead
+   * (handleClickCard is then ignored). Default: false.
+   */
+  actionSelectorOnCardClick?: boolean;
   /** Callback for ambiente card remote toggle (only for cardType='ambiente') */
   handleToggleRemote?: (isOn: boolean, item: CardGridItem) => void;
   /** Empty state message */
@@ -752,6 +758,7 @@ export class CardGridPanel {
       emptyMessage,
       showTempRangeTooltip,
       enableActionSelector,
+      actionSelectorOnCardClick,
       enableSelection,
       enableDragDrop,
       handleSelect,
@@ -843,6 +850,7 @@ export class CardGridPanel {
           showTempRangeTooltip: showTempRangeTooltip || false,
           customStyle: cardCustomStyle || undefined,
           enableActionSelector: enableActionSelector || false,
+          actionSelectorOnCardClick: actionSelectorOnCardClick || false,
         });
       }
 

--- a/src/components/template-card-v6/template-card-v6.d.ts
+++ b/src/components/template-card-v6/template-card-v6.d.ts
@@ -45,6 +45,12 @@ export interface RenderCardV6Options {
    * provided are shown. Default: false (3 separate buttons).
    */
   enableActionSelector?: boolean;
+  /**
+   * Requires enableActionSelector. When true, the single ⋮ button is not
+   * rendered and the selection modal opens on the card body click instead
+   * (handleClickCard is then ignored). Default: false.
+   */
+  actionSelectorOnCardClick?: boolean;
 }
 
 export interface CardResult {

--- a/src/components/template-card-v6/template-card-v6.js
+++ b/src/components/template-card-v6/template-card-v6.js
@@ -718,6 +718,10 @@ function openCardActionSelector({ title, options }) {
  *   3 piano-key buttons with a single button that opens a selection modal
  *   (Gráfico / Configurações / Relatório). Options shown depend on which
  *   handleAction* handlers are provided.
+ * @param {boolean} [options.actionSelectorOnCardClick] - Requires
+ *   enableActionSelector. When true, the ⋮ button is not rendered and the
+ *   selection modal opens on the card body click instead (handleClickCard is
+ *   then ignored — the modal is the single entry point for actions).
  * @returns {Object} jQuery-like object
  */
 export function renderCardComponentV6({
@@ -737,6 +741,7 @@ export function renderCardComponentV6({
   showTempRangeTooltip = false,
   customStyle, // V6: Per-card style overrides
   enableActionSelector = false, // V6: "step" — single button opens action selection modal
+  actionSelectorOnCardClick = false, // V6: card click opens the selector (suppresses the ⋮ button)
 }) {
   const {
     entityId,
@@ -1705,9 +1710,12 @@ export function renderCardComponentV6({
     },
   });
 
+  // Built in "step" mode; also consumed by the card click handler when
+  // actionSelectorOnCardClick is enabled.
+  const selectorOptions = [];
+
   if (enableActionSelector) {
     // ---- "Step" mode: one button opens a selection modal ----
-    const selectorOptions = [];
     if (typeof handleActionDashboard === 'function') {
       selectorOptions.push({
         id: 'dashboard',
@@ -1736,7 +1744,7 @@ export function renderCardComponentV6({
       });
     }
 
-    if (selectorOptions.length > 0) {
+    if (selectorOptions.length > 0 && !actionSelectorOnCardClick) {
       const selectorBtn = document.createElement('button');
       selectorBtn.className = 'card-action action-selector';
       selectorBtn.title = 'Ações';
@@ -1947,8 +1955,15 @@ export function renderCardComponentV6({
     });
   }
 
-  // Handle card clicks
-  if (typeof handleClickCard === 'function') {
+  // Handle card clicks. With actionSelectorOnCardClick the selection modal is
+  // the single entry point for actions — it takes precedence over handleClickCard.
+  if (enableActionSelector && actionSelectorOnCardClick && selectorOptions.length > 0) {
+    enhancedCardElement.addEventListener('click', (e) => {
+      if (!e.target.closest('.card-action') && !e.target.closest('.card-checkbox')) {
+        openCardActionSelector({ title: cardEntity.name, options: selectorOptions });
+      }
+    });
+  } else if (typeof handleClickCard === 'function') {
     enhancedCardElement.addEventListener('click', (e) => {
       if (!e.target.closest('.card-action') && !e.target.closest('.card-checkbox')) {
         handleClickCard(entityObject);

--- a/src/thingsboard/bas-components/MAIN_BAS/controller.js
+++ b/src/thingsboard/bas-components/MAIN_BAS/controller.js
@@ -2751,9 +2751,10 @@ function mountWaterPanel(waterHost, settings, classified) {
         closeMaximizedPanel();
       }
     },
-    // RFC-0158: Action selector "step" — card shows a single ⋮ button that
-    // opens a modal to pick Gráfico / Relatório / Configurações.
+    // RFC-0158: Action selector "step" — the selection modal (Gráfico /
+    // Relatório / Configurações) opens on the card body click; no ⋮ button.
     enableActionSelector: true,
+    actionSelectorOnCardClick: true,
     handleActionDashboard: function (item) {
       basRouteWaterClick(item, settings);
     },
@@ -4029,9 +4030,10 @@ function mountEnergyPanel(host, settings, classified) {
         closeMaximizedPanel();
       }
     },
-    // RFC-0158: Action selector "step" — card shows a single ⋮ button that
-    // opens a modal to pick Gráfico / Relatório / Configurações.
+    // RFC-0158: Action selector "step" — the selection modal (Gráfico /
+    // Relatório / Configurações) opens on the card body click; no ⋮ button.
     enableActionSelector: true,
+    actionSelectorOnCardClick: true,
     handleActionDashboard: function (item) {
       basRouteEnergyClick(item, settings);
     },

--- a/src/thingsboard/bas-components/MAIN_BAS/styles.css
+++ b/src/thingsboard/bas-components/MAIN_BAS/styles.css
@@ -642,43 +642,15 @@ tb-html-widget > div,
 
 /* TODO(RFC-0115): Selection checkbox — hidden until comparison/selection flow is ready.
    Same feature as .bas-footer-slot above. Remove when implemented.
-   Class .card-checkbox rendered by renderCardComponentV6 (template-card-v6.js) when enableSelection=true. */
-.card-checkbox {
+   Class .card-checkbox rendered by renderCardComponentV6 (template-card-v6.js) when enableSelection=true.
+   Scoped to the BAS root: TB injects widget CSS page-wide and .card-checkbox is
+   used by other library components (review PR #86 — global-leak fix). */
+#bas-dashboard-root .card-checkbox {
   display: none !important;
 }
 
-/* ---- BAS: action-selector proporcional ----------------------------------------
-   O container .card-actions foi projetado para 3 botões piano-key (max-height:72%).
-   Com enableActionSelector:true há apenas 1 botão — compactar para evitar que o
-   container grande sobreponha o identifier (.device-title-row z-index:5 < z-index:10).
-   Overrides BAS-específicos em styles.css — não toca template-card-v6.js.
-   ---------------------------------------------------------------------------------*/
-.bas-water-slot .card-actions,
-.bas-ambientes-slot .card-actions,
-.bas-motors-slot .card-actions {
-  max-height: fit-content !important;
-  padding: 3px 2px !important;
-}
-.bas-water-slot .card-action,
-.bas-ambientes-slot .card-action,
-.bas-motors-slot .card-action {
-  width: 22px !important;
-  height: 22px !important;
-  min-height: 22px !important;
-}
-.bas-water-slot .card-action svg,
-.bas-ambientes-slot .card-action svg,
-.bas-motors-slot .card-action svg {
-  width: 13px !important;
-  height: 13px !important;
-}
-/* Empurra o title-row para depois da coluna do botão — identifier fica visível */
-.bas-water-slot .device-title-row,
-.bas-ambientes-slot .device-title-row,
-.bas-motors-slot .device-title-row {
-  left: 40px !important;
-  max-width: calc(100% - 48px) !important;
-}
+/* (Removido) Overrides do botão único ⋮ — com actionSelectorOnCardClick a modal
+   de ações abre no clique do card e nenhum botão de action é renderizado. */
 
 /* ---- CONSUMO: colapso explícito (especificidade alta) ----------------------------
    O ThingsBoard prefixa styles.css com .widget-type-..., elevando para 0,2,0 qualquer


### PR DESCRIPTION
## O que muda

Novo param opt-in no `renderCardComponentV6` (requer `enableActionSelector`):

```js
renderCardComponentV6({
  enableActionSelector: true,
  actionSelectorOnCardClick: true, // novo — default false
  ...
});
```

Com a flag ligada:
- O botao unico de acoes **nao e renderizado**
- O **clique no corpo do card** abre a modal de selecao (Grafico / Relatorio / Configuracoes), com **precedencia** sobre `handleClickCard`
- Flag desligada → comportamento atual byte-identico (botao unico ou piano-keys legados)

Repassado pelo `CardGridPanel` e tipado no `template-card-v6.d.ts`.

## MAIN_BAS

- `actionSelectorOnCardClick: true` nos paineis de **Agua** e **Energia/Motores** — o botao some e o clique no card vira o ponto unico de entrada das acoes.
- **Removido** o CSS do PR #86 que compactava a coluna do botao unico e deslocava o `device-title-row` em 40px — sem botao renderizado, viraria um buraco morto no card.
- **Fix do review do PR #86**: regra `.card-checkbox { display:none }` agora escopada em `#bas-dashboard-root` — o CSS de widget TB e injetado na pagina inteira e `.card-checkbox` e usado por outros componentes da lib (vazamento global eliminado).

## Trade-off de UX (consciente)

Card de solenoide: antes 1 clique abria o modal on-off direto; agora sao 2 cliques (card → Grafico no selector, que roteia para o on-off via `basRouteWaterClick`). Se incomodar em campo, o follow-up natural e o selector aceitar opcoes extras do caller (ex.: Acionamento para solenoides).

## Validacao

- `node --check` OK em `template-card-v6.js` e `MAIN_BAS/controller.js`
- `npm run build:tsup` compila limpo (CardGridPanel TS + DTS)
- Obs: o corpo do commit menciona formatacao prettier do controller, mas o diff final ficou minimo (10 linhas) — a formatacao ja estava alinhada ao HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)