### PR TITLE
feat(card-badges): shared alarm/ticket badge helpers + wire into MAIN_BAS

### DIFF
--- a/src/components/card-badges/index.ts
+++ b/src/components/card-badges/index.ts
@@ -1,0 +1,276 @@
+/**
+ * Card alarm/ticket badges — shared decoration helpers (RFC-0183 / RFC-0198).
+ *
+ * Lifted from the v-5.2.0 TELEMETRY widget controller so every consumer that
+ * renders device cards (TELEMETRY, MAIN_BAS, v-5.4.0 grid) can decorate them
+ * from a single source instead of keeping private copies.
+ *
+ * Data sources (window globals, both optional):
+ * - `window.AlarmServiceOrchestrator.getAlarmCountForDevice(gcdrDeviceId)`
+ * - `window.TicketServiceOrchestrator.getTicketCountForDevice(identifier)`
+ *   with a per-device `tickets_items` SERVER_SCOPE JSON fallback, gated by
+ *   `window.MyIOUtils.ticketsEnabled === true`.
+ *
+ * Unlike the original TELEMETRY alarm badge, BOTH badges here are always
+ * inserted in the DOM (hidden when count = 0) so the refresh functions can
+ * light them up when the orchestrators finish loading after the cards
+ * rendered — the common case outside the shopping dashboard, where panels
+ * mount before the alarm prefetch resolves.
+ */
+
+const ALARM_STYLES_ID = 'myio-alarm-badge-styles';
+const TICKET_STYLES_ID = 'myio-ticket-badge-styles';
+
+declare global {
+  interface Window {
+    AlarmServiceOrchestrator?: {
+      getAlarmCountForDevice?: (gcdrDeviceId: string) => number;
+    };
+    TicketServiceOrchestrator?: {
+      getTicketCountForDevice?: (identifier: string) => number;
+    };
+  }
+}
+
+export interface AlarmBadgeOptions {
+  /** Custom counter (e.g. to filter offline alarms). Default: AlarmServiceOrchestrator. */
+  getCount?: (gcdrDeviceId: string) => number;
+}
+
+export interface TicketBadgeOptions {
+  /** Overrides the `window.MyIOUtils.ticketsEnabled === true` gate. */
+  gateOpen?: boolean;
+}
+
+function injectAlarmBadgeStyles(): void {
+  if (document.getElementById(ALARM_STYLES_ID)) return;
+  const s = document.createElement('style');
+  s.id = ALARM_STYLES_ID;
+  s.textContent = `
+    .myio-alarm-badge {
+      position: absolute;
+      top: 6px;
+      left: 6px;
+      background: #dc2626;
+      color: #fff;
+      border-radius: 10px;
+      padding: 2px 5px;
+      font-size: 10px;
+      font-weight: 700;
+      display: flex;
+      align-items: center;
+      gap: 2px;
+      z-index: 10;
+      pointer-events: none;
+      line-height: 1.3;
+    }
+  `;
+  document.head.appendChild(s);
+}
+
+function injectTicketBadgeStyles(): void {
+  if (document.getElementById(TICKET_STYLES_ID)) return;
+  const s = document.createElement('style');
+  s.id = TICKET_STYLES_ID;
+  s.textContent = `
+    /* Mini clone of .tbx-btn-ticket-notif */
+    .myio-ticket-badge {
+      position: absolute;
+      bottom: 6px;
+      left: 6px;
+      width: 24px;
+      height: 24px;
+      background: rgba(8, 145, 178, 0.12);
+      color: #0891b2;
+      border: 1px solid rgba(8, 145, 178, 0.25);
+      border-radius: 6px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 10;
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s;
+    }
+    .myio-ticket-badge:hover {
+      background: rgba(8, 145, 178, 0.22);
+      border-color: rgba(8, 145, 178, 0.45);
+    }
+    /* Count pill — clone of .tbx-ticket-badge */
+    .myio-ticket-badge-count {
+      position: absolute;
+      top: -5px;
+      right: -5px;
+      min-width: 14px;
+      height: 14px;
+      padding: 0 3px;
+      border-radius: 7px;
+      background: #0891b2;
+      color: #fff;
+      font-size: 9px;
+      font-weight: 700;
+      line-height: 14px;
+      text-align: center;
+      pointer-events: none;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.3);
+    }
+  `;
+  document.head.appendChild(s);
+}
+
+function defaultAlarmCount(gcdrDeviceId: string): number {
+  const aso = window.AlarmServiceOrchestrator;
+  return aso?.getAlarmCountForDevice?.(gcdrDeviceId) ?? 0;
+}
+
+function alarmTitle(count: number): string {
+  return `${count} alarme${count !== 1 ? 's' : ''} ativo${count !== 1 ? 's' : ''}`;
+}
+
+function ticketTitle(count: number): string {
+  return count > 0 ? `${count} chamado${count !== 1 ? 's' : ''} aberto${count !== 1 ? 's' : ''}` : 'Chamados';
+}
+
+/**
+ * RFC-0183: Append an alarm badge (red bell) to a card element. The badge is
+ * always inserted (hidden when count = 0) so refreshAlarmBadges() can update
+ * it when the AlarmServiceOrchestrator loads later.
+ */
+export function addAlarmBadge(
+  cardElement: HTMLElement | null | undefined,
+  gcdrDeviceId: string | null | undefined,
+  opts?: AlarmBadgeOptions,
+): void {
+  if (!cardElement || !gcdrDeviceId) return;
+  if (cardElement.querySelector(`[data-alarm-device-id="${gcdrDeviceId}"]`)) return;
+
+  const count = (opts?.getCount ?? defaultAlarmCount)(gcdrDeviceId);
+
+  injectAlarmBadgeStyles();
+  if (cardElement.style) cardElement.style.position = 'relative';
+
+  const badge = document.createElement('div');
+  badge.className = 'myio-alarm-badge';
+  badge.setAttribute('data-alarm-device-id', gcdrDeviceId);
+  badge.style.display = count > 0 ? '' : 'none';
+  badge.title = alarmTitle(count);
+  badge.innerHTML =
+    '<svg viewBox="0 0 24 24" width="10" height="10" fill="currentColor" aria-hidden="true">' +
+    '<path d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.9 2 2 2zm6-6V11c0-3.07-1.63-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.64 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"/>' +
+    '</svg>' +
+    `<span>${count > 99 ? '99+' : count}</span>`;
+  cardElement.appendChild(badge);
+}
+
+/**
+ * Refresh every alarm badge on the page (e.g. on myio:alarms-updated or after
+ * the alarm prefetch resolves) without re-rendering the cards.
+ */
+export function refreshAlarmBadges(opts?: AlarmBadgeOptions): void {
+  const getCount = opts?.getCount ?? defaultAlarmCount;
+  document.querySelectorAll<HTMLElement>('.myio-alarm-badge[data-alarm-device-id]').forEach((badge) => {
+    const gcdrDeviceId = badge.getAttribute('data-alarm-device-id');
+    if (!gcdrDeviceId) return;
+    const count = getCount(gcdrDeviceId);
+    const span = badge.querySelector('span');
+    if (count > 0) {
+      badge.style.display = '';
+      badge.title = alarmTitle(count);
+      if (span) span.textContent = count > 99 ? '99+' : String(count);
+    } else {
+      badge.style.display = 'none';
+    }
+  });
+}
+
+/**
+ * RFC-0198: Append a ticket badge (headphone icon + count pill) to a card
+ * element. Always inserted (hidden when count = 0 or the tickets gate is
+ * closed) so refreshTicketBadges() can update it on myio:tickets-ready.
+ * Count source: TicketServiceOrchestrator, falling back to the device's
+ * `tickets_items` SERVER_SCOPE JSON (open states: 2, 3, 6).
+ */
+export function addTicketBadge(
+  cardElement: HTMLElement | null | undefined,
+  identifier: string | null | undefined,
+  ticketsItemsRaw?: unknown,
+  opts?: TicketBadgeOptions,
+): void {
+  if (!cardElement || !identifier) return;
+  if (cardElement.querySelector(`[data-ticket-identifier="${identifier}"]`)) return;
+
+  const tso = window.TicketServiceOrchestrator;
+  let count = tso?.getTicketCountForDevice?.(identifier) ?? 0;
+
+  if (count === 0 && ticketsItemsRaw) {
+    try {
+      const parsed =
+        typeof ticketsItemsRaw === 'string' ? JSON.parse(ticketsItemsRaw) : ticketsItemsRaw;
+      const summaries = Array.isArray(parsed)
+        ? parsed
+        : ((parsed as { items?: unknown[] })?.items ?? []);
+      count = (summaries as Array<{ status?: number }>).filter((t) =>
+        [2, 3, 6].includes(t?.status as number),
+      ).length;
+    } catch {
+      /* malformed attribute — keep count = 0 */
+    }
+  }
+
+  injectTicketBadgeStyles();
+  if (cardElement.style) cardElement.style.position = 'relative';
+
+  const gateOpen =
+    opts?.gateOpen ?? (window as { MyIOUtils?: { ticketsEnabled?: boolean } }).MyIOUtils?.ticketsEnabled === true;
+
+  const badge = document.createElement('div');
+  badge.className = 'myio-ticket-badge';
+  badge.setAttribute('data-ticket-identifier', identifier);
+  badge.style.display = count > 0 && gateOpen ? '' : 'none';
+  badge.title = ticketTitle(count);
+  badge.innerHTML =
+    '<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+    '<path d="M3 18v-6a9 9 0 0 1 18 0v6"/>' +
+    '<path d="M21 19a2 2 0 0 1-2 2h-1a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h3z"/>' +
+    '<path d="M3 19a2 2 0 0 0 2 2h1a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2H3z"/>' +
+    '</svg>' +
+    (count > 0 ? `<span class="myio-ticket-badge-count">${count > 99 ? '99+' : count}</span>` : '');
+  cardElement.appendChild(badge);
+}
+
+/**
+ * Refresh every ticket badge on the page (call on myio:tickets-ready).
+ */
+export function refreshTicketBadges(opts?: TicketBadgeOptions): void {
+  const tso = window.TicketServiceOrchestrator;
+  if (!tso?.getTicketCountForDevice) return;
+  const gateOpen =
+    opts?.gateOpen ?? (window as { MyIOUtils?: { ticketsEnabled?: boolean } }).MyIOUtils?.ticketsEnabled === true;
+
+  if (!gateOpen) {
+    document.querySelectorAll<HTMLElement>('.myio-ticket-badge').forEach((el) => {
+      el.style.display = 'none';
+    });
+    return;
+  }
+
+  document
+    .querySelectorAll<HTMLElement>('.myio-ticket-badge[data-ticket-identifier]')
+    .forEach((badge) => {
+      const identifier = badge.getAttribute('data-ticket-identifier');
+      if (!identifier) return;
+      const count = tso.getTicketCountForDevice!(identifier);
+      if (count > 0) {
+        badge.style.display = '';
+        badge.title = ticketTitle(count);
+        let pill = badge.querySelector<HTMLElement>('.myio-ticket-badge-count');
+        if (!pill) {
+          pill = document.createElement('span');
+          pill.className = 'myio-ticket-badge-count';
+          badge.appendChild(pill);
+        }
+        pill.textContent = count > 99 ? '99+' : String(count);
+      } else {
+        badge.style.display = 'none';
+      }
+    });
+}

--- a/src/components/card-grid-panel/CardGridPanel.ts
+++ b/src/components/card-grid-panel/CardGridPanel.ts
@@ -135,6 +135,12 @@ export interface CardGridPanelOptions {
    * (handleClickCard is then ignored). Default: false.
    */
   actionSelectorOnCardClick?: boolean;
+  /**
+   * Called after each card element is mounted in the grid. Use it to decorate
+   * cards with overlays the renderer doesn't own (e.g. alarm/ticket badges via
+   * the card-badges helpers). Fires for every card type on every render.
+   */
+  onCardRendered?: (item: CardGridItem, cardElement: HTMLElement) => void;
   /** Callback for ambiente card remote toggle (only for cardType='ambiente') */
   handleToggleRemote?: (isOn: boolean, item: CardGridItem) => void;
   /** Empty state message */
@@ -759,6 +765,7 @@ export class CardGridPanel {
       showTempRangeTooltip,
       enableActionSelector,
       actionSelectorOnCardClick,
+      onCardRendered,
       enableSelection,
       enableDragDrop,
       handleSelect,
@@ -865,6 +872,13 @@ export class CardGridPanel {
         }
         wrapper.appendChild(cardResult[0]);
         grid.appendChild(wrapper);
+        if (onCardRendered) {
+          try {
+            onCardRendered(item, cardResult[0] as HTMLElement);
+          } catch (err) {
+            console.warn('[CardGridPanel] onCardRendered callback failed:', err);
+          }
+        }
       }
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -760,6 +760,15 @@ export type { InferredDeviceType } from './classify/deviceType';
 // RFC-0109: Upsell Post-Setup Modal
 export { openUpsellModal } from './components/premium-modals/upsell';
 
+// RFC-0183/RFC-0198: shared card alarm/ticket badge decoration helpers
+export {
+  addAlarmBadge,
+  refreshAlarmBadges,
+  addTicketBadge,
+  refreshTicketBadges,
+} from './components/card-badges';
+export type { AlarmBadgeOptions, TicketBadgeOptions } from './components/card-badges';
+
 // RFC-0205: Premium Dialog — exported confirm/message modal
 export { openConfirmDialog, openMessageDialog } from './components/premium-modals/dialog';
 export type {

--- a/src/thingsboard/bas-components/MAIN_BAS/controller.js
+++ b/src/thingsboard/bas-components/MAIN_BAS/controller.js
@@ -1002,6 +1002,10 @@ function parseDevicesFromData(data) {
       connectionStatusTs: cdTs.connectionStatus != null ? cdTs.connectionStatus : null,
       statusValue: cd.status != null ? cd.status : (cd.state != null ? cd.state : null),
       statusTs: cdTs.status != null ? cdTs.status : (cdTs.state != null ? cdTs.state : null),
+      // RFC-0183/RFC-0198: alarm/ticket badge keys (SERVER_SCOPE datakeys —
+      // null when the dashboard datasource doesn't include them)
+      gcdrDeviceId: cd.gcdrDeviceId || null,
+      ticketsItems: cd.tickets_items || null,
     };
 
     // Add domain-specific properties
@@ -2755,6 +2759,8 @@ function mountWaterPanel(waterHost, settings, classified) {
     // Relatório / Configurações) opens on the card body click; no ⋮ button.
     enableActionSelector: true,
     actionSelectorOnCardClick: true,
+    // RFC-0183/RFC-0198: alarm + ticket badges on each rendered card
+    onCardRendered: basDecorateCardWithBadges,
     handleActionDashboard: function (item) {
       basRouteWaterClick(item, settings);
     },
@@ -4034,6 +4040,8 @@ function mountEnergyPanel(host, settings, classified) {
     // Relatório / Configurações) opens on the card body click; no ⋮ button.
     enableActionSelector: true,
     actionSelectorOnCardClick: true,
+    // RFC-0183/RFC-0198: alarm + ticket badges on each rendered card
+    onCardRendered: basDecorateCardWithBadges,
     handleActionDashboard: function (item) {
       basRouteEnergyClick(item, settings);
     },
@@ -4691,6 +4699,112 @@ var _chartDataCache = {};
  * @param {number} [options.maxAgeMs=300000] - Cache max age in ms for normal use
  * @returns {function} fetchData function that returns { labels, dailyTotals }
  */
+// ============================================================================
+// RFC-0183: Alarm prefetch + AlarmServiceOrchestrator (ported from v-5.2.0
+// MAIN_VIEW). Feeds the card alarm badges (MyIOLibrary.addAlarmBadge).
+// Requires customer SERVER_SCOPE attrs gcdrCustomerId/gcdrTenantId/gcdrApiKey
+// — when absent the orchestrator is simply not built and badges stay hidden.
+// ============================================================================
+
+async function basPrefetchCustomerAlarms(gcdrCustomerId, gcdrTenantId, gcdrApiKey, alarmsBaseUrl) {
+  try {
+    var url =
+      alarmsBaseUrl +
+      '/alarms?state=OPEN,ACK,ESCALATED,SNOOZED&customerId=' +
+      encodeURIComponent(gcdrCustomerId) +
+      '&limit=100';
+    var response = await fetch(url, {
+      headers: {
+        'X-API-Key': gcdrApiKey,
+        'X-Tenant-ID': gcdrTenantId || '',
+        Accept: 'application/json',
+      },
+    });
+    if (!response.ok) {
+      LogHelper.warn('[MAIN_BAS] Alarm prefetch failed:', response.status);
+      return;
+    }
+    var json = await response.json();
+    var alarms = Array.isArray(json.data) ? json.data : json.items || [];
+    basBuildAlarmServiceOrchestrator(alarms, gcdrCustomerId, gcdrTenantId, gcdrApiKey, alarmsBaseUrl);
+    // Cards may have rendered before the prefetch resolved — light the badges up.
+    if (window.MyIOLibrary && typeof window.MyIOLibrary.refreshAlarmBadges === 'function') {
+      window.MyIOLibrary.refreshAlarmBadges();
+    }
+  } catch (err) {
+    LogHelper.warn('[MAIN_BAS] Alarm prefetch error:', err);
+  }
+}
+
+function basBuildAlarmServiceOrchestrator(alarms, gcdrCustomerId, gcdrTenantId, gcdrApiKey, alarmsBaseUrl) {
+  // Normalize: source = deviceId (GCDR UUID) — same contract as v-5.2.0.
+  var normalizedAlarms = (alarms || []).map(function (a) {
+    return Object.assign({}, a, { source: a.source || a.deviceId || '' });
+  });
+
+  var deviceAlarmMap = new Map();
+  normalizedAlarms.forEach(function (alarm) {
+    var did = alarm.deviceId;
+    if (!did) return;
+    if (!deviceAlarmMap.has(did)) deviceAlarmMap.set(did, []);
+    deviceAlarmMap.get(did).push(alarm);
+  });
+
+  var deviceAlarmTypes = new Map();
+  deviceAlarmMap.forEach(function (devAlarms, did) {
+    deviceAlarmTypes.set(
+      did,
+      new Set(
+        devAlarms.map(function (a) {
+          return a.alarmType || a.title || 'unknown';
+        })
+      )
+    );
+  });
+
+  window.AlarmServiceOrchestrator = {
+    alarms: normalizedAlarms,
+    deviceAlarmMap: deviceAlarmMap,
+    deviceAlarmTypes: deviceAlarmTypes,
+    getAlarmCountForDevice: function (gcdrDeviceId) {
+      var list = deviceAlarmMap.get(gcdrDeviceId);
+      return list ? list.length : 0;
+    },
+    getAlarmsForDevice: function (gcdrDeviceId) {
+      return deviceAlarmMap.get(gcdrDeviceId) || [];
+    },
+    getAlarmTypesForDevice: function (gcdrDeviceId) {
+      return deviceAlarmTypes.get(gcdrDeviceId) || new Set();
+    },
+    refresh: function () {
+      return basPrefetchCustomerAlarms(gcdrCustomerId, gcdrTenantId, gcdrApiKey, alarmsBaseUrl);
+    },
+  };
+
+  LogHelper.log(
+    '[MAIN_BAS] AlarmServiceOrchestrator built —',
+    deviceAlarmMap.size,
+    'devices with alarms,',
+    normalizedAlarms.length,
+    'total alarms'
+  );
+}
+
+// RFC-0183/RFC-0198: decorate a freshly rendered device card with alarm and
+// ticket badges. Wired as CardGridPanel.onCardRendered on the Water and
+// Energy/Motors panels. No-ops gracefully on libs older than the helpers.
+function basDecorateCardWithBadges(item, cardEl) {
+  var dev = item && item.source;
+  if (!dev || !cardEl || typeof MyIOLibrary === 'undefined') return;
+  if (typeof MyIOLibrary.addAlarmBadge === 'function') {
+    MyIOLibrary.addAlarmBadge(cardEl, dev.gcdrDeviceId || null);
+  }
+  if (typeof MyIOLibrary.addTicketBadge === 'function') {
+    var identifier = (dev.rawData && dev.rawData.identifier) || null;
+    MyIOLibrary.addTicketBadge(cardEl, identifier, dev.ticketsItems || null);
+  }
+}
+
 // Bridge for the currently-published lib: the compiled widget hardcodes the
 // viz-tab tooltip as "Por Shopping", but BAS splits the separate series by
 // DEVICE. The vizModeLabels config param covers this once the lib ships it —
@@ -5852,6 +5966,26 @@ self.onInit = async function () {
           hasClientSecret: !!MAP_CUSTOMER_CREDENTIALS.customer_Ingestion_Secret,
         });
         LogHelper.log('[MAIN_BAS] Customer telemetry settings loaded:', CUSTOMER_TELEMETRY_SETTINGS);
+
+        // RFC-0183: build the alarm orchestrator for card badges. Fire and
+        // forget — basPrefetchCustomerAlarms refreshes badges when it lands.
+        var gcdrCustomerId = attrs?.gcdrCustomerId || '';
+        var gcdrTenantId = attrs?.gcdrTenantId || '';
+        var gcdrApiKey = attrs?.gcdrApiKey || '';
+        if (gcdrCustomerId && gcdrApiKey) {
+          var alarmsBaseUrl =
+            self.ctx.settings?.alarmsApiBaseUrl || 'https://alarms-api.a.myio-bas.com';
+          basPrefetchCustomerAlarms(gcdrCustomerId, gcdrTenantId, gcdrApiKey, alarmsBaseUrl);
+        } else {
+          LogHelper.warn(
+            '[MAIN_BAS] RFC-0183: gcdrCustomerId/gcdrApiKey ausentes nos attrs do customer — alarm badges desativados'
+          );
+        }
+
+        // RFC-0198: tickets gate for the card ticket badges (count comes from
+        // the per-device tickets_items SERVER_SCOPE attr — no orchestrator in BAS yet)
+        window.MyIOUtils = window.MyIOUtils || {};
+        window.MyIOUtils.ticketsEnabled = self.ctx.settings?.enableTicketsBadge === true;
       } catch (error) {
         LogHelper.error('[MAIN_BAS] Error fetching customer attributes:', error);
       }

--- a/src/thingsboard/bas-components/MAIN_BAS/settingsSchema.json
+++ b/src/thingsboard/bas-components/MAIN_BAS/settingsSchema.json
@@ -41,6 +41,18 @@
         "default": "https://api.data.apps.myio-bas.com/api/v1",
         "description": "Base URL for apps myio"
       },
+      "alarmsApiBaseUrl": {
+        "title": "Alarms API Base URL",
+        "type": "string",
+        "default": "https://alarms-api.a.myio-bas.com",
+        "description": "RFC-0183: GCDR alarms backend. Auth uses the customer SERVER_SCOPE attrs gcdrCustomerId/gcdrTenantId/gcdrApiKey; card alarm badges stay hidden when they are absent."
+      },
+      "enableTicketsBadge": {
+        "title": "Enable Tickets Badge on Cards",
+        "type": "boolean",
+        "default": false,
+        "description": "RFC-0198: shows the ticket badge on device cards. Counts come from each device's tickets_items SERVER_SCOPE attribute."
+      },
       "pumpsMotorsLabel": {
         "title": "Energy Section Label",
         "type": "string",
@@ -172,6 +184,15 @@
       "key": "dataApiHost",
       "type": "text",
       "placeholder": "Base URL for apps myio"
+    },
+    {
+      "key": "alarmsApiBaseUrl",
+      "type": "text",
+      "placeholder": "https://alarms-api.a.myio-bas.com"
+    },
+    {
+      "key": "enableTicketsBadge",
+      "type": "checkbox"
     },
     {
       "key": "defaultThemeMode",

--- a/tests/cardBadges.test.ts
+++ b/tests/cardBadges.test.ts
@@ -1,0 +1,125 @@
+// RFC-0183/RFC-0198: shared card alarm/ticket badge helpers
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import {
+  addAlarmBadge,
+  refreshAlarmBadges,
+  addTicketBadge,
+  refreshTicketBadges,
+} from '../src/components/card-badges';
+
+declare global {
+  interface Window {
+    MyIOUtils?: { ticketsEnabled?: boolean };
+  }
+}
+
+let card: HTMLElement;
+
+beforeEach(() => {
+  card = document.createElement('div');
+  document.body.appendChild(card);
+});
+
+afterEach(() => {
+  card.remove();
+  delete (window as any).AlarmServiceOrchestrator;
+  delete (window as any).TicketServiceOrchestrator;
+  delete (window as any).MyIOUtils;
+});
+
+describe('addAlarmBadge', () => {
+  it('inserts a hidden badge when the orchestrator is absent (count 0)', () => {
+    addAlarmBadge(card, 'gcdr-1');
+    const badge = card.querySelector<HTMLElement>('[data-alarm-device-id="gcdr-1"]');
+    expect(badge).not.toBeNull();
+    expect(badge!.style.display).toBe('none');
+  });
+
+  it('shows the count when the orchestrator reports alarms', () => {
+    (window as any).AlarmServiceOrchestrator = {
+      getAlarmCountForDevice: () => 3,
+    };
+    addAlarmBadge(card, 'gcdr-2');
+    const badge = card.querySelector<HTMLElement>('[data-alarm-device-id="gcdr-2"]')!;
+    expect(badge.style.display).toBe('');
+    expect(badge.querySelector('span')!.textContent).toBe('3');
+    expect(badge.title).toContain('3 alarmes');
+  });
+
+  it('does nothing without gcdrDeviceId and avoids duplicates', () => {
+    addAlarmBadge(card, null);
+    expect(card.querySelector('.myio-alarm-badge')).toBeNull();
+
+    addAlarmBadge(card, 'gcdr-3');
+    addAlarmBadge(card, 'gcdr-3');
+    expect(card.querySelectorAll('[data-alarm-device-id="gcdr-3"]')).toHaveLength(1);
+  });
+
+  it('refreshAlarmBadges lights hidden badges up when alarms arrive later', () => {
+    addAlarmBadge(card, 'gcdr-4');
+    expect(card.querySelector<HTMLElement>('.myio-alarm-badge')!.style.display).toBe('none');
+
+    (window as any).AlarmServiceOrchestrator = {
+      getAlarmCountForDevice: () => 120,
+    };
+    refreshAlarmBadges();
+
+    const badge = card.querySelector<HTMLElement>('.myio-alarm-badge')!;
+    expect(badge.style.display).toBe('');
+    expect(badge.querySelector('span')!.textContent).toBe('99+');
+  });
+});
+
+describe('addTicketBadge', () => {
+  it('counts open tickets (status 2/3/6) from the tickets_items fallback when gate is open', () => {
+    (window as any).MyIOUtils = { ticketsEnabled: true };
+    const ticketsItems = JSON.stringify([
+      { status: 2 },
+      { status: 3 },
+      { status: 5 }, // closed — not counted
+      { status: 6 },
+    ]);
+    addTicketBadge(card, 'DEV-001', ticketsItems);
+    const badge = card.querySelector<HTMLElement>('[data-ticket-identifier="DEV-001"]')!;
+    expect(badge.style.display).toBe('');
+    expect(badge.querySelector('.myio-ticket-badge-count')!.textContent).toBe('3');
+  });
+
+  it('stays hidden when the tickets gate is closed even with open tickets', () => {
+    const ticketsItems = JSON.stringify([{ status: 2 }]);
+    addTicketBadge(card, 'DEV-002', ticketsItems);
+    const badge = card.querySelector<HTMLElement>('[data-ticket-identifier="DEV-002"]')!;
+    expect(badge.style.display).toBe('none');
+  });
+
+  it('prefers the TicketServiceOrchestrator count over the attribute fallback', () => {
+    (window as any).MyIOUtils = { ticketsEnabled: true };
+    (window as any).TicketServiceOrchestrator = {
+      getTicketCountForDevice: () => 7,
+    };
+    addTicketBadge(card, 'DEV-003', JSON.stringify([{ status: 2 }]));
+    const badge = card.querySelector<HTMLElement>('[data-ticket-identifier="DEV-003"]')!;
+    expect(badge.querySelector('.myio-ticket-badge-count')!.textContent).toBe('7');
+  });
+
+  it('tolerates malformed tickets_items JSON', () => {
+    (window as any).MyIOUtils = { ticketsEnabled: true };
+    addTicketBadge(card, 'DEV-004', '{not json');
+    const badge = card.querySelector<HTMLElement>('[data-ticket-identifier="DEV-004"]')!;
+    expect(badge.style.display).toBe('none');
+  });
+
+  it('refreshTicketBadges updates counts and hides everything when the gate closes', () => {
+    (window as any).MyIOUtils = { ticketsEnabled: true };
+    (window as any).TicketServiceOrchestrator = {
+      getTicketCountForDevice: () => 2,
+    };
+    addTicketBadge(card, 'DEV-005', null);
+    const badge = card.querySelector<HTMLElement>('[data-ticket-identifier="DEV-005"]')!;
+    expect(badge.querySelector('.myio-ticket-badge-count')!.textContent).toBe('2');
+
+    (window as any).MyIOUtils.ticketsEnabled = false;
+    refreshTicketBadges();
+    expect(badge.style.display).toBe('none');
+  });
+});


### PR DESCRIPTION
## Problema

Os badges de **alarme** (RFC-0183, sino vermelho) e **tickets** (RFC-0198, headphone ciano) eram funcoes **privadas** do controller do widget TELEMETRY v-5.2.0. Os cards do dashboard BAS (renderizados via `CardGridPanel`) nao tinham badge nenhum — nem a infraestrutura (`gcdrDeviceId`, `AlarmServiceOrchestrator`) existia no MAIN_BAS.

## Solucao — fonte unica na lib + consumo no BAS

### Biblioteca
- **`src/components/card-badges`** (novo): `addAlarmBadge`/`refreshAlarmBadges` e `addTicketBadge`/`refreshTicketBadges`, exportados em `src/index.ts`. Os dois badges sao **sempre inseridos** (escondidos quando count=0) para que o refresh os acenda quando os orquestradores carregam **depois** dos cards renderizarem — o caso comum fora do dashboard de shopping. Contagem vem de `window.AlarmServiceOrchestrator` / `window.TicketServiceOrchestrator`, com fallback no atributo SERVER_SCOPE `tickets_items` por device, gated por `MyIOUtils.ticketsEnabled`.
- **`CardGridPanel`**: novo hook `onCardRendered(item, cardEl)` disparado apos cada card montar (try/catch para callback defeituoso nao quebrar o grid).
- **9 testes** vitest (contagem, dedup, refresh tardio, fallback de status 2/3/6, gate fechado, JSON malformado, precedencia do orchestrator).

### MAIN_BAS
- `parseDevicesFromData` extrai `gcdrDeviceId` e `tickets_items` para o device.
- Port de `basPrefetchCustomerAlarms` + `basBuildAlarmServiceOrchestrator` do MAIN_VIEW; construidos no `onInit` a partir dos attrs SERVER_SCOPE do customer (`gcdrCustomerId`/`gcdrTenantId`/`gcdrApiKey`). `refreshAlarmBadges()` e chamado quando o prefetch resolve.
- Paineis de **Agua** e **Energia/Motores** passam `onCardRendered = basDecorateCardWithBadges`. Guardado com `typeof` — libs publicadas antigas viram no-op silencioso.
- `settingsSchema`: `alarmsApiBaseUrl` + `enableTicketsBadge`.

## Pre-requisitos de campo (sem codigo nao resolve)
1. O datasource **AllDevices** do dashboard BAS precisa incluir os datakeys `gcdrDeviceId` (e `tickets_items` p/ tickets).
2. O customer BAS precisa dos attrs `gcdrCustomerId`/`gcdrApiKey` e devices registrados no GCDR.
3. So funciona no TB apos a **proxima release da lib** (helpers + hook entram no bundle; o controller ja guarda com `typeof`).
4. Tickets em modo "attr fallback" (sem `TicketServiceOrchestrator` no BAS) — porta completa do TbTicketSync fica como follow-up.

## Validacao
- 9/9 testes novos passando
- `node --check` no controller, JSON do schema valido, `npm run build:tsup` limpo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
