### PR TITLE
refactor: deviceType is deprecated — deviceProfile is the single classification authority

### DIFF
--- a/src/components/cards/main-view/v5.2.0/template-card-v5.js
+++ b/src/components/cards/main-view/v5.2.0/template-card-v5.js
@@ -92,7 +92,10 @@ export function renderCardComponentV5({
     labelOrName,
     deviceIdentifier,
     entityType,
-    deviceType,
+    // deviceType (campo do payload) está em desuso — preferir deviceProfile;
+    // o alias abaixo mantém o resto do template funcionando com o profile.
+    deviceType: legacyDeviceType,
+    deviceProfile,
     slaveId,
     ingestionId,
     val,
@@ -115,6 +118,10 @@ export function renderCardComponentV5({
     // Per-device exclude_groups_totals attribute (SERVER_SCOPE) — drives the orange marker
     excludeGroupsTotals,
   } = entityObject;
+
+  // deviceProfile é a autoridade; o campo legado deviceType (quando presente em
+  // payloads antigos) serve só de último recurso de exibição.
+  const deviceType = deviceProfile || legacyDeviceType || '';
 
   /*********************************************************
    * MyIO Global Toast Manager

--- a/src/components/cards/main-view/v6.0.0/template-card-v6.js
+++ b/src/components/cards/main-view/v6.0.0/template-card-v6.js
@@ -797,8 +797,8 @@ export function renderCardComponentV6({
     solenoidStatus,
   } = entityObject;
 
-  // RFC-0175: Use deviceProfile (preferred) or deviceType (fallback) for device classification
-  // This fixes SOLENOIDE devices which have deviceType=3F_MEDIDOR but deviceProfile=SOLENOIDE
+  // deviceProfile é a ÚNICA autoridade (deviceType em desuso, 2026-07-14) — o
+  // campo legado do payload fica só como último recurso de exibição.
   const effectiveDeviceType = deviceProfile || deviceType;
 
   // MyIO Global Toast Manager

--- a/src/components/premium-modals/device-profile/openDeviceProfileModal.ts
+++ b/src/components/premium-modals/device-profile/openDeviceProfileModal.ts
@@ -431,8 +431,9 @@ export function openDeviceProfileModal(params: OpenDeviceProfileModalParams) {
     m = key.match(/^cat-(\d+)-(cdt|cidc|cidp)$/);
     if (m) {
       const rule = cats.rules[Number(m[1])];
-      rule.conditional = rule.conditional || { deviceTypes: [] };
-      if (m[2] === 'cdt') return (rule.conditional.deviceTypes = rule.conditional.deviceTypes || []);
+      // deviceProfiles (a chave legada "deviceTypes" foi aposentada — sempre casou contra o profile)
+      rule.conditional = rule.conditional || { deviceProfiles: [] };
+      if (m[2] === 'cdt') return (rule.conditional.deviceProfiles = rule.conditional.deviceProfiles || []);
       if (m[2] === 'cidc')
         return (rule.conditional.identifierContains = rule.conditional.identifierContains || []);
       if (m[2] === 'cidp')

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,6 +158,8 @@ export {
 export type { AssetType, AssetTypeConfigEntry } from './utils/asset';
 
 // RFC-0109: Device Item Factory utilities
+// 2026-07-14: deviceType está EM DESUSO — classificação usa só o deviceProfile.
+// getDomainFromProfile é o nome canônico; getDomainFromDeviceType é alias @deprecated.
 export {
   DomainType,
   DeviceCategory,
@@ -166,6 +168,7 @@ export {
   isSolenoidDevice,
   isTemperatureDevice,
   isEnergyDevice,
+  getDomainFromProfile,
   getDomainFromDeviceType,
   extractPowerLimitsForDevice,
   createDeviceItem,

--- a/src/thingsboard/MYIO-SIM/v5.2.0/MAIN/controller.js
+++ b/src/thingsboard/MYIO-SIM/v5.2.0/MAIN/controller.js
@@ -734,9 +734,9 @@ Object.assign(window.MyIOUtils, {
       }
     }
 
-    // Generic efficiency recommendations based on device type
-    const deviceType = (deviceInfo.deviceType || '').toLowerCase();
-    if (deviceType.includes('bomba') || deviceType.includes('motor')) {
+    // Generic efficiency recommendations based on device profile (deviceType em desuso)
+    const deviceProfile = (deviceInfo.deviceProfile || '').toLowerCase();
+    if (deviceProfile.includes('bomba') || deviceProfile.includes('motor')) {
       recommendations.push({
         type: 'pump_efficiency',
         priority: 'medium',
@@ -977,7 +977,8 @@ let config = null;
 
 /**
  * RFC-0097/RFC-0106: Centralized device classification configuration
- * All deviceType → category mapping rules are defined here
+ * All deviceProfile → category mapping rules are defined here
+ * (deviceType em desuso 2026-07-14 — as listas abaixo casam contra deviceProfile)
  */
 const DEVICE_CLASSIFICATION_CONFIG = {
   // DeviceTypes que pertencem à categoria Climatização
@@ -1046,7 +1047,8 @@ const EQUIPMENT_EXCLUSION_PATTERN = new RegExp(
 
 function getEffectiveDeviceProfile(item) {
   if (!item || typeof item !== 'object') return '';
-  return String(item.effectiveDeviceType || item.deviceProfile || item.deviceType || '').toUpperCase();
+  // deviceType em desuso — sem fallback para deviceType
+  return String(item.effectiveDeviceType || item.deviceProfile || '').toUpperCase();
 }
 
 function isAllowedEquipmentProfile(item) {
@@ -1056,29 +1058,24 @@ function isAllowedEquipmentProfile(item) {
 
 /**
  * RFC-0106: Check if device is a store (loja)
- * A device is considered a store when BOTH deviceType AND deviceProfile equal '3F_MEDIDOR'
+ * deviceProfile é a ÚNICA autoridade (deviceType em desuso 2026-07-14):
+ * loja quando deviceProfile começa com '3F_MEDIDOR'
  *
- * @param {Object|string} itemOrDeviceProfile - Device item with deviceProfile/deviceType properties, or deviceProfile string directly
+ * @param {Object|string} itemOrDeviceProfile - Device item with deviceProfile property, or deviceProfile string directly
  * @returns {boolean} True if device is a store
  */
 function isStoreDevice(itemOrDeviceProfile) {
-  if (typeof itemOrDeviceProfile === 'string') {
-    // If only a string is passed, assume it's deviceProfile and return true if it matches
-    return String(itemOrDeviceProfile || '').toUpperCase() === '3F_MEDIDOR';
-  }
+  let deviceProfile;
 
-  if (!itemOrDeviceProfile || typeof itemOrDeviceProfile !== 'object') {
+  if (typeof itemOrDeviceProfile === 'string') {
+    deviceProfile = itemOrDeviceProfile;
+  } else if (itemOrDeviceProfile && typeof itemOrDeviceProfile === 'object') {
+    deviceProfile = itemOrDeviceProfile.deviceProfile;
+  } else {
     return false;
   }
 
-  const deviceType = String(itemOrDeviceProfile.deviceType || '').toUpperCase();
-  // RFC-0140: If deviceProfile is null/empty, assume it equals deviceType
-  const deviceProfile = String(
-    itemOrDeviceProfile.deviceProfile || itemOrDeviceProfile.deviceType || ''
-  ).toUpperCase();
-
-  // A device is a store only if BOTH deviceType AND deviceProfile are '3F_MEDIDOR'
-  return deviceProfile === '3F_MEDIDOR' && deviceType === '3F_MEDIDOR';
+  return String(deviceProfile || '').toUpperCase().startsWith('3F_MEDIDOR');
 }
 
 /**
@@ -1118,11 +1115,11 @@ function isEntradaDevice(item) {
 /**
  * RFC-0109: Simplified water meter classification
  *
- * New rule:
- * - STORE (loja): deviceType = deviceProfile = HIDROMETRO (both must be exactly "HIDROMETRO")
+ * New rule (deviceProfile é a ÚNICA autoridade — deviceType em desuso):
+ * - STORE (loja): deviceProfile = HIDROMETRO
  * - AREA_COMUM: everything else
  *
- * @param {Object} item - Device item with deviceType and deviceProfile properties
+ * @param {Object} item - Device item with deviceProfile property
  * @returns {boolean} True if device is a water store (loja)
  */
 function isWaterStoreDevice(item) {
@@ -1130,28 +1127,22 @@ function isWaterStoreDevice(item) {
     return false;
   }
 
-  const dt = String(item.deviceType || '').toUpperCase();
-  // RFC-0140: If deviceProfile is null/empty, assume it equals deviceType
-  const dp = String(item.deviceProfile || item.deviceType || '').toUpperCase();
+  const dp = String(item.deviceProfile || '').toUpperCase();
 
-  // LOJA: deviceType = HIDROMETRO AND deviceProfile = HIDROMETRO
-  return dt === 'HIDROMETRO' && dp === 'HIDROMETRO';
+  // LOJA: deviceProfile = HIDROMETRO
+  return dp === 'HIDROMETRO';
 }
 
 /**
  * RFC-0109: Water meter classification
  * Returns classification: 'loja', 'areacomum', or 'entrada'
  *
- * Rules:
- * - LOJA: deviceType = HIDROMETRO AND deviceProfile = HIDROMETRO
- * - AREA_COMUM:
- *   - deviceType = HIDROMETRO AND deviceProfile = HIDROMETRO_AREA_COMUM
- *   - OR deviceType = HIDROMETRO_AREA_COMUM (deviceProfile não importa)
- * - ENTRADA:
- *   - deviceType = HIDROMETRO AND deviceProfile = HIDROMETRO_SHOPPING
- *   - OR deviceType = HIDROMETRO_SHOPPING (deviceProfile não importa)
+ * Rules (deviceProfile é a ÚNICA autoridade — deviceType em desuso):
+ * - LOJA: deviceProfile = HIDROMETRO
+ * - ENTRADA: deviceProfile = HIDROMETRO_SHOPPING
+ * - AREA_COMUM: deviceProfile = HIDROMETRO_AREA_COMUM (e default para o resto)
  *
- * @param {Object} item - Device item with deviceType and deviceProfile properties
+ * @param {Object} item - Device item with deviceProfile property
  * @returns {'loja'|'areacomum'|'entrada'}
  */
 function classifyWaterMeterDevice(item) {
@@ -1159,30 +1150,28 @@ function classifyWaterMeterDevice(item) {
     return 'areacomum';
   }
 
-  const dt = String(item.deviceType || '').toUpperCase();
-  // RFC-0140: If deviceProfile is null/empty, assume it equals deviceType
-  const dp = String(item.deviceProfile || item.deviceType || '').toUpperCase();
+  const dp = String(item.deviceProfile || '').toUpperCase();
 
-  // LOJA: deviceType = HIDROMETRO AND deviceProfile = HIDROMETRO
-  if (dt === 'HIDROMETRO' && dp === 'HIDROMETRO') {
+  // LOJA: deviceProfile = HIDROMETRO
+  if (dp === 'HIDROMETRO') {
     return 'loja';
   }
 
-  // ENTRADA: deviceType = HIDROMETRO_SHOPPING OR (deviceType = HIDROMETRO AND deviceProfile = HIDROMETRO_SHOPPING)
-  if (dt === 'HIDROMETRO_SHOPPING' || (dt === 'HIDROMETRO' && dp === 'HIDROMETRO_SHOPPING')) {
+  // ENTRADA: deviceProfile = HIDROMETRO_SHOPPING
+  if (dp === 'HIDROMETRO_SHOPPING') {
     return 'entrada';
   }
 
-  // AREA_COMUM: deviceType = HIDROMETRO_AREA_COMUM OR (deviceType = HIDROMETRO AND deviceProfile = HIDROMETRO_AREA_COMUM)
+  // AREA_COMUM: deviceProfile = HIDROMETRO_AREA_COMUM
   // Also default for any other combination
   return 'areacomum';
 }
 
 /**
  * RFC-0109: Check if device is a water entrada (shopping entrance)
- * ENTRADA: deviceType = HIDROMETRO_SHOPPING OR (deviceType = HIDROMETRO AND deviceProfile = HIDROMETRO_SHOPPING)
+ * ENTRADA: deviceProfile = HIDROMETRO_SHOPPING (deviceType em desuso)
  *
- * @param {Object} item - Device item with deviceType and deviceProfile properties
+ * @param {Object} item - Device item with deviceProfile property
  * @returns {boolean} True if device is a water entrada
  */
 function isWaterEntradaDevice(item) {
@@ -1190,12 +1179,10 @@ function isWaterEntradaDevice(item) {
     return false;
   }
 
-  const dt = String(item.deviceType || '').toUpperCase();
-  // RFC-0140: If deviceProfile is null/empty, assume it equals deviceType
-  const dp = String(item.deviceProfile || item.deviceType || '').toUpperCase();
+  const dp = String(item.deviceProfile || '').toUpperCase();
 
-  // ENTRADA: deviceType = HIDROMETRO_SHOPPING OR (deviceType = HIDROMETRO AND deviceProfile = HIDROMETRO_SHOPPING)
-  return dt === 'HIDROMETRO_SHOPPING' || (dt === 'HIDROMETRO' && dp === 'HIDROMETRO_SHOPPING');
+  // ENTRADA: deviceProfile = HIDROMETRO_SHOPPING
+  return dp === 'HIDROMETRO_SHOPPING';
 }
 
 /**
@@ -1206,14 +1193,14 @@ function isWaterEntradaDevice(item) {
  * - Lojas: deviceProfile === '3F_MEDIDOR' (uses isStoreDevice)
  * - Others: classify by deviceProfile using DEVICE_CLASSIFICATION_CONFIG
  *
- * @param {Object} item - Device item with deviceType, deviceProfile and identifier properties
+ * @param {Object} item - Device item with deviceProfile and identifier properties
  * @returns {'lojas'|'climatizacao'|'elevadores'|'escadas_rolantes'|'outros'}
  */
 function classifyDeviceByDeviceType(item) {
   if (!item) return 'outros';
 
-  // RFC-0140: If deviceProfile is null/empty, assume it equals deviceType
-  const deviceProfile = String(item.deviceProfile || item.deviceType || '').toUpperCase();
+  // deviceType em desuso — sem fallback para deviceType
+  const deviceProfile = String(item.deviceProfile || '').toUpperCase();
 
   // RFC-0106: Lojas - use centralized isStoreDevice
   if (isStoreDevice(item)) {
@@ -1311,8 +1298,8 @@ function classifyDeviceByIdentifier(identifier = '') {
 }
 
 /**
- * RFC-0097/RFC-0106: Classify device using deviceType as primary method
- * @param {Object} item - Device item with deviceType, deviceProfile, identifier, and label
+ * RFC-0097/RFC-0106: Classify device using deviceProfile as primary method (deviceType em desuso)
+ * @param {Object} item - Device item with deviceProfile, identifier, and label
  * @returns {'climatizacao'|'elevadores'|'escadas_rolantes'|'outros'}
  */
 function classifyDevice(item) {
@@ -1322,7 +1309,7 @@ function classifyDevice(item) {
     return 'outros';
   }
 
-  // RFC-0097: Primary classification by deviceType (or deviceProfile when deviceType = 3F_MEDIDOR)
+  // RFC-0097: Primary classification by deviceProfile (deviceType em desuso)
   const category = classifyDeviceByDeviceType(item);
 
   // Return if we got a specific category (not 'outros')
@@ -1359,20 +1346,20 @@ function categoryToLabelWidget(category) {
 }
 
 /**
- * RFC-0106: Infer labelWidget from deviceType AND deviceProfile
- * Classification based on BOTH deviceType and deviceProfile from ThingsBoard datasource
+ * RFC-0106: Infer labelWidget from deviceProfile
+ * deviceProfile é a ÚNICA autoridade de classificação (deviceType em desuso 2026-07-14)
  *
  * Rules (priority order):
- * 1. LOJAS: deviceProfile = '3F_MEDIDOR' (uses isStoreDevice)
- * 2. ENTRADA: deviceType OR deviceProfile contains ENTRADA/TRAFO/SUBESTACAO
- * 3. For other categories, check deviceProfile first, then deviceType:
+ * 1. LOJAS: deviceProfile começa com '3F_MEDIDOR' (uses isStoreDevice)
+ * 2. ENTRADA: deviceProfile contains ENTRADA/TRAFO/SUBESTACAO
+ * 3. For other categories, check deviceProfile:
  *    - CHILLER, FANCOIL, HVAC, AR_CONDICIONADO → 'Climatização'
  *    - ELEVADOR → 'Elevadores'
  *    - ESCADA_ROLANTE → 'Escadas Rolantes'
  *    - BOMBA, MOTOR, etc → 'Área Comum'
  * 4. Default: 'Área Comum' (if no classification matches)
  *
- * @param {Object} row - Item with deviceType, deviceProfile, identifier, name
+ * @param {Object} row - Item with deviceProfile, identifier, name
  * @returns {string} labelWidget for widget filtering
  */
 function inferLabelWidget(row) {
@@ -1382,10 +1369,8 @@ function inferLabelWidget(row) {
     return groupType;
   }
 
-  // Get deviceType and deviceProfile from ThingsBoard datasource
-  const deviceType = String(row.deviceType || '').toUpperCase();
-  // RFC-0140: If deviceProfile is null/empty, assume it equals deviceType
-  const deviceProfile = String(row.deviceProfile || row.deviceType || '').toUpperCase();
+  // Get deviceProfile from ThingsBoard datasource (deviceType em desuso — sem fallback)
+  const deviceProfile = String(row.deviceProfile || '').toUpperCase();
 
   // ==========================================================================
   // RULE 1: LOJAS - use centralized isStoreDevice
@@ -1395,17 +1380,16 @@ function inferLabelWidget(row) {
   }
 
   // ==========================================================================
-  // RULE 2: ENTRADA - deviceType OR deviceProfile contains ENTRADA/TRAFO/SUBESTACAO
+  // RULE 2: ENTRADA - deviceProfile contains ENTRADA/TRAFO/SUBESTACAO
   // ==========================================================================
   const ENTRADA_PATTERNS = ['ENTRADA', 'TRAFO', 'SUBESTACAO'];
-  const isEntradaByType = ENTRADA_PATTERNS.some((p) => deviceType.includes(p));
   const isEntradaByProfile = ENTRADA_PATTERNS.some((p) => deviceProfile.includes(p));
-  if (isEntradaByType || isEntradaByProfile) {
+  if (isEntradaByProfile) {
     return 'Entrada';
   }
 
   // ==========================================================================
-  // RULE 3: Check deviceProfile FIRST for other categories, then deviceType
+  // RULE 3: Check deviceProfile for other categories (deviceType em desuso)
   // ==========================================================================
 
   // Climatização: CHILLER, FANCOIL, HVAC, AR_CONDICIONADO, COMPRESSOR, VENTILADOR
@@ -1418,28 +1402,19 @@ function inferLabelWidget(row) {
     'VENTILADOR',
     'CLIMATIZA',
   ];
-  if (
-    CLIMATIZACAO_PATTERNS.some((p) => deviceProfile.includes(p)) ||
-    CLIMATIZACAO_PATTERNS.some((p) => deviceType.includes(p))
-  ) {
+  if (CLIMATIZACAO_PATTERNS.some((p) => deviceProfile.includes(p))) {
     return 'Climatização';
   }
 
   // Elevadores: ELEVADOR, ELV
   const ELEVADOR_PATTERNS = ['ELEVADOR', 'ELV'];
-  if (
-    ELEVADOR_PATTERNS.some((p) => deviceProfile.includes(p)) ||
-    ELEVADOR_PATTERNS.some((p) => deviceType.includes(p))
-  ) {
+  if (ELEVADOR_PATTERNS.some((p) => deviceProfile.includes(p))) {
     return 'Elevadores';
   }
 
   // Escadas Rolantes: ESCADA_ROLANTE, ESCADA
   const ESCADA_PATTERNS = ['ESCADA_ROLANTE', 'ESCADA'];
-  if (
-    ESCADA_PATTERNS.some((p) => deviceProfile.includes(p)) ||
-    ESCADA_PATTERNS.some((p) => deviceType.includes(p))
-  ) {
+  if (ESCADA_PATTERNS.some((p) => deviceProfile.includes(p))) {
     return 'Escadas Rolantes';
   }
 
@@ -1454,21 +1429,17 @@ function inferLabelWidget(row) {
     'ILUMINACAO',
     'LUZ',
   ];
-  if (
-    AREA_COMUM_PATTERNS.some((p) => deviceProfile.includes(p)) ||
-    AREA_COMUM_PATTERNS.some((p) => deviceType.includes(p))
-  ) {
+  if (AREA_COMUM_PATTERNS.some((p) => deviceProfile.includes(p))) {
     return 'Área Comum';
   }
 
   // Temperature types
-  if (deviceProfile.includes('TERMOSTATO') || deviceType.includes('TERMOSTATO')) {
+  if (deviceProfile.includes('TERMOSTATO')) {
     return 'Temperatura';
   }
 
   // ==========================================================================
   // RULE 4: Default - if nothing matched, default to Área Comum
-  // (deviceType = 3F_MEDIDOR but deviceProfile != 3F_MEDIDOR means it's equipment)
   // ==========================================================================
   return 'Área Comum';
 }
@@ -4400,15 +4371,13 @@ function storeContractState(deviceCounts, validationResult = { isValid: true, di
 
 /**
  * Categorize items into 3 groups: lojas, entrada, areacomum
- * Rules:
- * - LOJAS: deviceProfile = '3F_MEDIDOR' (uses isStoreDevice)
- * - ENTRADA: (deviceType = '3F_MEDIDOR' AND deviceProfile in [TRAFO, ENTRADA, RELOGIO, SUBESTACAO])
- *            OR deviceType in [TRAFO, ENTRADA, RELOGIO, SUBESTACAO]
+ * Rules (deviceProfile é a ÚNICA autoridade — deviceType em desuso):
+ * - LOJAS: deviceProfile começa com '3F_MEDIDOR' (uses isStoreDevice)
+ * - ENTRADA: deviceProfile in [TRAFO, ENTRADA, RELOGIO, SUBESTACAO]
  * - AREACOMUM: everything else
  */
 function categorizeItemsByGroup(items) {
   const ENTRADA_PROFILES = new Set(['TRAFO', 'ENTRADA', 'RELOGIO', 'SUBESTACAO']);
-  const ENTRADA_TYPES = new Set(['TRAFO', 'ENTRADA', 'RELOGIO', 'SUBESTACAO']);
 
   const lojas = [];
   const entrada = [];
@@ -4418,9 +4387,8 @@ function categorizeItemsByGroup(items) {
   const toStr = (val) => String(val || '').toUpperCase();
 
   for (const item of items) {
-    const deviceType = toStr(item.deviceType);
-    // RFC-0140: If deviceProfile is null/empty, assume it equals deviceType
-    const deviceProfile = toStr(item.deviceProfile || item.deviceType);
+    // deviceType em desuso — sem fallback para deviceType
+    const deviceProfile = toStr(item.deviceProfile);
 
     // Rule 1: LOJAS - use centralized isStoreDevice
     if (isStoreDevice(item)) {
@@ -4428,10 +4396,8 @@ function categorizeItemsByGroup(items) {
       continue;
     }
 
-    // Rule 2: ENTRADA - deviceType = 3F_MEDIDOR with entrada profile, OR deviceType is entrada type
-    const isEntradaByProfile = deviceType === '3F_MEDIDOR' && ENTRADA_PROFILES.has(deviceProfile);
-    const isEntradaByType = ENTRADA_TYPES.has(deviceType);
-    if (isEntradaByProfile || isEntradaByType) {
+    // Rule 2: ENTRADA - deviceProfile is entrada profile
+    if (ENTRADA_PROFILES.has(deviceProfile)) {
       entrada.push(item);
       continue;
     }
@@ -4446,15 +4412,11 @@ function categorizeItemsByGroup(items) {
 /**
  * RFC-0109: Water categorization into 3 groups: lojas, areacomum, entrada
  *
- * Rules:
- * - LOJAS: deviceType = HIDROMETRO AND deviceProfile = HIDROMETRO
- * - ENTRADA:
- *   - deviceType = HIDROMETRO AND deviceProfile = HIDROMETRO_SHOPPING
- *   - OR deviceType = HIDROMETRO_SHOPPING (deviceProfile não importa)
- * - AREACOMUM:
- *   - deviceType = HIDROMETRO AND deviceProfile = HIDROMETRO_AREA_COMUM
- *   - OR deviceType = HIDROMETRO_AREA_COMUM (deviceProfile não importa)
- *   - OR any other combination (default)
+ * Rules (deviceProfile é a ÚNICA autoridade — deviceType em desuso):
+ * - LOJAS: deviceProfile = HIDROMETRO
+ * - ENTRADA: deviceProfile = HIDROMETRO_SHOPPING
+ * - AREACOMUM: deviceProfile = HIDROMETRO_AREA_COMUM (ou contém AREA_COMUM)
+ * - Sem match: não entra em grupo nenhum (log warn)
  */
 function categorizeItemsByGroupWater(items) {
   const entrada = [];
@@ -4466,40 +4428,34 @@ function categorizeItemsByGroupWater(items) {
   const toStr = (val) => String(val || '').toUpperCase();
 
   for (const item of items) {
-    const dt = toStr(item.deviceType);
-    // RFC-0140: If deviceProfile is null/empty, assume it equals deviceType
-    const dp = toStr(item.deviceProfile || item.deviceType);
+    // deviceType em desuso — deviceProfile é a única autoridade
+    const dp = toStr(item.deviceProfile);
 
-    // LOJAS: deviceType = HIDROMETRO AND deviceProfile = HIDROMETRO
-    if (dt === 'HIDROMETRO' && dp === 'HIDROMETRO') {
+    // LOJAS: deviceProfile = HIDROMETRO
+    if (dp === 'HIDROMETRO') {
       lojas.push(item);
       continue;
     }
 
-    // ENTRADA: deviceType = HIDROMETRO_SHOPPING OR (deviceType = HIDROMETRO AND deviceProfile = HIDROMETRO_SHOPPING)
-    if (dt === 'HIDROMETRO_SHOPPING' || (dt === 'HIDROMETRO' && dp === 'HIDROMETRO_SHOPPING')) {
+    // ENTRADA: deviceProfile = HIDROMETRO_SHOPPING
+    if (dp === 'HIDROMETRO_SHOPPING') {
       entrada.push(item);
       continue;
     }
 
     // AREACOMUM: ONLY devices explicitly marked as area comum
-    // - deviceType = HIDROMETRO_AREA_COMUM (any deviceProfile)
-    // - OR deviceType = HIDROMETRO AND deviceProfile = HIDROMETRO_AREA_COMUM
+    // - deviceProfile = HIDROMETRO_AREA_COMUM (ou contém AREA_COMUM)
     // This prevents unclassified devices from appearing in area comum
-    if (
-      dt === 'HIDROMETRO_AREA_COMUM' ||
-      dt.includes('AREA_COMUM') ||
-      (dt === 'HIDROMETRO' && (dp === 'HIDROMETRO_AREA_COMUM' || dp.includes('AREA_COMUM')))
-    ) {
+    if (dp === 'HIDROMETRO_AREA_COMUM' || dp.includes('AREA_COMUM')) {
       areacomum.push(item);
       continue;
     }
 
     // Devices that don't match any category are NOT added to any group
-    // This prevents HIDROMETRO without deviceProfile from appearing in areacomum
+    // This prevents devices without deviceProfile from appearing in areacomum
     // RFC-0140: Log warn for unclassified devices
     LogHelper.warn(
-      `[categorizeItemsByGroupWater] ⚠️ UNCLASSIFIED water device: "${item.label}" (deviceType=${dt || 'NULL'}, deviceProfile=${dp || 'NULL'})`
+      `[categorizeItemsByGroupWater] ⚠️ UNCLASSIFIED water device: "${item.label}" (deviceProfile=${dp || 'NULL'})`
     );
   }
 
@@ -4576,11 +4532,10 @@ function buildSummary(lojas, entrada, areacomum, periodKey) {
 
   for (const item of areacomum) {
     const lw = toStr(item.labelWidget);
-    const dt = toStr(item.deviceType);
-    // RFC-0140: If deviceProfile is null/empty, assume it equals deviceType
-    const dp = toStr(item.deviceProfile || item.deviceType);
+    const dp = toStr(item.deviceProfile);
     const label = toStr(item.label);
-    const combined = `${lw} ${dt} ${dp} ${label}`;
+    // deviceType em desuso (2026-07-14) — fora do texto combinado
+    const combined = `${lw} ${dp} ${label}`;
 
     if (ELEVADOR_PATTERNS.some((p) => combined.includes(p))) {
       elevadoresItems.push(item);
@@ -5978,10 +5933,11 @@ const MyIOOrchestrator = (() => {
       const shortDelayMins = 60; // 60 mins for BAD/OFFLINE recovery
 
       // RFC-0110 v5: Determine domain and telemetry timestamp
-      const deviceType = (options.deviceType || options.deviceProfile || '').toUpperCase();
-      const isTankDevice = deviceType === 'TANK' || deviceType === 'CAIXA_DAGUA';
-      const isHidrometerDevice = deviceType.startsWith('HIDROMETRO') || deviceType.includes('WATER');
-      const isTemperatureDevice = deviceType === 'TERMOSTATO' || deviceType.includes('TEMP');
+      // deviceType em desuso (2026-07-14) — domínio sai SÓ do deviceProfile
+      const deviceProfile = (options.deviceProfile || '').toUpperCase();
+      const isTankDevice = deviceProfile === 'TANK' || deviceProfile === 'CAIXA_DAGUA';
+      const isHidrometerDevice = deviceProfile.startsWith('HIDROMETRO') || deviceProfile.includes('WATER');
+      const isTemperatureDevice = deviceProfile === 'TERMOSTATO' || deviceProfile.includes('TEMP');
 
       const domain =
         isTankDevice || isHidrometerDevice ? 'water' : isTemperatureDevice ? 'temperature' : 'energy';
@@ -6257,13 +6213,13 @@ const MyIOOrchestrator = (() => {
       `[Orchestrator] 📋 Built metadata map: ${metadataByEntityId.size} entities, ${metadataByIngestion.size} with ingestionId`
     );
 
-    // DEBUG RFC-0107: Log deviceTypes of all entities in metadataByEntityId
+    // DEBUG RFC-0107: Log deviceProfiles of all entities in metadataByEntityId (deviceType em desuso)
     if (metadataByEntityId.size > 0) {
-      const deviceTypes = [];
+      const deviceProfiles = [];
       for (const [entityId, meta] of metadataByEntityId.entries()) {
-        deviceTypes.push(`${meta.label || entityId.substring(0, 8)}:${meta.deviceType || 'N/A'}`);
+        deviceProfiles.push(`${meta.label || entityId.substring(0, 8)}:${meta.deviceProfile || 'N/A'}`);
       }
-      LogHelper.log(`[Orchestrator] 📋 RFC-0107 Device types in metadata: ${deviceTypes.join(', ')}`);
+      LogHelper.log(`[Orchestrator] 📋 RFC-0107 Device profiles in metadata: ${deviceProfiles.join(', ')}`);
     }
 
     // DEBUG: Log all dataKeys found in ctx.data
@@ -6460,7 +6416,6 @@ const MyIOOrchestrator = (() => {
 
           // RFC-0110 v5: Pass telemetry timestamp and lastActivityTime for proper status calculation
           const deviceStatus = convertConnectionStatusToDeviceStatus(meta.connectionStatus, {
-            deviceType: meta.deviceType,
             deviceProfile: meta.deviceProfile,
             temperatureTs: meta.temperatureTs,
             lastActivityTime: meta.lastActivityTime,
@@ -6478,7 +6433,7 @@ const MyIOOrchestrator = (() => {
             temperature: temperatureValue,
             rawTemperature: rawTemperature, // RFC-FIX: Keep raw value for reference
             offSetTemperature: tempOffset, // RFC-FIX: Keep offset for reference
-            deviceType: meta.deviceType || 'TERMOSTATO',
+            deviceType: meta.deviceProfile || 'TERMOSTATO', // campo legado (deviceType em desuso) — preenchido do profile
             deviceProfile: meta.deviceProfile || '',
             deviceStatus: deviceStatus,
             connectionStatus: meta.connectionStatus || 'unknown',
@@ -6540,21 +6495,21 @@ const MyIOOrchestrator = (() => {
       // TANK/CAIXA_DAGUA get data directly from ThingsBoard (water_level, water_percentage)
       let tankItems = [];
       if (domain === 'water' && metadataByEntityId.size > 0) {
-        // DEBUG: Log all water device types
-        const waterDeviceTypes = [];
+        // DEBUG: Log all water device profiles (deviceType em desuso)
+        const waterDeviceProfiles = [];
         for (const [, meta] of metadataByEntityId.entries()) {
-          waterDeviceTypes.push(meta.deviceType || 'N/A');
+          waterDeviceProfiles.push(meta.deviceProfile || 'N/A');
         }
-        LogHelper.log(`[Orchestrator] 🔍 DEBUG Water device types: ${waterDeviceTypes.join(', ')}`);
+        LogHelper.log(`[Orchestrator] 🔍 DEBUG Water device profiles: ${waterDeviceProfiles.join(', ')}`);
 
         for (const [entityId, meta] of metadataByEntityId.entries()) {
-          const deviceType = String(meta.deviceType || '').toUpperCase();
-          if (deviceType === 'TANK' || deviceType === 'CAIXA_DAGUA') {
+          // deviceType está EM DESUSO (2026-07-14) — deviceProfile é a única autoridade
+          const deviceProfile = String(meta.deviceProfile || '').toUpperCase();
+          if (deviceProfile === 'TANK' || deviceProfile === 'CAIXA_DAGUA') {
             const waterLevel = Number(meta.waterLevel || 0);
             const waterPercentage = Number(meta.waterPercentage || 0);
             // RFC-0110 v5: Pass telemetry timestamp and lastActivityTime for proper status calculation
             const deviceStatus = convertConnectionStatusToDeviceStatus(meta.connectionStatus, {
-              deviceType: meta.deviceType,
               deviceProfile: meta.deviceProfile,
               waterLevelTs: meta.waterLevelTs,
               waterPercentageTs: meta.waterPercentageTs,
@@ -6572,9 +6527,9 @@ const MyIOOrchestrator = (() => {
               value: waterLevel, // water_level in liters
               waterLevel: waterLevel,
               waterPercentage: waterPercentage, // 0-1 range
-              deviceType: deviceType,
-              deviceProfile: meta.deviceProfile || deviceType,
-              effectiveDeviceType: meta.deviceProfile || deviceType,
+              deviceType: deviceProfile, // campo legado (deviceType em desuso) — preenchido do profile
+              deviceProfile: deviceProfile,
+              effectiveDeviceType: deviceProfile,
               deviceStatus: deviceStatus,
               connectionStatus: meta.connectionStatus || 'unknown',
               centralId: meta.centralId || null,
@@ -6730,7 +6685,7 @@ const MyIOOrchestrator = (() => {
       // RFC-0106: metadataMap was already built BEFORE API call (line ~1755)
       // Now combine metadata (ctx.data) with consumption values (API)
       // Match by ingestionId: metadata.ingestionId === api.id
-      // NO FALLBACK: deviceType, identifier, label ONLY from ctx.data
+      // NO FALLBACK: deviceProfile, identifier, label ONLY from ctx.data
 
       // RFC-0106: Value field differs by domain:
       // - energy: total_value (kWh)
@@ -6750,31 +6705,19 @@ const MyIOOrchestrator = (() => {
         const meta = metadataMap.get(apiId) || {}; // Get metadata by ingestionId
         const name = row.name || '';
 
-        // Use metadata from ThingsBoard datasource (ctx.data) - NO FALLBACKS for deviceType
-        // deviceType: ONLY from ctx.data where datakey = deviceType, NO fallback
+        // Use metadata from ThingsBoard datasource (ctx.data)
+        // deviceProfile: ONLY from ctx.data where datakey = deviceProfile, NO fallback
         // identifier: ONLY from ctx.data where datakey = identifier, fallback = 'N/A'
         // label: ONLY from ctx.data where datakey = label, fallback = 'SEM ETIQUETA'
-        const rawDeviceType = meta.deviceType || null;
+        // deviceType está EM DESUSO (2026-07-14) — deviceProfile é a única
+        // autoridade; a antiga "MASTER RULE" de coerção deviceType→profile morreu.
         const deviceProfile = meta.deviceProfile || null;
 
-        // MASTER RULE for deviceType:
-        // - If deviceType = deviceProfile = '3F_MEDIDOR' → keep as '3F_MEDIDOR' (it's a loja)
-        // - If deviceType = '3F_MEDIDOR' AND deviceProfile != '3F_MEDIDOR' → force deviceType = deviceProfile
-        let deviceType = rawDeviceType;
-        if (rawDeviceType === '3F_MEDIDOR' && deviceProfile && deviceProfile !== '3F_MEDIDOR') {
-          deviceType = deviceProfile;
-          LogHelper.log(
-            `[Orchestrator] 🔄 Master rule applied: deviceType changed from 3F_MEDIDOR to ${deviceProfile} for ${
-              meta.label || row.name
-            }`
-          );
-        }
         const identifier = meta.identifier || 'N/A';
         const label = meta.label || name || 'SEM ETIQUETA';
 
-        // Infer labelWidget from deviceType/deviceProfile
+        // Infer labelWidget from deviceProfile (deviceType em desuso)
         const labelWidget = inferLabelWidget({
-          deviceType: deviceType,
           deviceProfile: deviceProfile,
           identifier: identifier,
           name: name,
@@ -6791,12 +6734,11 @@ const MyIOOrchestrator = (() => {
           name: name,
           value: getValueFromRow(row),
           perc: 0,
-          deviceType: deviceType,
+          deviceType: deviceProfile || '', // campo legado (deviceType em desuso) — preenchido do profile
           deviceProfile: deviceProfile,
-          effectiveDeviceType: deviceProfile || deviceType || null,
+          effectiveDeviceType: deviceProfile || null,
           // RFC-0110 v5: Pass telemetry timestamp and lastActivityTime for proper status calculation
           deviceStatus: convertConnectionStatusToDeviceStatus(meta.connectionStatus, {
-            deviceType: meta.deviceType,
             deviceProfile: meta.deviceProfile,
             consumptionTs: meta.consumptionTs,
             lastActivityTime: meta.lastActivityTime,
@@ -6824,33 +6766,23 @@ const MyIOOrchestrator = (() => {
           groupLabel: labelWidget,
           // Flag to indicate if metadata was found
           _hasMetadata: !!meta.tbId,
+          // Placeholder do datasource (lixo, não classificação): em rows legadas sem
+          // profile, usa o deviceType bruto SÓ para detectar placeholder do domínio.
+          _placeholderBasis: (deviceProfile || meta.deviceType || '').toLowerCase(),
         };
       });
 
       // Filter out invalid items:
-      // 1. Items with deviceType = domain name (placeholder from API - 'energy' or 'water')
-      // 2. Items with effectiveDeviceType = domain name (no proper deviceType/deviceProfile)
-      // 3. Items without metadata (_hasMetadata = false) - these exist in API but not in ThingsBoard datasource
+      // 1. Items with deviceProfile = domain name (placeholder from API - 'energy' or 'water')
+      // 2. Items without metadata (_hasMetadata = false) - these exist in API but not in ThingsBoard datasource
       const itemsBeforeFilter = items.length;
       const domainLower = domain.toLowerCase(); // 'energy' or 'water'
       const filteredItems = items.filter((item) => {
-        const dt = (item.deviceType || '').toLowerCase();
-        const edt = (item.effectiveDeviceType || '').toLowerCase();
-
-        // Discard items with deviceType = domain (placeholder from API)
-        if (dt === domainLower) {
+        // Discard items with profile placeholder = domain (filtro de lixo de datasource,
+        // não classificação — deviceType em desuso)
+        if (item._placeholderBasis === domainLower) {
           LogHelper.log(
-            `[Orchestrator] 🗑️ Discarding item with deviceType='${domain}': ${item.label || item.name}`
-          );
-          return false;
-        }
-
-        // Discard items with effectiveDeviceType = domain (no proper classification)
-        if (edt === domainLower) {
-          LogHelper.log(
-            `[Orchestrator] 🗑️ Discarding item with effectiveDeviceType='${domain}': ${
-              item.label || item.name
-            }`
+            `[Orchestrator] 🗑️ Discarding placeholder item ('${domain}'): ${item.label || item.name}`
           );
           return false;
         }
@@ -6868,7 +6800,7 @@ const MyIOOrchestrator = (() => {
       const discardedCount = itemsBeforeFilter - filteredItems.length;
       if (discardedCount > 0) {
         LogHelper.log(
-          `[Orchestrator] 🗑️ Discarded ${discardedCount} invalid items (no metadata or deviceType='${domain}')`
+          `[Orchestrator] 🗑️ Discarded ${discardedCount} invalid items (no metadata or placeholder='${domain}')`
         );
 
         // DEBUG: Show first 3 discarded items with their API IDs for debugging
@@ -7309,8 +7241,8 @@ const MyIOOrchestrator = (() => {
         );
 
         // RFC-0109: Water meter classification
-        // FIX: Use aliasName as PRIMARY classification (more reliable than deviceType/deviceProfile)
-        // Fallback to deviceType/deviceProfile if aliasName doesn't match
+        // FIX: Use aliasName as PRIMARY classification (more reliable than deviceProfile)
+        // Fallback to deviceProfile if aliasName doesn't match (deviceType em desuso)
         let classificationDebugLog = { byAlias: {}, byType: {}, defaults: [] };
         const classifyWaterMeter = (device) => {
           const aliasName = String(device._aliasName || '').toLowerCase();
@@ -7333,25 +7265,24 @@ const MyIOOrchestrator = (() => {
             return 'areacomum';
           }
 
-          // FALLBACK: Classification by deviceType/deviceProfile (if aliasName didn't match)
-          const dt = String(device.deviceType || '').toUpperCase();
-          // RFC-0140: If deviceProfile is null/empty, assume it equals deviceType
-          const dp = String(device.deviceProfile || device.deviceType || '').toUpperCase();
+          // FALLBACK: Classification by deviceProfile (if aliasName didn't match)
+          // deviceType em desuso — deviceProfile é a única autoridade
+          const dp = String(device.deviceProfile || '').toUpperCase();
 
-          // LOJA: deviceType = HIDROMETRO AND deviceProfile = HIDROMETRO
-          if (dt === 'HIDROMETRO' && dp === 'HIDROMETRO') {
+          // LOJA: deviceProfile = HIDROMETRO
+          if (dp === 'HIDROMETRO') {
             classificationDebugLog.byType['loja'] = (classificationDebugLog.byType['loja'] || 0) + 1;
             return 'loja';
           }
 
-          // ENTRADA: deviceType = HIDROMETRO_SHOPPING OR (deviceType = HIDROMETRO AND deviceProfile = HIDROMETRO_SHOPPING)
-          if (dt === 'HIDROMETRO_SHOPPING' || (dt === 'HIDROMETRO' && dp === 'HIDROMETRO_SHOPPING')) {
+          // ENTRADA: deviceProfile = HIDROMETRO_SHOPPING
+          if (dp === 'HIDROMETRO_SHOPPING') {
             classificationDebugLog.byType['entrada'] = (classificationDebugLog.byType['entrada'] || 0) + 1;
             return 'entrada';
           }
 
-          // AREA_COMUM: Check for explicit HIDROMETRO_AREA_COMUM types
-          if (dt.includes('AREA_COMUM') || dp.includes('AREA_COMUM')) {
+          // AREA_COMUM: Check for explicit HIDROMETRO_AREA_COMUM profile
+          if (dp.includes('AREA_COMUM')) {
             classificationDebugLog.byType['areacomum_explicit'] =
               (classificationDebugLog.byType['areacomum_explicit'] || 0) + 1;
             return 'areacomum';
@@ -7367,11 +7298,10 @@ const MyIOOrchestrator = (() => {
             classificationDebugLog.defaults.push({
               label: device.label,
               aliasName: device._aliasName,
-              dt: dt || 'NULL',
               dp: dp || 'NULL',
             });
             LogHelper.warn(
-              `[Orchestrator] ⚠️ UNCLASSIFIED water device: "${device.label}" (aliasName=${device._aliasName || 'N/A'}, deviceType=${dt || 'NULL'}, deviceProfile=${dp || 'NULL'})`
+              `[Orchestrator] ⚠️ UNCLASSIFIED water device: "${device.label}" (aliasName=${device._aliasName || 'N/A'}, deviceProfile=${dp || 'NULL'})`
             );
           }
 

--- a/src/thingsboard/MYIO-SIM/v5.2.0/STORES/controller.js
+++ b/src/thingsboard/MYIO-SIM/v5.2.0/STORES/controller.js
@@ -678,7 +678,8 @@ async function renderList(visible) {
     // RFC-0102: Simplified tbId resolution - orchestrator already provides valid tbId
     const resolvedTbId = it.tbId || it.id || it.ingestionId;
 
-    const deviceType = it.label.includes('dministra') ? '3F_MEDIDOR' : it.deviceType;
+    // deviceProfile é a única autoridade de classificação (deviceType em desuso; label não classifica)
+    const deviceType = it.deviceProfile;
 
     // RFC-0140: STORES represents store allocation, not physical meters
     // All stores should show as "normal" - status calculation doesn't make sense for store meters
@@ -771,7 +772,7 @@ async function renderList(visible) {
       domain: 'energy',
 
       // Metadados
-      deviceType: deviceType,
+      deviceType: deviceType, // campo legado (deviceType em desuso) — preenchido do profile
       deviceProfile: it.deviceProfile || 'N/D', // RFC-0091: Added for Settings
       deviceStatus: deviceStatus, // RFC-0091: Now properly calculated
       perc: it.perc ?? 0,
@@ -932,7 +933,7 @@ async function renderList(visible) {
             label: it.label,
             jwtToken: jwt,
             domain: WIDGET_DOMAIN, // Same as EQUIPMENTS
-            deviceType: entityObject.deviceType, // RFC-0091: Pass deviceType for Power Limits feature
+            deviceType: entityObject.deviceProfile, // campo legado (deviceType em desuso) — preenchido do profile
             deviceProfile: entityObject.deviceProfile, // RFC-0091: Pass deviceProfile for 3F_MEDIDOR fallback
             customerName: entityObject.customerName, // RFC-0091: Pass shopping name
             connectionData: {
@@ -1671,7 +1672,7 @@ function emitWaterTelemetry(widgetType, periodKey) {
       id: item.id || item.entityId || '',
       label: item.label || item.name || '',
       value: item.value || 0,
-      deviceType: item.deviceType || 'HIDROMETRO',
+      deviceType: item.deviceProfile || 'HIDROMETRO', // campo legado (deviceType em desuso) — preenchido do profile
     }));
 
     const payload = {
@@ -1793,7 +1794,7 @@ async function hydrateAndRender() {
             label: name,
             value: Number(device.total_value || 0),
             perc: 0,
-            deviceType: device.deviceType || '3F_MEDIDOR',
+            deviceType: device.deviceProfile || '3F_MEDIDOR', // campo legado (deviceType em desuso) — preenchido do profile
             slaveId: device.slaveId || null,
             centralId: device.centralId || device.gatewayId || null,
             centralName: device.centralName || device.ownerName || null,
@@ -1831,13 +1832,12 @@ async function hydrateAndRender() {
       const energyCache = orchestrator.getCache(WIDGET_DOMAIN);
       LogHelper.log(`[STORES] RFC-0102 Fallback: using energyCache with isStoreDevice filter`);
 
-      // RFC-0106: Filter for lojas only - BOTH deviceType AND deviceProfile must be '3F_MEDIDOR'
+      // RFC-0106: Filter for lojas only - deviceProfile é a única autoridade (deviceType em desuso)
       const isStoreDeviceFallback =
         window.MyIOUtils?.isStoreDevice ||
         ((item) => {
           const deviceProfile = String(item?.deviceProfile || '').toUpperCase();
-          const deviceType = String(item?.deviceType || '').toUpperCase();
-          return deviceProfile === '3F_MEDIDOR' && deviceType === '3F_MEDIDOR';
+          return deviceProfile.startsWith('3F_MEDIDOR');
         });
 
       if (energyCache && energyCache.size > 0) {
@@ -1846,7 +1846,7 @@ async function hydrateAndRender() {
         const processedTbIds = new Set();
 
         energyCache.forEach((item, _key) => {
-          // Filter for lojas only - BOTH deviceType AND deviceProfile must be '3F_MEDIDOR'
+          // Filter for lojas only - deviceProfile é a única autoridade (deviceType em desuso)
           if (!isStoreDeviceFallback(item)) return;
 
           // RFC-0108: Skip duplicates - cache may have same item under tbId and ingestionId keys
@@ -1870,7 +1870,7 @@ async function hydrateAndRender() {
             label: displayLabel,
             value: Number(item.total_value || item.value || 0),
             perc: 0,
-            deviceType: item.deviceType || '3F_MEDIDOR',
+            deviceType: item.deviceProfile || '3F_MEDIDOR', // campo legado (deviceType em desuso) — preenchido do profile
             connectionStatus: item.connectionStatus || 'online',
             deviceProfile: item.deviceProfile || '3F_MEDIDOR',
             updatedIdentifiers: {},
@@ -2248,14 +2248,13 @@ self.onInit = async function () {
     LogHelper.log(`[TELEMETRY] 🔄 Processing data from orchestrator...`);
     LogHelper.log(`[TELEMETRY] Received ${items.length} items from orchestrator for domain ${domain}`);
 
-    // RFC-0106: Filter for lojas only - BOTH deviceType AND deviceProfile must be '3F_MEDIDOR'
+    // RFC-0106: Filter for lojas only - deviceProfile é a única autoridade (deviceType em desuso)
     // Use isStoreDevice from MyIOUtils or inline check
     const isStoreDevice =
       window.MyIOUtils?.isStoreDevice ||
       ((item) => {
         const deviceProfile = String(item?.deviceProfile || '').toUpperCase();
-        const deviceType = String(item?.deviceType || '').toUpperCase();
-        return deviceProfile === '3F_MEDIDOR' && deviceType === '3F_MEDIDOR';
+        return deviceProfile.startsWith('3F_MEDIDOR');
       });
 
     // RFC-0102: Filter and map items from orchestrator
@@ -2263,12 +2262,10 @@ self.onInit = async function () {
     items.forEach((item) => {
       const ingestionId = item.ingestionId || item.id;
 
-      // Filter for lojas only - BOTH deviceType AND deviceProfile must be '3F_MEDIDOR'
+      // Filter for lojas only - deviceProfile é a única autoridade (deviceType em desuso)
       if (!isStoreDevice(item)) {
         LogHelper.log(
-          `[TELEMETRY] Skipping non-loja device: ${item.label || item.name} (deviceType=${
-            item.deviceType
-          }, deviceProfile=${item.deviceProfile})`
+          `[TELEMETRY] Skipping non-loja device: ${item.label || item.name} (deviceProfile=${item.deviceProfile})`
         );
         return; // Skip non-lojas devices
       }
@@ -2291,7 +2288,7 @@ self.onInit = async function () {
         label: displayLabel, // Use label (human-readable) first, fallback to name
         value: Number(item.value || item.total_value || 0),
         perc: 0,
-        deviceType: item.deviceType || '3F_MEDIDOR',
+        deviceType: item.deviceProfile || '3F_MEDIDOR', // campo legado (deviceType em desuso) — preenchido do profile
         slaveId: item.slaveId || null,
         centralId: item.centralId || item.gatewayId || null,
         centralName: item.assetName || item.centralName || null,

--- a/src/thingsboard/MYIO-SIM/v5.2.0/TELEMETRY/controller.js
+++ b/src/thingsboard/MYIO-SIM/v5.2.0/TELEMETRY/controller.js
@@ -505,7 +505,7 @@ function initializeCards(devices) {
             label: device.labelOrName,
             jwtToken: jwt,
             domain: WIDGET_DOMAIN,
-            deviceType: device.deviceType,
+            deviceType: device.deviceProfile, // campo legado (deviceType em desuso) — preenchido do profile
             deviceProfile: device.deviceProfile,
             customerName: device.customerName,
             connectionData: {
@@ -770,7 +770,7 @@ async function processAndRenderDevices(cache) {
       labelOrName: item.label || item.name || 'Unknown',
       deviceIdentifier: item.identifier || 'Sem identificador',
       val: displayValue,
-      deviceType: item.deviceType || '',
+      deviceType: item.deviceProfile || '', // campo legado (deviceType em desuso) — preenchido do profile
       deviceProfile: item.deviceProfile || '',
       deviceStatus: deviceStatus,
       connectionStatus: item.connectionStatus || 'offline',

--- a/src/thingsboard/MYIO-SIM/v5.2.0/TEMPERATURE_SENSORS/controller.js
+++ b/src/thingsboard/MYIO-SIM/v5.2.0/TEMPERATURE_SENSORS/controller.js
@@ -257,7 +257,7 @@ function initializeSensorCards(sensors) {
               label: sensor.label || sensor.name,
               jwtToken: jwt,
               domain: WIDGET_DOMAIN,
-              deviceType: sensor.deviceType || 'TERMOSTATO',
+              deviceType: sensor.deviceProfile || 'TERMOSTATO', // campo legado (deviceType em desuso) — preenchido do profile
               deviceProfile: sensor.deviceProfile || 'TERMOSTATO',
               customerId: sensor.customerId,
               customerName: sensor.customerName,

--- a/src/thingsboard/MYIO-SIM/v5.2.0/TEMPERATURE_WITHOUT_CLIMATE_CONTROL/controller.js
+++ b/src/thingsboard/MYIO-SIM/v5.2.0/TEMPERATURE_WITHOUT_CLIMATE_CONTROL/controller.js
@@ -266,7 +266,7 @@ function initializeSensorCards(sensors) {
                 label: sensor.label || sensor.name,
                 jwtToken: jwt,
                 domain: WIDGET_DOMAIN,
-                deviceType: sensor.deviceType || 'TERMOSTATO',
+                deviceType: sensor.deviceProfile || 'TERMOSTATO', // campo legado (deviceType em desuso) — preenchido do profile
                 deviceProfile: sensor.deviceProfile || 'TERMOSTATO',
                 customerId: sensor.customerId,
                 customerName: sensor.customerName,

--- a/src/thingsboard/MYIO-SIM/v5.2.0/WATER_COMMON_AREA/controller.js
+++ b/src/thingsboard/MYIO-SIM/v5.2.0/WATER_COMMON_AREA/controller.js
@@ -387,11 +387,8 @@ function buildAuthoritativeItems() {
     // RFC-0140 FIX: Default to HIDROMETRO_AREA_COMUM since this is the WATER_COMMON_AREA widget
     // If deviceProfile is not set in ThingsBoard, assume it's area comum (not lojas)
     const deviceProfile = attrs.deviceProfile || 'HIDROMETRO_AREA_COMUM';
-    let deviceTypeToDisplay = attrs.deviceType || 'HIDROMETRO';
-
-    if (deviceTypeToDisplay === '3F_MEDIDOR' && deviceProfile !== 'N/D') {
-      deviceTypeToDisplay = deviceProfile;
-    }
+    // campo legado (deviceType em desuso) — preenchido do profile
+    const deviceTypeToDisplay = deviceProfile;
 
     return {
       id: tbId || ingestionId, // para seleção/toggle
@@ -417,28 +414,20 @@ function buildAuthoritativeItems() {
   });
 
   // RFC-0140 FIX: Filter to include ONLY area comum devices
-  // Rules:
-  // - deviceType = HIDROMETRO_AREA_COMUM (any deviceProfile)
-  // - OR deviceType = HIDROMETRO AND deviceProfile = HIDROMETRO_AREA_COMUM
-  // This excludes HIDROMETRO + HIDROMETRO (lojas) from appearing in WATER_COMMON_AREA
+  // Rules (deviceProfile é a única autoridade de classificação; deviceType em desuso):
+  // - deviceProfile = HIDROMETRO_AREA_COMUM (ou contém AREA_COMUM)
+  // This excludes HIDROMETRO (lojas) from appearing in WATER_COMMON_AREA
   const filtered = mapped.filter((item) => {
-    const dt = String(item.deviceType || '').toUpperCase();
-    // RFC-0140: If deviceProfile is null/empty, assume it equals deviceType
-    const dp = String(item.deviceProfile || item.deviceType || '').toUpperCase();
+    const dp = String(item.deviceProfile || '').toUpperCase();
 
-    // Accept if deviceType is explicitly HIDROMETRO_AREA_COMUM
-    if (dt === 'HIDROMETRO_AREA_COMUM' || dt.includes('AREA_COMUM')) {
+    // Accept if deviceProfile is HIDROMETRO_AREA_COMUM
+    if (dp === 'HIDROMETRO_AREA_COMUM' || dp.includes('AREA_COMUM')) {
       return true;
     }
 
-    // Accept if deviceType = HIDROMETRO AND deviceProfile = HIDROMETRO_AREA_COMUM
-    if (dt === 'HIDROMETRO' && (dp === 'HIDROMETRO_AREA_COMUM' || dp.includes('AREA_COMUM'))) {
-      return true;
-    }
-
-    // Reject everything else (including HIDROMETRO + HIDROMETRO which are lojas)
+    // Reject everything else (including HIDROMETRO which are lojas)
     LogHelper.log(
-      `[WATER_COMMON_AREA] Filtering out device: ${item.label} (deviceType=${dt}, deviceProfile=${dp})`
+      `[WATER_COMMON_AREA] Filtering out device: ${item.label} (deviceProfile=${dp})`
     );
     return false;
   });
@@ -739,7 +728,7 @@ async function renderList(visible) {
       pulses: it.pulses || 0,
 
       // Metadados
-      deviceType: it.deviceType || 'HIDROMETRO',
+      deviceType: it.deviceProfile || 'HIDROMETRO', // campo legado (deviceType em desuso) — preenchido do profile
       deviceProfile: it.deviceProfile || 'HIDROMETRO',
       deviceStatus: deviceStatus,
       connectionStatus: 'online', // RFC-0144: Force connectionStatus to 'online' for water area comum
@@ -770,17 +759,13 @@ async function renderList(visible) {
 
     // RFC-0140 FORCE CHECK: Skip rendering if device is NOT area comum
     // This is the final safety check before rendering
-    const dtCheck = String(it.deviceType || '').toUpperCase();
-    // RFC-0140: If deviceProfile is null/empty, assume it equals deviceType
-    const dpCheck = String(it.deviceProfile || it.deviceType || '').toUpperCase();
-    const isAreaComum =
-      dtCheck === 'HIDROMETRO_AREA_COMUM' ||
-      dtCheck.includes('AREA_COMUM') ||
-      (dtCheck === 'HIDROMETRO' && (dpCheck === 'HIDROMETRO_AREA_COMUM' || dpCheck.includes('AREA_COMUM')));
+    // deviceProfile é a única autoridade de classificação (deviceType em desuso)
+    const dpCheck = String(it.deviceProfile || '').toUpperCase();
+    const isAreaComum = dpCheck === 'HIDROMETRO_AREA_COMUM' || dpCheck.includes('AREA_COMUM');
 
     if (!isAreaComum) {
       LogHelper.warn(
-        `[WATER_COMMON_AREA] FORCE CHECK: Skipping non-area-comum device: ${it.label} (deviceType=${dtCheck}, deviceProfile=${dpCheck})`
+        `[WATER_COMMON_AREA] FORCE CHECK: Skipping non-area-comum device: ${it.label} (deviceProfile=${dpCheck})`
       );
       container.remove(); // Remove the empty container
       continue;
@@ -883,7 +868,7 @@ async function renderList(visible) {
             label: it.label,
             jwtToken: jwt,
             domain: WIDGET_DOMAIN,
-            deviceType: entityObject.deviceType,
+            deviceType: entityObject.deviceProfile, // campo legado (deviceType em desuso) — preenchido do profile
             deviceProfile: entityObject.deviceProfile,
             customerName: entityObject.customerName,
             connectionData: {
@@ -1388,7 +1373,7 @@ self.onInit = async function () {
       label: item.label || item.identifier || item.id,
       value: Number(item.value || 0),
       perc: 0,
-      deviceType: item.deviceType || 'HIDROMETRO',
+      deviceType: item.deviceProfile || 'HIDROMETRO', // campo legado (deviceType em desuso) — preenchido do profile
       slaveId: item.slaveId || null,
       centralId: item.centralId || null,
       updatedIdentifiers: {},
@@ -1654,7 +1639,7 @@ self.onInit = async function () {
           slaveId: item.slaveId || null,
           centralId: item.centralId || null,
           centralName: item.centralName || null,
-          deviceType: item.deviceType || 'HIDROMETRO_AREA_COMUM',
+          deviceType: item.deviceProfile || 'HIDROMETRO_AREA_COMUM', // campo legado (deviceType em desuso) — preenchido do profile
           deviceProfile: item.deviceProfile || 'HIDROMETRO_AREA_COMUM',
           updatedIdentifiers: {},
           connectionStatusTime: item.lastConnectTime || null,
@@ -1679,24 +1664,18 @@ self.onInit = async function () {
 
       // RFC-0140 FIX: Filter to include ONLY area comum devices (same logic as buildAuthoritativeItems)
       // This ensures consistency even when data comes from MAIN
+      // deviceProfile é a única autoridade de classificação (deviceType em desuso)
       STATE.itemsBase = mappedItems.filter((item) => {
-        const dt = String(item.deviceType || '').toUpperCase();
-        // RFC-0140: If deviceProfile is null/empty, assume it equals deviceType
-        const dp = String(item.deviceProfile || item.deviceType || '').toUpperCase();
+        const dp = String(item.deviceProfile || '').toUpperCase();
 
-        // Accept if deviceType is explicitly HIDROMETRO_AREA_COMUM
-        if (dt === 'HIDROMETRO_AREA_COMUM' || dt.includes('AREA_COMUM')) {
+        // Accept if deviceProfile is HIDROMETRO_AREA_COMUM
+        if (dp === 'HIDROMETRO_AREA_COMUM' || dp.includes('AREA_COMUM')) {
           return true;
         }
 
-        // Accept if deviceType = HIDROMETRO AND deviceProfile = HIDROMETRO_AREA_COMUM
-        if (dt === 'HIDROMETRO' && (dp === 'HIDROMETRO_AREA_COMUM' || dp.includes('AREA_COMUM'))) {
-          return true;
-        }
-
-        // Reject everything else (including HIDROMETRO + HIDROMETRO which are lojas)
+        // Reject everything else (including HIDROMETRO which are lojas)
         LogHelper.log(
-          `[WATER_COMMON_AREA] Filtering out MAIN item: ${item.label} (deviceType=${dt}, deviceProfile=${dp})`
+          `[WATER_COMMON_AREA] Filtering out MAIN item: ${item.label} (deviceProfile=${dp})`
         );
         return false;
       });

--- a/src/thingsboard/MYIO-SIM/v5.2.0/WATER_STORES/controller.js
+++ b/src/thingsboard/MYIO-SIM/v5.2.0/WATER_STORES/controller.js
@@ -387,11 +387,8 @@ function buildAuthoritativeItems() {
     // RFC-0140 FIX: Default to hidrometro_lojas since this is the WATER_STORES widget
     // If deviceProfile is not set in ThingsBoard, assume it's lojas (not area comum)
     const deviceProfile = attrs.deviceProfile || 'hidrometro_lojas';
-    let deviceTypeToDisplay = attrs.deviceType || 'HIDROMETRO';
-
-    if (deviceTypeToDisplay === '3F_MEDIDOR' && deviceProfile !== 'N/D') {
-      deviceTypeToDisplay = deviceProfile;
-    }
+    // campo legado (deviceType em desuso) — preenchido do profile
+    const deviceTypeToDisplay = deviceProfile;
 
     return {
       id: tbId || ingestionId, // para seleção/toggle
@@ -417,40 +414,33 @@ function buildAuthoritativeItems() {
   });
 
   // RFC-0140 FIX: Filter to include ONLY LOJAS devices
-  // Rules:
-  // - deviceType = HIDROMETRO AND deviceProfile = HIDROMETRO (exact match = loja)
-  // - OR deviceType contains LOJA
+  // Rules (deviceProfile é a única autoridade de classificação; deviceType em desuso):
+  // - deviceProfile = HIDROMETRO (exato) = loja
+  // - OR deviceProfile contém LOJA
   // This excludes HIDROMETRO_AREA_COMUM from appearing in WATER_STORES
   const filtered = mapped.filter((item) => {
-    const dt = String(item.deviceType || '').toUpperCase();
-    // RFC-0140: If deviceProfile is null/empty, assume it equals deviceType
-    const dp = String(item.deviceProfile || item.deviceType || '').toUpperCase();
-
-    // Accept if deviceType contains LOJA
-    if (dt.includes('LOJA')) {
-      return true;
-    }
-
-    // Accept if deviceType = HIDROMETRO AND deviceProfile = HIDROMETRO (both same = loja)
-    if (dt === 'HIDROMETRO' && dp === 'HIDROMETRO') {
-      return true;
-    }
+    const dp = String(item.deviceProfile || '').toUpperCase();
 
     // Reject AREA_COMUM devices
-    if (dt.includes('AREA_COMUM') || dp.includes('AREA_COMUM')) {
+    if (dp.includes('AREA_COMUM')) {
       LogHelper.log(
-        `[WATER_STORES] Filtering out area comum device: ${item.label} (deviceType=${dt}, deviceProfile=${dp})`
+        `[WATER_STORES] Filtering out area comum device: ${item.label} (deviceProfile=${dp})`
       );
       return false;
     }
 
-    // Accept other HIDROMETRO devices as lojas by default
-    if (dt === 'HIDROMETRO') {
+    // Accept if deviceProfile contains LOJA
+    if (dp.includes('LOJA')) {
+      return true;
+    }
+
+    // Accept HIDROMETRO devices as lojas
+    if (dp === 'HIDROMETRO') {
       return true;
     }
 
     LogHelper.log(
-      `[WATER_STORES] Filtering out device: ${item.label} (deviceType=${dt}, deviceProfile=${dp})`
+      `[WATER_STORES] Filtering out device: ${item.label} (deviceProfile=${dp})`
     );
     return false;
   });
@@ -751,7 +741,7 @@ async function renderList(visible) {
       pulses: it.pulses || 0,
 
       // Metadados
-      deviceType: it.deviceType || 'HIDROMETRO',
+      deviceType: it.deviceProfile || 'HIDROMETRO', // campo legado (deviceType em desuso) — preenchido do profile
       deviceProfile: it.deviceProfile || 'HIDROMETRO',
       deviceStatus: deviceStatus,
       connectionStatus: 'online', // RFC-0144: Force connectionStatus to 'online' for water lojas
@@ -782,22 +772,18 @@ async function renderList(visible) {
 
     // RFC-0140 FORCE CHECK: Skip rendering if device is NOT a loja
     // This is the final safety check before rendering
-    const dtCheck = String(it.deviceType || '').toUpperCase();
-    // RFC-0140: If deviceProfile is null/empty, assume it equals deviceType
-    const dpCheck = String(it.deviceProfile || it.deviceType || '').toUpperCase();
+    // deviceProfile é a única autoridade de classificação (deviceType em desuso)
+    const dpCheck = String(it.deviceProfile || '').toUpperCase();
 
-    // Check if it's a LOJA device (HIDROMETRO + HIDROMETRO or contains LOJA)
-    const isLoja =
-      dtCheck.includes('LOJA') ||
-      (dtCheck === 'HIDROMETRO' && dpCheck === 'HIDROMETRO') ||
-      (dtCheck === 'HIDROMETRO' && !dpCheck.includes('AREA_COMUM'));
+    // Check if it's a LOJA device (HIDROMETRO or contains LOJA)
+    const isLoja = dpCheck.includes('LOJA') || dpCheck === 'HIDROMETRO';
 
     // Skip AREA_COMUM devices
-    const isAreaComum = dtCheck.includes('AREA_COMUM') || dpCheck.includes('AREA_COMUM');
+    const isAreaComum = dpCheck.includes('AREA_COMUM');
 
     if (!isLoja || isAreaComum) {
       LogHelper.warn(
-        `[WATER_STORES] FORCE CHECK: Skipping non-loja device: ${it.label} (deviceType=${dtCheck}, deviceProfile=${dpCheck})`
+        `[WATER_STORES] FORCE CHECK: Skipping non-loja device: ${it.label} (deviceProfile=${dpCheck})`
       );
       container.remove(); // Remove the empty container
       continue;
@@ -900,7 +886,7 @@ async function renderList(visible) {
             label: it.label,
             jwtToken: jwt,
             domain: WIDGET_DOMAIN,
-            deviceType: entityObject.deviceType,
+            deviceType: entityObject.deviceProfile, // campo legado (deviceType em desuso) — preenchido do profile
             deviceProfile: entityObject.deviceProfile,
             customerName: entityObject.customerName,
             connectionData: {
@@ -1401,7 +1387,7 @@ self.onInit = async function () {
       label: item.label || item.identifier || item.id,
       value: Number(item.value || 0),
       perc: 0,
-      deviceType: item.deviceType || 'HIDROMETRO',
+      deviceType: item.deviceProfile || 'HIDROMETRO', // campo legado (deviceType em desuso) — preenchido do profile
       slaveId: item.slaveId || null,
       centralId: item.centralId || null,
       updatedIdentifiers: {},
@@ -1667,7 +1653,7 @@ self.onInit = async function () {
           slaveId: item.slaveId || null,
           centralId: item.centralId || null,
           centralName: item.centralName || null,
-          deviceType: item.deviceType || 'hidrometro_lojas',
+          deviceType: item.deviceProfile || 'hidrometro_lojas', // campo legado (deviceType em desuso) — preenchido do profile
           deviceProfile: item.deviceProfile || 'hidrometro_lojas',
           updatedIdentifiers: {},
           connectionStatusTime: item.lastConnectTime || null,
@@ -1692,36 +1678,30 @@ self.onInit = async function () {
 
       // RFC-0140 FIX: Filter to include ONLY LOJAS devices (same logic as buildAuthoritativeItems)
       // This ensures consistency even when data comes from MAIN
+      // deviceProfile é a única autoridade de classificação (deviceType em desuso)
       STATE.itemsBase = mappedItems.filter((item) => {
-        const dt = String(item.deviceType || '').toUpperCase();
-        // RFC-0140: If deviceProfile is null/empty, assume it equals deviceType
-        const dp = String(item.deviceProfile || item.deviceType || '').toUpperCase();
+        const dp = String(item.deviceProfile || '').toUpperCase();
 
         // Reject AREA_COMUM devices
-        if (dt.includes('AREA_COMUM') || dp.includes('AREA_COMUM')) {
+        if (dp.includes('AREA_COMUM')) {
           LogHelper.log(
-            `[WATER_STORES] Filtering out area comum MAIN item: ${item.label} (deviceType=${dt}, deviceProfile=${dp})`
+            `[WATER_STORES] Filtering out area comum MAIN item: ${item.label} (deviceProfile=${dp})`
           );
           return false;
         }
 
-        // Accept if deviceType contains LOJA
-        if (dt.includes('LOJA')) {
+        // Accept if deviceProfile contains LOJA
+        if (dp.includes('LOJA')) {
           return true;
         }
 
-        // Accept if deviceType = HIDROMETRO AND deviceProfile = HIDROMETRO (both same = loja)
-        if (dt === 'HIDROMETRO' && dp === 'HIDROMETRO') {
-          return true;
-        }
-
-        // Accept other HIDROMETRO devices as lojas by default
-        if (dt === 'HIDROMETRO') {
+        // Accept HIDROMETRO devices as lojas
+        if (dp === 'HIDROMETRO') {
           return true;
         }
 
         LogHelper.log(
-          `[WATER_STORES] Filtering out MAIN item: ${item.label} (deviceType=${dt}, deviceProfile=${dp})`
+          `[WATER_STORES] Filtering out MAIN item: ${item.label} (deviceProfile=${dp})`
         );
         return false;
       });

--- a/src/thingsboard/MYIO-SIM/v5.2.0_UNIQUE/controller.js
+++ b/src/thingsboard/MYIO-SIM/v5.2.0_UNIQUE/controller.js
@@ -8050,7 +8050,11 @@ function classifyAllDevices(data) {
   // Process each device with all its rows
   for (const rows of deviceRowsMap.values()) {
     const device = extractDeviceMetadataFromRows(rows);
-    const domain = window.MyIOLibrary.getDomainFromDeviceType(device.deviceType);
+    // deviceProfile é a autoridade (deviceType só quando não há profile) — um
+    // hidrômetro com deviceType=MOTOR errado tem que cair em water, não energy.
+    const domain = window.MyIOLibrary.getDomainFromDeviceType(
+      device.deviceProfile || device.deviceType
+    );
     const context = window.MyIOLibrary.detectContext(device, domain);
 
     if (classified[domain]?.[context] !== undefined) {

--- a/src/thingsboard/MYIO-SIM/v5.2.0_UNIQUE/controller.js
+++ b/src/thingsboard/MYIO-SIM/v5.2.0_UNIQUE/controller.js
@@ -7570,17 +7570,18 @@ function buildEnergyCategoryDataByShopping(classified) {
   return shoppings.map((s) => {
     const total = s.totalConsumption;
 
-    // Subcategories within Equipamentos (counts only; consumption not split at this level)
+    // Subcategories within Equipamentos (counts only; consumption not split at
+    // this level) — pelo deviceProfile (deviceType em desuso)
     const elevatorsCount = s.equipDevices.filter((d) =>
-      (d.deviceType || '').toLowerCase().includes('elevador')
+      (d.deviceProfile || '').toLowerCase().includes('elevador')
     ).length;
     const escalatorsCount = s.equipDevices.filter((d) =>
-      (d.deviceType || '').toLowerCase().includes('escada')
+      (d.deviceProfile || '').toLowerCase().includes('escada')
     ).length;
     const hvacCount = s.equipDevices.filter(
       (d) =>
-        (d.deviceType || '').toLowerCase().includes('ar_condicionado') ||
-        (d.deviceType || '').toLowerCase().includes('hvac')
+        (d.deviceProfile || '').toLowerCase().includes('ar_condicionado') ||
+        (d.deviceProfile || '').toLowerCase().includes('hvac')
     ).length;
     const othersCount = s.equipDevices.length - elevatorsCount - escalatorsCount - hvacCount;
 
@@ -7863,11 +7864,9 @@ function buildCustomersEnergyBreakdown(classified) {
     const entry = shoppingMap.get(normalizedName);
     const value = Number(device.value || device.consumption || 0);
 
-    // Check if it's a store device (3F_MEDIDOR)
-    const deviceType = (device.deviceType || '').toUpperCase();
-    // RFC-0140: If deviceProfile is null/empty, assume it equals deviceType
-    const deviceProfile = (device.deviceProfile || device.deviceType || '').toUpperCase();
-    const isStore = deviceProfile === '3F_MEDIDOR' && deviceType === '3F_MEDIDOR';
+    // Check if it's a store device — deviceProfile apenas (deviceType em desuso)
+    const deviceProfile = (device.deviceProfile || '').toUpperCase();
+    const isStore = deviceProfile.startsWith('3F_MEDIDOR');
 
     if (isStore) {
       entry.lojas += value;
@@ -8050,11 +8049,9 @@ function classifyAllDevices(data) {
   // Process each device with all its rows
   for (const rows of deviceRowsMap.values()) {
     const device = extractDeviceMetadataFromRows(rows);
-    // deviceProfile é a autoridade (deviceType só quando não há profile) — um
-    // hidrômetro com deviceType=MOTOR errado tem que cair em water, não energy.
-    const domain = window.MyIOLibrary.getDomainFromDeviceType(
-      device.deviceProfile || device.deviceType
-    );
+    // deviceProfile é a ÚNICA autoridade (deviceType em desuso) — um hidrômetro
+    // com deviceType=MOTOR errado tem que cair em water, não energy.
+    const domain = window.MyIOLibrary.getDomainFromDeviceType(device.deviceProfile);
     const context = window.MyIOLibrary.detectContext(device, domain);
 
     if (classified[domain]?.[context] !== undefined) {
@@ -8210,10 +8207,11 @@ function extractDeviceMetadataFromRows(rows) {
     }
   }
 
-  // RFC-0111: Classification is based ONLY on deviceType from ThingsBoard
-  // No name-based inference - deviceType must be properly configured in ThingsBoard
-  const deviceType = dataKeyValues['deviceType'] || 'SEM_DEVICE_TYPE';
-  const deviceProfile = dataKeyValues['deviceProfile'] || deviceType;
+  // RFC-0111 (2026-07-14): classification is based ONLY on deviceProfile —
+  // deviceType está EM DESUSO (chegava errado do provisionamento) e não entra
+  // em NENHUMA decisão; o campo continua no item apenas por compat de payload.
+  const deviceType = dataKeyValues['deviceType'] || '';
+  const deviceProfile = dataKeyValues['deviceProfile'] || '';
 
   // RFC-0140 FIX: ThingsBoard 'consumption' is INSTANTANEOUS POWER (kW), NOT accumulated consumption (kWh)
   // consumption/val/value for cards should ONLY come from ingestion API enrichment
@@ -8230,8 +8228,8 @@ function extractDeviceMetadataFromRows(rows) {
   const pulsesTs = dataKeyTimestamps['pulses'] || null;
   const temperatureTs = dataKeyTimestamps[DOMAIN_TEMPERATURE] || null;
   const waterLevelTs = dataKeyTimestamps['water_level'] || null;
-  const isWater = deviceType.includes('HIDROMETRO');
-  const isTemperature = deviceType.includes('TERMOSTATO');
+  const isWater = deviceProfile.includes('HIDROMETRO');
+  const isTemperature = deviceProfile.includes('TERMOSTATO');
   const domain = isWater ? DOMAIN_WATER : isTemperature ? DOMAIN_TEMPERATURE : DOMAIN_ENERGY;
 
   // RFC-0110: Get domain-specific telemetry timestamp

--- a/src/thingsboard/MYIO-SIM/v5.2.0_UNIQUE/controller.js
+++ b/src/thingsboard/MYIO-SIM/v5.2.0_UNIQUE/controller.js
@@ -8051,7 +8051,10 @@ function classifyAllDevices(data) {
     const device = extractDeviceMetadataFromRows(rows);
     // deviceProfile é a ÚNICA autoridade (deviceType em desuso) — um hidrômetro
     // com deviceType=MOTOR errado tem que cair em water, não energy.
-    const domain = window.MyIOLibrary.getDomainFromDeviceType(device.deviceProfile);
+    // getDomainFromProfile é o nome canônico; fallback para o alias em libs antigas.
+    const domain = (window.MyIOLibrary.getDomainFromProfile || window.MyIOLibrary.getDomainFromDeviceType)(
+      device.deviceProfile
+    );
     const context = window.MyIOLibrary.detectContext(device, domain);
 
     if (classified[domain]?.[context] !== undefined) {

--- a/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/HEADER/controller.js
+++ b/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/HEADER/controller.js
@@ -2236,7 +2236,7 @@ self.onInit = async function ({ strt: presetStart, end: presetEnd } = {}) {
             identifier: d.identifier || '',
             label: d.label || d.identifier || '',
             domain,
-            deviceProfile: d.deviceProfile || d.deviceType || '',
+            deviceProfile: d.deviceProfile || '', // deviceType em desuso
           });
           return [
             ...(data.energy?.items || []).map((d) => toW(d, 'energy')),

--- a/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/MAIN_VIEW/controller.js
+++ b/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/MAIN_VIEW/controller.js
@@ -1274,23 +1274,16 @@ function inferLabelWidget(row) {
     return 'Lojas';
   }
 
+  // deviceType está EM DESUSO (2026-07-14) — domínio/labelWidget saem SÓ do profile
   const dp = String(row.deviceProfile || '').toUpperCase();
-  const dt = String(row.deviceType || '').toUpperCase();
 
   // Temperature domain
-  if (dp.includes('TERMOSTATO') || dt.includes('TERMOSTATO')) {
+  if (dp.includes('TERMOSTATO')) {
     return 'Temperatura';
   }
 
   // Water domain (hidrômetros + caixas d'água)
-  if (
-    dp.includes('HIDROMETRO') ||
-    dt.includes('HIDROMETRO') ||
-    dp === 'TANK' ||
-    dt === 'TANK' ||
-    dp === 'CAIXA_DAGUA' ||
-    dt === 'CAIXA_DAGUA'
-  ) {
+  if (dp.includes('HIDROMETRO') || dp === 'TANK' || dp === 'CAIXA_DAGUA') {
     const wg = Lib.resolveGroup(row, undefined, 'water').group;
     if (wg === 'ocultos') return 'Ocultos';
     if (wg === 'entrada') return 'Entrada';
@@ -3845,11 +3838,11 @@ function buildSummary(lojas, entrada, areacomum, periodKey) {
 
   for (const item of areacomum) {
     const lw = toStr(item.labelWidget);
-    const dt = toStr(item.deviceType);
     const dp = toStr(item.deviceProfile);
     const label = toStr(item.label);
     const id = toStr(item.identifier);
-    const combined = `${lw} ${dt} ${dp} ${label}`;
+    // deviceType em desuso (2026-07-14) — fora do texto combinado
+    const combined = `${lw} ${dp} ${label}`;
 
     // RFC-0207 (A1b → cleanup): top-level bucket is resolver-only (degrades to
     // 'outros' when the library is missing — logged once above). Identifier-prefix
@@ -5530,7 +5523,8 @@ const MyIOOrchestrator = (() => {
     // RFC-0110 v5: Use library's calculateDeviceStatus if available
     if (lib?.calculateDeviceStatus) {
       // RFC-0130: Get delay based on device profile (stores=60d, equipment=24h, water=48h, temp=24h)
-      const deviceProfile = options.deviceProfile || options.deviceType || '';
+      // deviceType em desuso — profile apenas
+      const deviceProfile = options.deviceProfile || '';
       const delayMins = window.MyIOUtils?.getDelayTimeConnectionInMins?.(deviceProfile);
       const shortDelayMins = SHORT_DELAY_IN_MINS_TO_BYPASS_OFFLINE_STATUS;
       const isDebugDevice = deviceName.includes('HIDR. SCMP110A') || deviceName.includes('HIDR. SCMP110A');
@@ -5693,7 +5687,8 @@ const MyIOOrchestrator = (() => {
     let debugLabel = meta.label || meta.identifier || overrides.label || '';
 
     // RFC-0110 v5: Determine domain and telemetry timestamp for device status calculation
-    const effectiveDeviceType = (meta.deviceProfile || meta.deviceType || '').toLowerCase();
+    // deviceType em desuso (2026-07-14) — domínio sai SÓ do deviceProfile
+    const effectiveDeviceType = (meta.deviceProfile || '').toLowerCase();
     const isWaterDevice =
       effectiveDeviceType.includes('hidrometro') ||
       effectiveDeviceType.includes('water') ||
@@ -5714,8 +5709,8 @@ const MyIOOrchestrator = (() => {
           : meta.consumptionTs);
 
     // RFC-0109 + RFC-0110 v5: Calculate deviceStatus with telemetry timestamp and lastActivityTime fallback
-    // RFC-0130: Pass deviceProfile for delay time calculation
-    const deviceProfile = meta.deviceProfile || meta.deviceType || '';
+    // RFC-0130: Pass deviceProfile for delay time calculation (deviceType em desuso)
+    const deviceProfile = meta.deviceProfile || '';
     let deviceStatus = convertConnectionStatusToDeviceStatus(meta.connectionStatus, debugLabel, {
       domain: domain,
       deviceProfile: deviceProfile,
@@ -5754,8 +5749,9 @@ const MyIOOrchestrator = (() => {
       const limitsToUse = deviceMapLimits || customerLimits;
 
       if (limitsToUse) {
-        const deviceTypeForRanges = meta.deviceProfile || meta.deviceType || '3F_MEDIDOR';
-        const ranges = extractLimitsFromJSON(limitsToUse, deviceTypeForRanges, 'consumption');
+        // deviceType em desuso — a chave do mapInstantaneousPower é o profile
+        const profileForRanges = meta.deviceProfile || '3F_MEDIDOR';
+        const ranges = extractLimitsFromJSON(limitsToUse, profileForRanges, 'consumption');
 
         if (ranges && typeof window.MyIOLibrary?.calculateDeviceStatusWithRanges === 'function') {
           const delayMins = window.MyIOUtils?.getDelayTimeConnectionInMins?.(deviceProfile) ?? 1440;
@@ -5812,10 +5808,10 @@ const MyIOOrchestrator = (() => {
       entityLabel: meta.label || meta.identifier || '',
       name: meta.label || meta.identifier || '',
 
-      // Device classification
-      deviceType: meta.deviceType || '',
+      // Device classification — deviceType em desuso; campos legados preenchidos do profile
+      deviceType: meta.deviceProfile || '',
       deviceProfile: meta.deviceProfile || '',
-      effectiveDeviceType: meta.deviceProfile || meta.deviceType || null,
+      effectiveDeviceType: meta.deviceProfile || null,
 
       // Status (RFC-0109 + RFC-0110)
       deviceStatus: deviceStatus,
@@ -6447,7 +6443,8 @@ const MyIOOrchestrator = (() => {
                 name: meta.label || meta.identifier || 'Sensor',
                 value: temperatureValue, // RFC-0189: API last value when enabled, else ctx.data
                 temperature: temperatureValue,
-                deviceType: meta.deviceType || 'TERMOSTATO',
+                // deviceType em desuso — campo legado preenchido do profile
+                deviceType: meta.deviceProfile || 'TERMOSTATO',
                 offSetTemperature: tempOffset,
                 lastTelemetryTs, // RFC-0189 + RFC-0188: null when API disabled/unavailable (graceful fallback)
               },
@@ -6514,52 +6511,43 @@ const MyIOOrchestrator = (() => {
       let tankItems = [];
       let hidrometroItems = [];
       if (domain === 'water' && metadataByEntityId.size > 0) {
-        // DEBUG: Log all water device types
-        const waterDeviceTypes = [];
+        // DEBUG: Log all water device profiles (deviceType em desuso)
+        const waterDeviceProfiles = [];
         for (const [, meta] of metadataByEntityId.entries()) {
-          waterDeviceTypes.push(meta.deviceType || 'N/A');
+          waterDeviceProfiles.push(meta.deviceProfile || 'N/A');
         }
-        LogHelper.log(`[Orchestrator] 🔍 DEBUG Water device types: ${waterDeviceTypes.join(', ')}`);
+        LogHelper.log(`[Orchestrator] 🔍 DEBUG Water device profiles: ${waterDeviceProfiles.join(', ')}`);
 
         for (const [entityId, meta] of metadataByEntityId.entries()) {
-          const deviceType = String(meta.deviceType || '').toUpperCase();
+          // deviceType está EM DESUSO (2026-07-14) — deviceProfile é a única
+          // autoridade (ex.: "Entrada Sanasa" tinha deviceType=ENTRADA mas
+          // deviceProfile=HIDROMETRO_SHOPPING — é hidrômetro, não tank).
           const deviceProfile = String(meta.deviceProfile || '').toUpperCase();
-          // RFC-0107: Detect tank devices by:
-          // 1. deviceType = TANK or CAIXA_DAGUA
-          // 2. OR has water_level/water_percentage data (even without deviceType)
-          // BUT EXCLUDE hidrometers (devices with pulses data or HIDROMETRO deviceType)
+          // RFC-0107: Detect tank devices by profile TANK/CAIXA_DAGUA
+          // OR water_level/water_percentage data; hidrometers by profile.
           const hasWaterLevelData = meta.waterLevel !== undefined || meta.waterPercentage !== undefined;
-          // deviceProfile is authoritative when present; deviceType is only a fallback.
-          // (e.g. "Entrada Sanasa" has deviceType=ENTRADA but deviceProfile=HIDROMETRO_SHOPPING —
-          //  it is a water meter, not a tank.)
-          const isTankByType = deviceProfile
-            ? deviceProfile === 'TANK' || deviceProfile === 'CAIXA_DAGUA'
-            : deviceType === 'TANK' || deviceType === 'CAIXA_DAGUA';
-          const isHidrometer = deviceProfile
-            ? deviceProfile.includes('HIDROMETRO')
-            : deviceType.includes('HIDROMETRO');
+          const isTankByType = deviceProfile === 'TANK' || deviceProfile === 'CAIXA_DAGUA';
+          const isHidrometer = deviceProfile.includes('HIDROMETRO');
 
           // RFC-0107: Build HIDROMETRO items from ctx.data
-          // Categorization based on deviceType AND deviceProfile:
+          // Categorization based on deviceProfile:
           // - HIDROMETRO_SHOPPING → Entrada (main water meter)
           // - HIDROMETRO_AREA_COMUM → Área Comum (common area meters)
-          // - HIDROMETRO with profile = HIDROMETRO or empty → Lojas (store meters)
+          // - HIDROMETRO (or empty) → Lojas (store meters)
           if (isHidrometer) {
             const pulses = Number(meta.pulses || 0);
-            const dp = (deviceProfile || '').toUpperCase();
-            const dt = deviceType.toUpperCase();
 
-            // Determine labelWidget based on deviceType and deviceProfile
+            // Determine labelWidget based on deviceProfile
             let labelWidget = 'Lojas'; // Default: store meters
             let isEntradaDevice = false;
 
-            if (dt === 'HIDROMETRO_SHOPPING' || dp === 'HIDROMETRO_SHOPPING') {
+            if (deviceProfile === 'HIDROMETRO_SHOPPING') {
               labelWidget = 'Entrada';
               isEntradaDevice = true;
-            } else if (dt === 'HIDROMETRO_AREA_COMUM' || dp === 'HIDROMETRO_AREA_COMUM') {
+            } else if (deviceProfile === 'HIDROMETRO_AREA_COMUM') {
               labelWidget = 'Área Comum';
             }
-            // else: HIDROMETRO with profile = HIDROMETRO or empty → Lojas
+            // else: profile HIDROMETRO → Lojas
 
             // RFC-0111: Use centralized factory
             hidrometroItems.push(
@@ -6572,9 +6560,9 @@ const MyIOOrchestrator = (() => {
                   name: meta.label || meta.identifier || 'Hidrômetro',
                   value: 0, // RFC-0108 FIX: Use 0 as placeholder - real value comes from API enrichment
                   pulses: pulses,
-                  deviceType: deviceType,
-                  deviceProfile: deviceProfile || deviceType,
-                  effectiveDeviceType: deviceProfile || deviceType,
+                  deviceType: deviceProfile, // campo legado (em desuso) — preenchido do profile
+                  deviceProfile: deviceProfile,
+                  effectiveDeviceType: deviceProfile,
                   labelWidget: labelWidget,
                   groupLabel: labelWidget,
                   _isHidrometerDevice: isEntradaDevice,
@@ -6600,9 +6588,9 @@ const MyIOOrchestrator = (() => {
                   value: waterLevel,
                   waterLevel: waterLevel,
                   waterPercentage: waterPercentage,
-                  deviceType: deviceType || 'TANK',
-                  deviceProfile: meta.deviceProfile || deviceType || 'TANK',
-                  effectiveDeviceType: meta.deviceProfile || deviceType || 'TANK',
+                  deviceType: deviceProfile || 'TANK', // campo legado (em desuso)
+                  deviceProfile: deviceProfile || 'TANK',
+                  effectiveDeviceType: deviceProfile || 'TANK',
                   labelWidget: "Caixa D'Água",
                   groupLabel: "Caixa D'Água",
                   _isTankDevice: true,
@@ -6882,21 +6870,15 @@ const MyIOOrchestrator = (() => {
           unmatchedCount++;
         }
 
-        // Use metadata from ThingsBoard datasource (ctx.data) - NO FALLBACKS for deviceType
-        const rawDeviceType = meta.deviceType || null;
+        // deviceType está EM DESUSO (2026-07-14) — deviceProfile é a única
+        // autoridade; a antiga "MASTER RULE" de coerção deviceType→profile morreu.
         const deviceProfile = meta.deviceProfile || null;
 
-        // MASTER RULE for deviceType:
-        // - If deviceType = deviceProfile = '3F_MEDIDOR' → keep as '3F_MEDIDOR' (it's a loja)
-        // - If deviceType = '3F_MEDIDOR' AND deviceProfile != '3F_MEDIDOR' → force deviceType = deviceProfile
-        let deviceType = rawDeviceType;
-        if (rawDeviceType === '3F_MEDIDOR' && deviceProfile && deviceProfile !== '3F_MEDIDOR') {
-          deviceType = deviceProfile;
-        }
-
-        // Skip items with deviceType = domain (placeholder)
-        const dt = (deviceType || '').toLowerCase();
-        if (dt === domainLower) {
+        // Skip placeholder rows do datasource (profile — ou, em rows legadas sem
+        // profile, o deviceType bruto — igual ao nome do domínio). Filtro de lixo
+        // de datasource, não classificação.
+        const placeholderBasis = (deviceProfile || meta.deviceType || '').toLowerCase();
+        if (placeholderBasis === domainLower) {
           continue;
         }
 
@@ -6915,9 +6897,8 @@ const MyIOOrchestrator = (() => {
         const label = labelClean || entityNameClean || 'SEM ETIQUETA';
         const name = apiRow?.name || entityNameClean || '';
 
-        // Infer labelWidget from deviceType/deviceProfile
+        // Infer labelWidget from deviceProfile (deviceType em desuso)
         const labelWidget = inferLabelWidget({
-          deviceType: deviceType,
           deviceProfile: deviceProfile,
           identifier: identifier,
           name: name,
@@ -6938,9 +6919,9 @@ const MyIOOrchestrator = (() => {
               name: name,
               value: getValueFromRow(apiRow),
               perc: 0,
-              deviceType: deviceType,
+              deviceType: deviceProfile || '', // campo legado (em desuso) — preenchido do profile
               deviceProfile: deviceProfile,
-              effectiveDeviceType: deviceProfile || deviceType || null,
+              effectiveDeviceType: deviceProfile || null,
               // API-specific fields
               gatewayId: apiRow?.gatewayId || null,
               customerId: apiRow?.customerId || null,
@@ -7859,10 +7840,9 @@ const MyIOOrchestrator = (() => {
         const value = Number(item.value) || Number(item.consumption) || 0;
         customerTotal += value;
 
-        // Check if it's a store device (both deviceType AND deviceProfile are '3F_MEDIDOR')
+        // Check if it's a store device — deviceProfile apenas (deviceType em desuso)
         const deviceProfile = String(item.deviceProfile || '').toUpperCase();
-        const deviceType = String(item.deviceType || '').toUpperCase();
-        const isStore = deviceProfile === '3F_MEDIDOR' && deviceType === '3F_MEDIDOR';
+        const isStore = deviceProfile.startsWith('3F_MEDIDOR');
 
         if (isStore) {
           lojasTotal += value;

--- a/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/TELEMETRY/controller.js
+++ b/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/TELEMETRY/controller.js
@@ -1170,9 +1170,9 @@ function _getEnergyGroupKey(it) {
 
   // genuine fallback ('outros'): only 3F_MEDIDOR cards are group-filterable as
   // 'outros'; everything else stays null (always shown).
-  const dt = String(it.deviceType || '').toUpperCase();
+  // deviceType em desuso (2026-07-14) — profile apenas
   const dp = String(it.deviceProfile || '').toUpperCase();
-  if (dt === '3F_MEDIDOR' || dp === '3F_MEDIDOR') return 'outros';
+  if (dp === '3F_MEDIDOR') return 'outros';
   return null;
 }
 
@@ -1202,17 +1202,17 @@ const EQUIPMENT_EXCLUSION_PATTERN =
 function inferDisplayIdentifier(item) {
   if (!item) return 'N/A';
 
-  // Primeiro, tentar usar deviceType
-  const deviceType = String(item.deviceType || '').toUpperCase();
-  if (deviceType && deviceType !== 'N/D' && deviceType !== '3F_MEDIDOR') {
-    // Se for um deviceType conhecido, retornar o próprio deviceType ou abreviação
-    if (CLIMATIZACAO_DEVICE_TYPES_SET.has(deviceType)) {
-      return deviceType;
+  // Primeiro, tentar usar o deviceProfile (deviceType em desuso, 2026-07-14)
+  const deviceProfile = String(item.deviceProfile || '').toUpperCase();
+  if (deviceProfile && deviceProfile !== 'N/D' && deviceProfile !== '3F_MEDIDOR') {
+    // Se for um profile conhecido, retornar o próprio profile ou abreviação
+    if (CLIMATIZACAO_DEVICE_TYPES_SET.has(deviceProfile)) {
+      return deviceProfile;
     }
-    if (ELEVADORES_DEVICE_TYPES_SET.has(deviceType)) {
+    if (ELEVADORES_DEVICE_TYPES_SET.has(deviceProfile)) {
       return 'ELV';
     }
-    if (ESCADAS_DEVICE_TYPES_SET.has(deviceType)) {
+    if (ESCADAS_DEVICE_TYPES_SET.has(deviceProfile)) {
       return 'ESC';
     }
   }
@@ -2517,7 +2517,8 @@ function showTempInfoTooltip(triggerElement) {
 
   if (window._telemetryAuthoritativeItems) {
     window._telemetryAuthoritativeItems.forEach((item) => {
-      if (item.deviceType === 'TERMOSTATO') {
+      // profile exato (deviceType em desuso); EXTERNAL fica fora como antes
+      if ((item.deviceProfile || '').toUpperCase() === 'TERMOSTATO') {
         const temp = Number(item.value) || 0;
         totalTemp += temp;
 
@@ -2758,9 +2759,8 @@ function renderList(visible) {
       deviceIdentifierToDisplay = inferDisplayIdentifier(it);
     }
 
-    // RFC-0106: Use effectiveDeviceType for card icon (deviceProfile > deviceType)
-    // This ensures proper icon rendering based on actual device classification
-    const cardDeviceType = it.effectiveDeviceType || it.deviceProfile || it.deviceType || 'N/A';
+    // RFC-0106: ícone do card pelo deviceProfile (deviceType em desuso)
+    const cardDeviceType = it.deviceProfile || it.effectiveDeviceType || 'N/A';
 
     const entityObject = {
       entityId: it.tbId || it.id, // preferir TB deviceId
@@ -2863,9 +2863,10 @@ function renderList(visible) {
         const endDateISO = self.ctx?.scope?.endDateISO;
         const startTs = startDateISO ? new Date(startDateISO).getTime() : Date.now() - 86400000;
         const endTs = endDateISO ? new Date(endDateISO).getTime() : Date.now();
-        const deviceType = it.deviceType || entityObject.deviceType;
+        // deviceProfile apenas (deviceType em desuso)
+        const deviceType = it.deviceProfile || entityObject.deviceType;
         const isWaterTank = deviceType === 'TANK' || deviceType === 'CAIXA_DAGUA';
-        const isTermostato = deviceType === 'TERMOSTATO';
+        const isTermostato = String(deviceType || '').startsWith('TERMOSTATO');
 
         LogHelper.log(
           '[TELEMETRY v5] Opening dashboard for deviceType:',
@@ -3200,8 +3201,9 @@ function renderList(visible) {
         try {
           showBusy(); // mensagem fixa
 
-          const deviceType = it.deviceType || entityObject.deviceType;
-          const isTermostatoDevice = deviceType === 'TERMOSTATO';
+          // deviceProfile apenas (deviceType em desuso)
+          const deviceType = it.deviceProfile || entityObject.deviceType;
+          const isTermostatoDevice = String(deviceType || '').startsWith('TERMOSTATO');
 
           // For TERMOSTATO devices, reports use ThingsBoard API (no ingestion)
           if (isTermostatoDevice || WIDGET_DOMAIN === 'temperature') {
@@ -3975,23 +3977,20 @@ const _QF_GROUPS = [
 ];
 
 // Equipment category for the "Tipo" quick-filter group.
-// Mirrors categorizeItemsByGroup (MAIN_VIEW): the device GROUP is decided by
-// deviceProfile alone — so a device living in the "lojas" group always reads as
-// 'stores' here, even if its deviceType says otherwise. The areacomum bucket is
-// then sub-categorized by RFC-0128 (deviceType / identifier).
+// Mirrors categorizeItemsByGroup (MAIN_VIEW): tudo decidido pelo deviceProfile
+// (deviceType em desuso, 2026-07-14) + identifier (RFC-0128).
 function _quickFilterCategory(item) {
-  const dt = String(item.deviceType || '').toUpperCase();
   const dp = String(item.deviceProfile || '').toUpperCase();
   const idf = String(item.identifier || '').toUpperCase();
   const hasAny = (s, arr) => arr.some((k) => s.includes(k));
 
-  if (dp === '3F_MEDIDOR') return 'stores';
+  if (dp.startsWith('3F_MEDIDOR')) return 'stores';
   if (['TRAFO', 'ENTRADA', 'RELOGIO', 'SUBESTACAO'].indexOf(dp) !== -1) return 'entrada';
   // areacomum bucket
-  if (hasAny(dt, ['CHILLER', 'FANCOIL', 'HVAC', 'AR_CONDICIONADO', 'BOMBA_CAG']) || idf.includes('CAG'))
+  if (hasAny(dp, ['CHILLER', 'FANCOIL', 'HVAC', 'AR_CONDICIONADO', 'BOMBA_CAG']) || idf.includes('CAG'))
     return 'hvac';
-  if (dt.includes('ELEVADOR') || idf.startsWith('ELV-')) return 'elevators';
-  if (dt.includes('ESCADA_ROLANTE') || idf.startsWith('ESC-')) return 'escalators';
+  if (dp.includes('ELEVADOR') || idf.startsWith('ELV-')) return 'elevators';
+  if (dp.includes('ESCADA_ROLANTE') || idf.startsWith('ESC-')) return 'escalators';
   return 'others';
 }
 
@@ -5396,20 +5395,21 @@ function emitAreaComumBreakdown(periodKey) {
       breakdown[category].total += energia;
       breakdown[category].count += 1;
 
-      // RFC-0097: Agrupar subcategorias de climatização por identifier (ou deviceType)
+      // RFC-0097: Agrupar subcategorias de climatização por identifier (ou deviceProfile —
+      // deviceType em desuso, 2026-07-14)
       if (category === 'climatizacao') {
         const identifier = String(item.identifier || '')
           .toUpperCase()
           .trim();
-        const deviceType = String(item.deviceType || '').toUpperCase();
+        const deviceProfile = String(item.deviceProfile || '').toUpperCase();
 
-        // Usar identifier como chave de agrupamento, ou deviceType se identifier estiver vazio
+        // Usar identifier como chave de agrupamento, ou deviceProfile se identifier estiver vazio
         let groupKey = identifier;
         let groupLabel = identifier;
 
         if (!identifier || identifier === 'N/A' || identifier === 'NULL' || identifier === 'UNDEFINED') {
-          groupKey = deviceType || 'OUTROS';
-          groupLabel = deviceType || 'Outros';
+          groupKey = deviceProfile || 'OUTROS';
+          groupLabel = deviceProfile || 'Outros';
         }
 
         // Inicializar grupo se não existir
@@ -5436,20 +5436,15 @@ function emitAreaComumBreakdown(periodKey) {
         */
       }
 
-      // RFC-0097: Agrupar subcategorias de "outros" por deviceType (ou deviceProfile se 3F_MEDIDOR)
+      // RFC-0097: Agrupar subcategorias de "outros" por deviceProfile (deviceType em desuso)
       if (category === 'outros') {
-        let deviceType = String(item.deviceType || 'DESCONHECIDO')
+        const deviceProfile = String(item.deviceProfile || 'DESCONHECIDO')
           .toUpperCase()
           .trim();
 
-        // Se deviceType é 3F_MEDIDOR, usar deviceProfile como tipo real
-        if (deviceType === '3F_MEDIDOR' && item.deviceProfile) {
-          deviceType = String(item.deviceProfile).toUpperCase().trim();
-        }
-
-        // Usar deviceType como chave de agrupamento
-        const groupKey = deviceType || 'DESCONHECIDO';
-        const groupLabel = deviceType || 'Desconhecido';
+        // Usar deviceProfile como chave de agrupamento
+        const groupKey = deviceProfile || 'DESCONHECIDO';
+        const groupLabel = deviceProfile || 'Desconhecido';
 
         // Inicializar grupo se não existir
         if (!outrosSubcategories.has(groupKey)) {
@@ -5601,7 +5596,8 @@ function emitWaterTelemetry(widgetType, periodKey) {
       identifier: item.identifier || item.deviceIdentifier || '', // FIX: incluir identifier para classificação de banheiros
       label: item.label || item.name || '',
       value: item.value || 0,
-      deviceType: item.deviceType || 'HIDROMETRO',
+      // campo legado (deviceType em desuso) — preenchido do profile
+      deviceType: item.deviceProfile || 'HIDROMETRO',
     }));
 
     // RFC-0002: For areaComum context, classify devices into banheiros vs outros
@@ -6253,10 +6249,10 @@ self.onInit = async function () {
                 entityLabel: item.entityLabel || item.label || item.name || '',
                 value: temp,
                 perc: 0,
-                deviceType: item.deviceType || WIDGET_DOMAIN,
+                // campos legados de type preenchidos do profile (deviceType em desuso)
+                deviceType: item.deviceProfile || WIDGET_DOMAIN,
                 deviceProfile: item.deviceProfile || null,
-                effectiveDeviceType:
-                  item.effectiveDeviceType || item.deviceProfile || item.deviceType || null,
+                effectiveDeviceType: item.deviceProfile || item.effectiveDeviceType || null,
                 slaveId: item.slaveId || null,
                 centralId: item.centralId || null,
                 centralName: item.centralName || null,
@@ -6367,9 +6363,9 @@ self.onInit = async function () {
       const deviceStatus = item.deviceStatus || 'no_info';
       const connectionStatus = item.connectionStatus || 'unknown';
 
-      // RFC-0107: Calculate percentage and value for water tanks
+      // RFC-0107: Calculate percentage and value for water tanks (profile apenas)
       const isTankDevice =
-        item._isTankDevice || item.deviceType === 'TANK' || item.deviceType === 'CAIXA_DAGUA';
+        item._isTankDevice || item.deviceProfile === 'TANK' || item.deviceProfile === 'CAIXA_DAGUA';
       let itemPerc = 0;
       let itemValue = temp;
 
@@ -6393,9 +6389,10 @@ self.onInit = async function () {
         entityLabel: item.entityLabel || item.label || item.name || '',
         value: itemValue,
         perc: itemPerc,
-        deviceType: item.deviceType || WIDGET_DOMAIN,
+        // campos legados de type preenchidos do profile (deviceType em desuso)
+        deviceType: item.deviceProfile || WIDGET_DOMAIN,
         deviceProfile: item.deviceProfile || null,
-        effectiveDeviceType: item.effectiveDeviceType || item.deviceProfile || item.deviceType || null,
+        effectiveDeviceType: item.deviceProfile || item.effectiveDeviceType || null,
         slaveId: item.slaveId || null,
         centralId: item.centralId || null,
         centralName: item.centralName || null,

--- a/src/thingsboard/main-dashboard-shopping/v-5.4.0/controller.js
+++ b/src/thingsboard/main-dashboard-shopping/v-5.4.0/controller.js
@@ -158,8 +158,9 @@ function gcdrDeviceToMeta(dev) {
     name: dev.name || '',
     label: dev.label || dev.displayName || dev.name || '',
     labelOrName: dev.label || dev.displayName || dev.name || '',
-    deviceType: dev.deviceType || '',
-    deviceProfile: dev.deviceProfile || dev.deviceType || '',
+    // deviceType em desuso (2026-07-14) — campo legado preenchido do profile; sem fallback profile←type
+    deviceType: dev.deviceProfile || '',
+    deviceProfile: dev.deviceProfile || '',
     identifier: dev.identifier || '',
     slaveId: dev.slaveId != null ? String(dev.slaveId) : '',
     centralId: dev.centralId || '',
@@ -1751,7 +1752,7 @@ function handleGridCardAction(action, device) {
         deviceId,
         ingestionId: device?.ingestionId || undefined,
         label: device?.labelOrName || device?.name || undefined,
-        deviceType: device?.deviceType || device?.deviceProfile || undefined,
+        deviceType: device?.deviceProfile || undefined, // campo legado (deviceType em desuso)
         jwtToken,
         api: apiConfig,
         startDate: startDateISO,
@@ -1768,7 +1769,7 @@ function handleGridCardAction(action, device) {
         deviceId,
         ingestionId: device?.ingestionId || undefined,
         label: device?.labelOrName || device?.name || undefined,
-        deviceType: device?.deviceType || device?.deviceProfile || undefined,
+        deviceType: device?.deviceProfile || undefined, // campo legado (deviceType em desuso)
         jwtToken,
         api: apiConfig,
         startDate: startDateISO,

--- a/src/utils/devices/deviceClassificationProfile.ts
+++ b/src/utils/devices/deviceClassificationProfile.ts
@@ -23,6 +23,7 @@ export interface ClassifiableItem {
   identifier?: string | null;
   /** Free-text fields used by the breakdown's combined-substring matching (RFC-0207 A1b). */
   labelWidget?: string | null;
+  /** @deprecated EM DESUSO (2026-07-14) — nunca é lido; classificação usa só deviceProfile/identifier. */
   deviceType?: string | null;
   label?: string | null;
   [key: string]: unknown;
@@ -87,7 +88,10 @@ export interface IdentifierMatch {
 
 /** Conditional rule: when deviceProfile is one of these, require an identifier hit. */
 export interface ConditionalRule extends IdentifierMatch {
-  deviceTypes: string[];
+  /** Perfis (deviceProfile) que exigem hit de identifier. */
+  deviceProfiles: string[];
+  /** @deprecated Nome legado do campo (sempre comparou contra o deviceProfile) — normalizado para deviceProfiles. */
+  deviceTypes?: string[];
 }
 
 /** A single (non-fallback) category rule. */
@@ -96,9 +100,10 @@ export interface CategoryRule {
   /** Exact deviceProfile matches (the legacy "deviceTypes" Set). */
   deviceProfiles: string[];
   /**
-   * Substring patterns over the COMBINED text (labelWidget + deviceType +
-   * deviceProfile + label), mirroring buildSummary's loose matching (A1b).
-   * This is what unifies the breakdown subcategorization into one source.
+   * Substring patterns over the COMBINED text (labelWidget + deviceProfile +
+   * label — deviceType em desuso, removido 2026-07-14), mirroring
+   * buildSummary's loose matching (A1b). This is what unifies the breakdown
+   * subcategorization into one source.
    */
   combinedContains?: string[];
   /** climatizacao-only conditional ({BOMBA,MOTOR} + identifier hit). */
@@ -223,9 +228,9 @@ export const DEFAULT_DEVICE_CLASSIFICATION_PROFILE: DeviceClassificationProfile 
               'BOMBA_HIDRAULICA',
               'BOMBASHIDRAULICAS',
             ],
-            // CLIMATIZACAO_CONDITIONAL_TYPES_SET + identifier requirement
+            // CLIMATIZACAO conditional (perfis BOMBA/MOTOR) + identifier requirement
             conditional: {
-              deviceTypes: ['BOMBA', 'MOTOR'],
+              deviceProfiles: ['BOMBA', 'MOTOR'],
               // RFC-0207 A1 — BUG #1 FIX: substring (.includes), unifying with
               // equipmentCategory.js. Catches "CAG 01", "BOMBA CAG 2", etc.
               identifierContains: ['CAG', 'FANCOIL'],
@@ -319,14 +324,12 @@ function identifierOf(item: ClassifiableItem | null | undefined): string {
 }
 
 /**
- * combined: mirrors buildSummary's
- * `${labelWidget} ${deviceType} ${deviceProfile} ${label}` (upper-cased).
+ * combined: `${labelWidget} ${deviceProfile} ${label}` (upper-cased).
+ * deviceType está EM DESUSO e foi removido do texto combinado (2026-07-14).
  * Identifier is intentionally NOT included (buildSummary keeps it separate).
  */
 function combinedOf(item: ClassifiableItem | null | undefined): string {
-  return `${up(item?.labelWidget ?? '')} ${up(item?.deviceType ?? '')} ${up(
-    item?.deviceProfile ?? '',
-  )} ${up(item?.label ?? '')}`;
+  return `${up(item?.labelWidget ?? '')} ${up(item?.deviceProfile ?? '')} ${up(item?.label ?? '')}`;
 }
 
 /** Mirrors an IdentifierMatch against an already-normalized (trim+upper) id. */
@@ -461,8 +464,8 @@ export function resolveCategory(
         }
       }
     }
-    // conditional ({BOMBA,MOTOR} + identifier hit)
-    if (rule.conditional && rule.conditional.deviceTypes.some((t) => dp === up(t))) {
+    // conditional ({BOMBA,MOTOR} no PROFILE + identifier hit)
+    if (rule.conditional && rule.conditional.deviceProfiles.some((t) => dp === up(t))) {
       if (matchesIdentifier(id, rule.conditional)) {
         return { category: rule.name, matchedBy: 'conditional' };
       }
@@ -617,7 +620,11 @@ export function normalizeProfile(raw: DeviceClassificationProfile): DeviceClassi
         r.deviceProfiles = upArr(r.deviceProfiles) ?? [];
         r.combinedContains = upArr(r.combinedContains);
         if (r.conditional) {
-          r.conditional.deviceTypes = upArr(r.conditional.deviceTypes) ?? [];
+          // Compat: perfis JSON legados usavam a chave "deviceTypes" (que sempre
+          // comparou contra o deviceProfile) — normaliza para deviceProfiles.
+          r.conditional.deviceProfiles =
+            upArr(r.conditional.deviceProfiles) ?? upArr(r.conditional.deviceTypes) ?? [];
+          delete r.conditional.deviceTypes;
           upIdMatch(r.conditional);
         }
         upIdMatch(r.identifierFallback);

--- a/src/utils/devices/deviceIcons.ts
+++ b/src/utils/devices/deviceIcons.ts
@@ -106,14 +106,14 @@ export const DEFAULT_DEVICE_ICON =
   'https://dashboard.myio-bas.com/api/images/public/f9Ce4meybsdaAhAkUlAfy5ei3I4kcN4k'; // generic 3F_MEDIDOR
 
 /**
- * Resolves the static image URL for a given device type string.
+ * Resolves the static image URL for a given device profile string.
  * Lookup is case-insensitive on the input; the canonical keys are uppercase.
  *
- * @param deviceType - typically `ctx.data` deviceType or deviceProfile attribute
+ * @param deviceProfile - o attr `deviceProfile` do device (deviceType está em desuso)
  * @returns the mapped URL, or `DEFAULT_DEVICE_ICON` when not recognised
  */
-export function getDeviceIcon(deviceType?: string | null): string {
-  const key = String(deviceType || '').toUpperCase();
+export function getDeviceIcon(deviceProfile?: string | null): string {
+  const key = String(deviceProfile || '').toUpperCase();
   return (deviceIcons as Record<string, string>)[key] ?? DEFAULT_DEVICE_ICON;
 }
 

--- a/src/utils/devices/deviceInfo.js
+++ b/src/utils/devices/deviceInfo.js
@@ -46,8 +46,8 @@ export const ContextType = {
 /**
  * RFC-0111: Detect device context based on deviceProfile (+identifier).
  *
- * ⚠️ AUTORIDADE: deviceProfile decide TUDO. deviceType só é consultado quando o
- * device não tem deviceProfile (último recurso); name/label nunca entram.
+ * ⚠️ AUTORIDADE: deviceProfile decide TUDO. deviceType está EM DESUSO e não é
+ * lido nunca (nem como fallback); name/label também nunca entram.
  *
  * WATER Rules (priority order, sobre o deviceProfile):
  * 1. profile contém HIDROMETRO_SHOPPING → ENTRADA (main water meter)
@@ -62,39 +62,35 @@ export const ContextType = {
  * - profile começa com 3F_MEDIDOR → STORES (mesmo com deviceType errado)
  * - default → EQUIPMENTS
  *
- * TEMPERATURE Rules:
- * - deviceType = deviceProfile = TERMOSTATO → termostato (climatized)
- * - deviceType = TERMOSTATO AND deviceProfile = TERMOSTATO_EXTERNAL → termostato_external
- * - deviceType = TERMOSTATO_EXTERNAL → termostato_external
+ * TEMPERATURE Rules (sobre o deviceProfile):
+ * - profile contém EXTERNAL (TERMOSTATO_EXTERNAL) → termostato_external
+ * - default → termostato (climatized)
  *
- * @param {Object} device - Device object with deviceType, deviceProfile, and identifier properties
- * @param {string} [device.deviceType] - The device type string
- * @param {string} [device.deviceProfile] - The device profile string
+ * @param {Object} device - Device object with deviceProfile and identifier properties
+ * @param {string} [device.deviceProfile] - The device profile string (única autoridade)
  * @param {string} [device.identifier] - The device identifier (server_scope attribute)
  * @param {'energy' | 'water' | 'temperature'} domain - The device domain
  * @returns {string} The detected context
  *
  * @example
- * detectContext({ deviceType: 'HIDROMETRO', deviceProfile: 'HIDROMETRO' }, 'water');
+ * detectContext({ deviceProfile: 'HIDROMETRO' }, 'water');
  * // Returns 'hidrometro'
  *
  * @example
- * detectContext({ deviceType: 'HIDROMETRO', deviceProfile: 'HIDROMETRO_AREA_COMUM', identifier: 'BANHEIROS' }, 'water');
+ * detectContext({ deviceProfile: 'HIDROMETRO_AREA_COMUM', identifier: 'BANHEIROS' }, 'water');
  * // Returns 'banheiros'
  *
  * @example
- * detectContext({ deviceType: '3F_MEDIDOR', deviceProfile: '3F_MEDIDOR' }, 'energy');
+ * detectContext({ deviceProfile: '3F_MEDIDOR' }, 'energy');
  * // Returns 'stores'
  */
 export function detectContext(device, domain) {
   // 2026-07-14 (endurecimento do RFC-0111): deviceProfile é a ÚNICA autoridade
-  // de classificação. deviceType chega errado do provisionamento com frequência
-  // (hidrômetro com deviceType=MOTOR, loja 3F com deviceType=ELEVADOR, subestação
-  // com deviceType=SUBESTACAO mas profile=MOTOR) e name/label NUNCA entram na
-  // decisão. deviceType só é lido como último recurso quando o device NÃO tem
-  // deviceProfile — sem isso ele ficaria inclassificável.
-  const deviceProfile = String(device?.deviceProfile || '').toUpperCase().trim();
-  const basis = deviceProfile || String(device?.deviceType || '').toUpperCase().trim();
+  // de classificação. deviceType está EM DESUSO (chegava errado do
+  // provisionamento: hidrômetro com deviceType=MOTOR, loja 3F com
+  // deviceType=ELEVADOR, subestação com deviceType=SUBESTACAO mas
+  // profile=MOTOR) e não é lido NUNCA — nem como fallback. name/label idem.
+  const basis = String(device?.deviceProfile || '').toUpperCase().trim();
   const identifier = String(device?.identifier || '').toUpperCase();
 
   if (domain === DomainType.WATER) {
@@ -177,18 +173,17 @@ export function detectContext(device, domain) {
 /**
  * Detect both domain and context for a device in a single call.
  *
- * @param {Object} device - Device object with deviceType and deviceProfile properties
+ * @param {Object} device - Device object with deviceProfile (única autoridade) and identifier
  * @returns {{ domain: string, context: string }} Object with domain and context
  *
  * @example
- * detectDomainAndContext({ deviceType: 'HIDROMETRO', deviceProfile: 'HIDROMETRO_AREA_COMUM' });
+ * detectDomainAndContext({ deviceProfile: 'HIDROMETRO_AREA_COMUM' });
  * // Returns { domain: 'water', context: 'hidrometro_area_comum' }
  */
 export function detectDomainAndContext(device) {
-  // Domínio também é decidido pelo deviceProfile (deviceType só quando não há
-  // profile) — um hidrômetro com deviceType=MOTOR errado continua sendo água.
-  const basis = String(device?.deviceProfile || '').trim() || String(device?.deviceType || '');
-  const domain = getDomainFromDeviceType(basis);
+  // Domínio também é decidido exclusivamente pelo deviceProfile (deviceType em
+  // desuso) — um hidrômetro com deviceType=MOTOR errado continua sendo água.
+  const domain = getDomainFromDeviceType(String(device?.deviceProfile || ''));
   const context = detectContext(device, domain);
 
   return { domain, context };

--- a/src/utils/devices/deviceInfo.js
+++ b/src/utils/devices/deviceInfo.js
@@ -44,19 +44,23 @@ export const ContextType = {
 };
 
 /**
- * RFC-0111: Detect device context based on deviceType, deviceProfile, and identifier.
+ * RFC-0111: Detect device context based on deviceProfile (+identifier).
  *
- * WATER Rules (priority order):
- * 1. deviceType = HIDROMETRO_SHOPPING OR deviceProfile = HIDROMETRO_SHOPPING → ENTRADA (main water meter)
- * 2. deviceProfile = HIDROMETRO_AREA_COMUM AND identifier = 'BANHEIROS' → BANHEIROS
- * 3. deviceProfile = HIDROMETRO_AREA_COMUM → AREA_COMUM (common area without bathrooms)
- * 4. deviceType = deviceProfile = HIDROMETRO → LOJAS (store water meters)
+ * ⚠️ AUTORIDADE: deviceProfile decide TUDO. deviceType só é consultado quando o
+ * device não tem deviceProfile (último recurso); name/label nunca entram.
  *
- * ENERGY Rules:
- * - deviceType = deviceProfile = 3F_MEDIDOR → STORE (stores)
- * - deviceType = 3F_MEDIDOR AND deviceProfile != 3F_MEDIDOR → equipments
- * - deviceType != 3F_MEDIDOR AND NOT (ENTRADA/RELOGIO/TRAFO/SUBESTACAO) → equipments
- * - deviceType = ENTRADA/RELOGIO/TRAFO/SUBESTACAO → ENTRADA ENERGY
+ * WATER Rules (priority order, sobre o deviceProfile):
+ * 1. profile contém HIDROMETRO_SHOPPING → ENTRADA (main water meter)
+ * 2. profile = HIDROMETRO_AREA_COMUM AND identifier = 'BANHEIROS' → BANHEIROS
+ * 3. profile = HIDROMETRO_AREA_COMUM → AREA_COMUM (common area without bathrooms)
+ * 4. default → LOJAS/hidrometro (inclui profile HIDROMETRO exato)
+ *
+ * ENERGY Rules (sobre o deviceProfile):
+ * - profile contém ENTRADA/RELOGIO/TRAFO/SUBESTACAO → ENTRADA (main meters)
+ * - profile contém BOMBA_CAG → EQUIPMENTS (é Climatização/RFC-0128, não bomba BAS)
+ * - profile contém BOMBA → BOMBA (BAS) · contém MOTOR → MOTOR (BAS)
+ * - profile começa com 3F_MEDIDOR → STORES (mesmo com deviceType errado)
+ * - default → EQUIPMENTS
  *
  * TEMPERATURE Rules:
  * - deviceType = deviceProfile = TERMOSTATO → termostato (climatized)
@@ -83,88 +87,83 @@ export const ContextType = {
  * // Returns 'stores'
  */
 export function detectContext(device, domain) {
-  const deviceType = String(device?.deviceType || '').toUpperCase();
-  const deviceProfile = String(device?.deviceProfile || '').toUpperCase();
+  // 2026-07-14 (endurecimento do RFC-0111): deviceProfile é a ÚNICA autoridade
+  // de classificação. deviceType chega errado do provisionamento com frequência
+  // (hidrômetro com deviceType=MOTOR, loja 3F com deviceType=ELEVADOR, subestação
+  // com deviceType=SUBESTACAO mas profile=MOTOR) e name/label NUNCA entram na
+  // decisão. deviceType só é lido como último recurso quando o device NÃO tem
+  // deviceProfile — sem isso ele ficaria inclassificável.
+  const deviceProfile = String(device?.deviceProfile || '').toUpperCase().trim();
+  const basis = deviceProfile || String(device?.deviceType || '').toUpperCase().trim();
   const identifier = String(device?.identifier || '').toUpperCase();
-  const entradaTypes = ['ENTRADA', 'RELOGIO', 'TRAFO', 'SUBESTACAO'];
-  const isEntrada = entradaTypes.some((t) => deviceType.includes(t) || deviceProfile.includes(t));
 
   if (domain === DomainType.WATER) {
     // BAS: CAIXA_DAGUA (water tank)
-    if (deviceType.includes('CAIXA_DAGUA') || deviceProfile.includes('CAIXA_DAGUA')) {
+    if (basis.includes('CAIXA_DAGUA')) {
       return ContextType.CAIXA_DAGUA;
     }
 
     // BAS: SOLENOIDE (solenoid valve)
-    if (deviceType.includes('SOLENOIDE') || deviceProfile.includes('SOLENOIDE')) {
+    if (basis.includes('SOLENOIDE')) {
       return ContextType.SOLENOIDE;
     }
 
     // Priority 1: HIDROMETRO_SHOPPING → ENTRADA (main water meter for shopping)
-    if (deviceType.includes('HIDROMETRO_SHOPPING') || deviceProfile.includes('HIDROMETRO_SHOPPING')) {
+    if (basis.includes('HIDROMETRO_SHOPPING')) {
       return ContextType.HIDROMETRO_ENTRADA;
     }
 
     // Priority 2: BANHEIROS (identifier = 'BANHEIROS' with HIDROMETRO_AREA_COMUM profile)
-    if (deviceProfile === 'HIDROMETRO_AREA_COMUM' && identifier === 'BANHEIROS') {
+    if (basis === 'HIDROMETRO_AREA_COMUM' && identifier === 'BANHEIROS') {
       return ContextType.BANHEIROS;
     }
 
     // Priority 3: HIDROMETRO_AREA_COMUM (common area without bathroom identifier)
-    if (deviceType === 'HIDROMETRO' && deviceProfile === 'HIDROMETRO_AREA_COMUM') {
+    if (basis === 'HIDROMETRO_AREA_COMUM') {
       return ContextType.HIDROMETRO_AREA_COMUM;
     }
 
-    // Priority 4: deviceType = HIDROMETRO and deviceProfile = HIDROMETRO → store (lojas)
-    if (deviceType === 'HIDROMETRO' && deviceProfile === 'HIDROMETRO') {
-      return ContextType.HIDROMETRO;
-    }
-
-    // Default for water: hidrometro (store) - fallback for devices with HIDROMETRO in deviceType
-    if (deviceType.includes('HIDROMETRO')) {
-      return ContextType.HIDROMETRO;
-    }
-
+    // Default for water: hidrometro (lojas) — inclui profile HIDROMETRO exato
     return ContextType.HIDROMETRO;
   }
 
   if (domain === DomainType.ENERGY) {
-    // RFC-0111: ENTRADA/RELOGIO/TRAFO/SUBESTACAO → ENTRADA ENERGY (main meters)
-    if (isEntrada) {
+    // RFC-0111: profile ENTRADA/RELOGIO/TRAFO/SUBESTACAO → ENTRADA (main meters).
+    // Por PROFILE apenas — "3F SUBESTACAO Condominio" com profile=MOTOR NÃO é entrada.
+    const entradaProfiles = ['ENTRADA', 'RELOGIO', 'TRAFO', 'SUBESTACAO'];
+    if (entradaProfiles.some((t) => basis.includes(t))) {
       return ContextType.ENTRADA;
     }
 
+    // BOMBA_CAG é CLIMATIZAÇÃO (RFC-0128) — vai para equipments, NÃO para o
+    // grupo bomba (BAS). Checado antes do check genérico de BOMBA.
+    if (basis.includes('BOMBA_CAG')) {
+      return ContextType.EQUIPMENTS;
+    }
+
     // BAS: BOMBA (pumps) - check before generic motor
-    if (deviceType.includes('BOMBA') || deviceProfile.includes('BOMBA')) {
+    if (basis.includes('BOMBA')) {
       return ContextType.BOMBA;
     }
 
     // BAS: MOTOR (motors)
-    if (deviceType.includes('MOTOR') || deviceProfile.includes('MOTOR')) {
+    if (basis.includes('MOTOR')) {
       return ContextType.MOTOR;
     }
 
-    // RFC-0111: deviceType = 3F_MEDIDOR AND deviceProfile starts with 3F_MEDIDOR → STORE
+    // RFC-0111: profile começa com 3F_MEDIDOR → STORE (lojas), independente do
+    // deviceType (ex.: loja com deviceType=ELEVADOR errado continua loja).
     // Includes archived/variant profiles like 3F_MEDIDOR_ARQUIVADO_INSTALADO_SEM_DADOS
-    if (deviceType === '3F_MEDIDOR' && deviceProfile.startsWith('3F_MEDIDOR')) {
+    if (basis.startsWith('3F_MEDIDOR')) {
       return ContextType.STORES;
     }
-    // RFC-0111: deviceType = 3F_MEDIDOR AND deviceProfile doesn't start with 3F_MEDIDOR → equipments
-    if (deviceType === '3F_MEDIDOR') {
-      return ContextType.EQUIPMENTS;
-    }
-    // RFC-0111: deviceType != 3F_MEDIDOR → equipments
+
     return ContextType.EQUIPMENTS;
   }
 
   if (domain === DomainType.TEMPERATURE) {
-    // TERMOSTATO_EXTERNAL in deviceType → external (non-climatized)
-    if (deviceType.includes('TERMOSTATO_EXTERNAL')) {
-      return ContextType.TERMOSTATO_EXTERNAL;
-    }
-
-    // deviceType = TERMOSTATO AND deviceProfile = TERMOSTATO_EXTERNAL → external
-    if (deviceType.includes('TERMOSTATO') && deviceProfile.includes('EXTERNAL')) {
+    // TERMOSTATO_EXTERNAL → external (non-climatized)
+    if (basis.includes('EXTERNAL')) {
       return ContextType.TERMOSTATO_EXTERNAL;
     }
 
@@ -186,7 +185,10 @@ export function detectContext(device, domain) {
  * // Returns { domain: 'water', context: 'hidrometro_area_comum' }
  */
 export function detectDomainAndContext(device) {
-  const domain = getDomainFromDeviceType(device?.deviceType);
+  // Domínio também é decidido pelo deviceProfile (deviceType só quando não há
+  // profile) — um hidrômetro com deviceType=MOTOR errado continua sendo água.
+  const basis = String(device?.deviceProfile || '').trim() || String(device?.deviceType || '');
+  const domain = getDomainFromDeviceType(basis);
   const context = detectContext(device, domain);
 
   return { domain, context };

--- a/src/utils/devices/deviceInfo.js
+++ b/src/utils/devices/deviceInfo.js
@@ -6,17 +6,14 @@
  * @version 1.0.0
  */
 
-import { getDomainFromDeviceType, DomainType as DeviceItemDomainType } from './deviceItem.js';
+import { getDomainFromProfile, DomainType as DeviceItemDomainType } from './deviceItem.js';
 
 /**
  * Domain types for device classification
+ * (re-export do deviceItem.js — antes havia DOIS enums idênticos em paralelo)
  * @enum {string}
  */
-export const DomainType = {
-  ENERGY: 'energy',
-  WATER: 'water',
-  TEMPERATURE: 'temperature',
-};
+export const DomainType = DeviceItemDomainType;
 
 /**
  * Context types for device classification
@@ -183,7 +180,7 @@ export function detectContext(device, domain) {
 export function detectDomainAndContext(device) {
   // Domínio também é decidido exclusivamente pelo deviceProfile (deviceType em
   // desuso) — um hidrômetro com deviceType=MOTOR errado continua sendo água.
-  const domain = getDomainFromDeviceType(String(device?.deviceProfile || ''));
+  const domain = getDomainFromProfile(String(device?.deviceProfile || ''));
   const context = detectContext(device, domain);
 
   return { domain, context };

--- a/src/utils/devices/deviceItem.js
+++ b/src/utils/devices/deviceItem.js
@@ -81,7 +81,8 @@ export function isSolenoidDevice(deviceType) {
  */
 export function isTemperatureDevice(deviceType) {
   const dt = String(deviceType || '').toUpperCase();
-  return dt === 'TERMOSTATO' || dt === 'SENSOR_TEMP' || dt.includes('TEMP');
+  // startsWith cobre TERMOSTATO_EXTERNAL ("TERMOSTATO" não contém a substring "TEMP")
+  return dt === 'TERMOSTATO' || dt === 'SENSOR_TEMP' || dt.includes('TEMP') || dt.startsWith('TERMOSTATO');
 }
 
 /**

--- a/src/utils/devices/deviceItem.js
+++ b/src/utils/devices/deviceItem.js
@@ -340,21 +340,24 @@ export function createDeviceItem(entityId, meta, options = {}) {
     delayTimeConnectionInMins = 1440,
   } = options;
 
-  // Normalize values
-  const deviceType = meta.deviceType || meta.deviceProfile || '';
-  const deviceProfile = meta.deviceProfile || deviceType || '';
-  const effectiveDeviceType = deviceProfile || deviceType || null;
+  // Normalize values — deviceProfile é a ÚNICA autoridade de classificação;
+  // deviceType está EM DESUSO e não é lido (os campos legados deviceType/
+  // effectiveDeviceType do item continuam existindo por compat, mas são
+  // preenchidos a partir do profile).
+  const deviceProfile = meta.deviceProfile || '';
+  const deviceType = deviceProfile;
+  const effectiveDeviceType = deviceProfile || null;
   const identifier = meta.identifier || '';
   const label = meta.label || identifier || entityId;
 
-  // Detect device categories
-  const _isTankDevice = isTankDevice(deviceType);
-  const _isHidrometerDevice = isHydrometerDevice(deviceType);
-  const _isTemperatureDevice = isTemperatureDevice(deviceType);
+  // Detect device categories (pelo deviceProfile)
+  const _isTankDevice = isTankDevice(deviceProfile);
+  const _isHidrometerDevice = isHydrometerDevice(deviceProfile);
+  const _isTemperatureDevice = isTemperatureDevice(deviceProfile);
   const _isEnergyDevice = !_isTankDevice && !_isHidrometerDevice && !_isTemperatureDevice;
 
-  // Determine domain if not provided
-  const effectiveDomain = domain || getDomainFromDeviceType(deviceType);
+  // Determine domain if not provided (pelo deviceProfile)
+  const effectiveDomain = domain || getDomainFromDeviceType(deviceProfile);
 
   // Normalize connection status
   const rawConnectionStatus = meta.connectionStatus;
@@ -612,7 +615,8 @@ export function recalculateDeviceStatus(item, newData = {}, options = {}) {
   };
 
   const updatedOptions = {
-    domain: options.domain ?? getDomainFromDeviceType(item.deviceType),
+    // deviceProfile é a autoridade (deviceType em desuso)
+    domain: options.domain ?? getDomainFromDeviceType(item.deviceProfile),
     labelWidget: item.labelWidget,
     globalMapInstantaneousPower: options.globalMapInstantaneousPower ?? item.mapInstantaneousPower,
     temperatureLimits: options.temperatureLimits ?? {

--- a/src/utils/devices/deviceItem.js
+++ b/src/utils/devices/deviceItem.js
@@ -45,54 +45,56 @@ export const DeviceCategory = {
 };
 
 /**
- * Checks if device type is a water tank
- * @param {string} deviceType - Device type string
+ * Checks if a device PROFILE is a water tank.
+ * (deviceType está em desuso — alimente sempre com o deviceProfile.)
+ * @param {string} deviceProfile - Device profile string
  * @returns {boolean}
  */
-export function isTankDevice(deviceType) {
-  const dt = String(deviceType || '').toUpperCase();
+export function isTankDevice(deviceProfile) {
+  const dt = String(deviceProfile || '').toUpperCase();
   return dt === 'TANK' || dt === 'CAIXA_DAGUA';
 }
 
 /**
- * Checks if device type is a hydrometer
- * @param {string} deviceType - Device type string
+ * Checks if a device PROFILE is a hydrometer.
+ * (deviceType está em desuso — alimente sempre com o deviceProfile.)
+ * @param {string} deviceProfile - Device profile string
  * @returns {boolean}
  */
-export function isHydrometerDevice(deviceType) {
-  const dt = String(deviceType || '').toUpperCase();
+export function isHydrometerDevice(deviceProfile) {
+  const dt = String(deviceProfile || '').toUpperCase();
   return dt.startsWith('HIDROMETRO');
 }
 
 /**
- * Checks if device type is a solenoid valve (water infrastructure)
- * @param {string} deviceType - Device type string
+ * Checks if a device PROFILE is a solenoid valve (water infrastructure)
+ * @param {string} deviceProfile - Device profile string
  * @returns {boolean}
  */
-export function isSolenoidDevice(deviceType) {
-  const dt = String(deviceType || '').toUpperCase();
+export function isSolenoidDevice(deviceProfile) {
+  const dt = String(deviceProfile || '').toUpperCase();
   return dt.includes('SOLENOIDE');
 }
 
 /**
- * Checks if device type is a temperature sensor
- * @param {string} deviceType - Device type string
+ * Checks if a device PROFILE is a temperature sensor
+ * @param {string} deviceProfile - Device profile string
  * @returns {boolean}
  */
-export function isTemperatureDevice(deviceType) {
-  const dt = String(deviceType || '').toUpperCase();
+export function isTemperatureDevice(deviceProfile) {
+  const dt = String(deviceProfile || '').toUpperCase();
   // startsWith cobre TERMOSTATO_EXTERNAL ("TERMOSTATO" não contém a substring "TEMP")
   return dt === 'TERMOSTATO' || dt === 'SENSOR_TEMP' || dt.includes('TEMP') || dt.startsWith('TERMOSTATO');
 }
 
 /**
- * Checks if device type is an energy device
+ * Checks if a device PROFILE is an energy device
  * RFC-0128: Includes all energy equipment categories
- * @param {string} deviceType - Device type or profile string
+ * @param {string} deviceProfile - Device profile string
  * @returns {boolean}
  */
-export function isEnergyDevice(deviceType) {
-  const dt = String(deviceType || '').toUpperCase();
+export function isEnergyDevice(deviceProfile) {
+  const dt = String(deviceProfile || '').toUpperCase();
 
   // Explicitly exclude non-energy devices (lighting, remotes, solenoids)
   // RFC-0175: SOLENOIDE is a control device, not an energy meter
@@ -139,19 +141,25 @@ export function isEnergyDevice(deviceType) {
 }
 
 /**
- * Determines the domain for a device based on its type
- * @param {string} deviceType - Device type string
+ * Determines the domain for a device based on its PROFILE.
+ * @param {string} deviceProfile - Device profile string (única autoridade)
  * @returns {string} Domain: 'energy', 'water', or 'temperature'
  */
-export function getDomainFromDeviceType(deviceType) {
-  if (isTankDevice(deviceType) || isHydrometerDevice(deviceType) || isSolenoidDevice(deviceType)) {
+export function getDomainFromProfile(deviceProfile) {
+  if (isTankDevice(deviceProfile) || isHydrometerDevice(deviceProfile) || isSolenoidDevice(deviceProfile)) {
     return DomainType.WATER;
   }
-  if (isTemperatureDevice(deviceType)) {
+  if (isTemperatureDevice(deviceProfile)) {
     return DomainType.TEMPERATURE;
   }
   return DomainType.ENERGY;
 }
+
+/**
+ * @deprecated deviceType está EM DESUSO (2026-07-14). Use getDomainFromProfile
+ * e alimente com o deviceProfile. Alias mantido só para widgets já publicados.
+ */
+export const getDomainFromDeviceType = getDomainFromProfile;
 
 /**
  * Extracts power limits from mapInstantaneousPower JSON for a specific device type
@@ -357,7 +365,7 @@ export function createDeviceItem(entityId, meta, options = {}) {
   const _isEnergyDevice = !_isTankDevice && !_isHidrometerDevice && !_isTemperatureDevice;
 
   // Determine domain if not provided (pelo deviceProfile)
-  const effectiveDomain = domain || getDomainFromDeviceType(deviceProfile);
+  const effectiveDomain = domain || getDomainFromProfile(deviceProfile);
 
   // Normalize connection status
   const rawConnectionStatus = meta.connectionStatus;
@@ -616,7 +624,7 @@ export function recalculateDeviceStatus(item, newData = {}, options = {}) {
 
   const updatedOptions = {
     // deviceProfile é a autoridade (deviceType em desuso)
-    domain: options.domain ?? getDomainFromDeviceType(item.deviceProfile),
+    domain: options.domain ?? getDomainFromProfile(item.deviceProfile),
     labelWidget: item.labelWidget,
     globalMapInstantaneousPower: options.globalMapInstantaneousPower ?? item.mapInstantaneousPower,
     temperatureLimits: options.temperatureLimits ?? {

--- a/src/utils/devices/deviceStatus.js
+++ b/src/utils/devices/deviceStatus.js
@@ -280,12 +280,13 @@ export function isDeviceOffline(deviceStatus) {
  * Gets the appropriate icon for a device status
  *
  * @param {string} deviceStatus - The device status
- * @param {string} deviceType - The device type (optional, for water/temperature/solenoid devices)
+ * @param {string} deviceProfile - O deviceProfile do device (deviceType está em desuso —
+ *   alimente com o profile; opcional, para água/temperatura/solenoide)
  * @returns {string} The icon emoji/character
  */
-export function getDeviceStatusIcon(deviceStatus, deviceType = null) {
-  // Normalize device type for comparison
-  const normalizedType = deviceType?.toUpperCase() || '';
+export function getDeviceStatusIcon(deviceStatus, deviceProfile = null) {
+  // Normalize device profile for comparison
+  const normalizedType = deviceProfile?.toUpperCase() || '';
 
   // Use water icons for TANK/CAIXA_DAGUA/HIDROMETRO devices (including subtypes)
   const isWaterDevice =

--- a/src/utils/devices/deviceTypeConfig.ts
+++ b/src/utils/devices/deviceTypeConfig.ts
@@ -86,18 +86,19 @@ export const DEVICE_TYPE_CONFIG: Record<string, DeviceTypeConfigEntry> = {
 export const DEFAULT_DEVICE_IMAGE =
   'https://cdn-icons-png.flaticon.com/512/1178/1178428.png';
 
-/** Resolves the domain category for a device type (default `'energy'`). */
-export function getDeviceCategory(deviceType?: string | null): DeviceTypeCategory {
-  const normalizedType = String(deviceType || '').toUpperCase();
+/** Resolves the domain category for a device PROFILE (default `'energy'`). deviceType em desuso. */
+export function getDeviceCategory(deviceProfile?: string | null): DeviceTypeCategory {
+  const normalizedType = String(deviceProfile || '').toUpperCase();
   return DEVICE_TYPE_CONFIG[normalizedType]?.category || 'energy';
 }
 
 /**
- * Resolves the STATIC image URL for a device type, falling back to the generic
- * flaticon default. Returns the default for dynamic-image types (image `null`).
+ * Resolves the STATIC image URL for a device PROFILE (deviceType em desuso),
+ * falling back to the generic flaticon default. Returns the default for
+ * dynamic-image types (image `null`).
  */
-export function getStaticDeviceImage(deviceType?: string | null): string {
-  const normalizedType = String(deviceType || '').toUpperCase();
+export function getStaticDeviceImage(deviceProfile?: string | null): string {
+  const normalizedType = String(deviceProfile || '').toUpperCase();
   return DEVICE_TYPE_CONFIG[normalizedType]?.image || DEFAULT_DEVICE_IMAGE;
 }
 

--- a/src/utils/devices/equipmentCategory.js
+++ b/src/utils/devices/equipmentCategory.js
@@ -24,29 +24,29 @@ export const EquipmentCategory = {
 /**
  * Equipment classification configuration
  * Ported from MAIN_VIEW/controller.js DEVICE_CLASSIFICATION_CONFIG
+ *
+ * 2026-07-14: deviceType está EM DESUSO — classificação usa APENAS
+ * deviceProfile + identifier (attr curado). As chaves deviceTypes/
+ * conditionalDeviceTypes foram removidas.
  */
 export const EQUIPMENT_CLASSIFICATION_CONFIG = {
   climatizacao: {
-    deviceTypes: ['CHILLER', 'AR_CONDICIONADO', 'HVAC', 'FANCOIL'],
     deviceProfiles: ['CHILLER', 'FANCOIL', 'HVAC', 'AR_CONDICIONADO', 'BOMBA_CAG'],
-    conditionalDeviceTypes: ['BOMBA', 'MOTOR'],
+    conditionalDeviceProfiles: ['BOMBA', 'MOTOR'], // + identifier CAG/FANCOIL
     identifiers: ['CAG', 'FANCOIL', 'HVAC'],
     identifierPrefixes: ['CAG-', 'FANCOIL-'],
   },
   elevadores: {
-    deviceTypes: ['ELEVADOR'],
     deviceProfiles: ['ELEVADOR'],
     identifiers: ['ELV', 'ELEVADOR', 'ELEVADORES'],
     identifierPrefixes: ['ELV-', 'ELEVADOR-'],
   },
   escadas_rolantes: {
-    deviceTypes: ['ESCADA_ROLANTE'],
     deviceProfiles: ['ESCADA_ROLANTE'],
     identifiers: ['ESC', 'ESCADA', 'ESCADASROLANTES'],
     identifierPrefixes: ['ESC-', 'ESCADA-', 'ESCADA_'],
   },
   entrada: {
-    deviceTypes: ['ENTRADA', 'RELOGIO', 'TRAFO', 'SUBESTACAO'],
     deviceProfiles: ['ENTRADA', 'RELOGIO', 'TRAFO', 'SUBESTACAO'],
   },
 };
@@ -67,54 +67,55 @@ const CATEGORY_DISPLAY_MAP = {
 /**
  * Classify an energy device into its equipment category.
  *
- * Priority order:
- * 1. ENTRADA (main meters): ENTRADA, RELOGIO, TRAFO, SUBESTACAO
- * 2. LOJAS (stores): deviceType = deviceProfile = '3F_MEDIDOR' (exact match)
- * 3. CLIMATIZACAO: CHILLER, FANCOIL, HVAC, AR_CONDICIONADO, BOMBA_CAG, or CAG identifier
- * 4. ELEVADORES: ELEVADOR or ELV- identifier prefix
- * 5. ESCADAS_ROLANTES: ESCADA_ROLANTE or ESC- identifier prefix
- * 6. OUTROS: Remaining 3F_MEDIDOR equipment
+ * ⚠️ AUTORIDADE: deviceProfile decide (deviceType está EM DESUSO e não é lido);
+ * identifier (attr SERVER_SCOPE curado) complementa; name/label nunca entram.
+ *
+ * Priority order (sobre o deviceProfile):
+ * 1. ENTRADA (main meters): profile contém ENTRADA, RELOGIO, TRAFO, SUBESTACAO
+ * 2. LOJAS (stores): profile começa com '3F_MEDIDOR'
+ * 3. CLIMATIZACAO: profile CHILLER/FANCOIL/HVAC/AR_CONDICIONADO/BOMBA_CAG, ou identifier CAG
+ * 4. ELEVADORES: profile ELEVADOR or ELV- identifier prefix
+ * 5. ESCADAS_ROLANTES: profile ESCADA_ROLANTE or ESC- identifier prefix
+ * 6. OUTROS: remaining equipment
  *
  * @param {Object} device - Device object
- * @param {string} [device.deviceType] - Device type
- * @param {string} [device.deviceProfile] - Device profile
+ * @param {string} [device.deviceProfile] - Device profile (única autoridade)
  * @param {string} [device.identifier] - Device identifier (server_scope attribute)
  * @returns {string} Equipment category from EquipmentCategory enum
  *
  * @example
- * classifyEquipment({ deviceType: '3F_MEDIDOR', deviceProfile: 'CHILLER' }); // 'climatizacao'
- * classifyEquipment({ deviceType: '3F_MEDIDOR', deviceProfile: '3F_MEDIDOR' }); // 'lojas'
- * classifyEquipment({ deviceType: 'ENTRADA', deviceProfile: 'ENTRADA' }); // 'entrada'
+ * classifyEquipment({ deviceProfile: 'CHILLER' }); // 'climatizacao'
+ * classifyEquipment({ deviceProfile: '3F_MEDIDOR' }); // 'lojas'
+ * classifyEquipment({ deviceProfile: 'ENTRADA' }); // 'entrada'
  */
 export function classifyEquipment(device) {
-  const deviceType = String(device?.deviceType || '').toUpperCase();
-  const deviceProfile = String(device?.deviceProfile || '').toUpperCase();
+  const deviceProfile = String(device?.deviceProfile || '').toUpperCase().trim();
   const identifier = String(device?.identifier || '').toUpperCase();
 
-  // Priority 1: ENTRADA (main meters)
-  const entradaTypes = ['ENTRADA', 'RELOGIO', 'TRAFO', 'SUBESTACAO'];
-  if (entradaTypes.some((t) => deviceType.includes(t) || deviceProfile.includes(t))) {
+  // Priority 1: ENTRADA (main meters) — pelo PROFILE apenas
+  const entradaProfiles = ['ENTRADA', 'RELOGIO', 'TRAFO', 'SUBESTACAO'];
+  if (entradaProfiles.some((t) => deviceProfile.includes(t))) {
     return EquipmentCategory.ENTRADA;
   }
 
-  // Priority 2: LOJAS (stores) - exact match required
-  if (deviceType === '3F_MEDIDOR' && deviceProfile === '3F_MEDIDOR') {
+  // Priority 2: LOJAS (stores) — inclui variantes (3F_MEDIDOR_ARQUIVADO_...)
+  if (deviceProfile.startsWith('3F_MEDIDOR')) {
     return EquipmentCategory.LOJAS;
   }
 
-  // Priority 3: CLIMATIZACAO
-  const hvacTypes = ['CHILLER', 'FANCOIL', 'HVAC', 'AR_CONDICIONADO', 'BOMBA_CAG'];
+  // Priority 3: CLIMATIZACAO (BOMBA_CAG incluso — é climatização, não bomba BAS)
+  const hvacProfiles = ['CHILLER', 'FANCOIL', 'HVAC', 'AR_CONDICIONADO', 'BOMBA_CAG'];
   const hvacIdentifiers = ['CAG', 'HVAC', 'AR_CONDICIONADO'];
   if (
-    hvacTypes.some((t) => deviceType.includes(t) || deviceProfile.includes(t)) ||
+    hvacProfiles.some((t) => deviceProfile.includes(t)) ||
     hvacIdentifiers.some((id) => identifier.includes(id))
   ) {
     return EquipmentCategory.CLIMATIZACAO;
   }
 
-  // Conditional: BOMBA/MOTOR with CAG identifier → climatizacao
+  // Conditional: profile BOMBA/MOTOR com identifier CAG/FANCOIL → climatizacao
   if (
-    ['BOMBA', 'MOTOR'].some((t) => deviceType.includes(t)) &&
+    ['BOMBA', 'MOTOR'].some((t) => deviceProfile.includes(t)) &&
     ['CAG', 'FANCOIL'].some((id) => identifier.includes(id))
   ) {
     return EquipmentCategory.CLIMATIZACAO;
@@ -122,7 +123,6 @@ export function classifyEquipment(device) {
 
   // Priority 4: ELEVADORES
   if (
-    deviceType.includes('ELEVADOR') ||
     deviceProfile.includes('ELEVADOR') ||
     identifier.startsWith('ELV-') ||
     identifier.startsWith('ELEVADOR-')
@@ -132,17 +132,11 @@ export function classifyEquipment(device) {
 
   // Priority 5: ESCADAS ROLANTES
   if (
-    deviceType.includes('ESCADA') ||
     deviceProfile.includes('ESCADA') ||
     identifier.startsWith('ESC-') ||
     identifier.startsWith('ESCADA')
   ) {
     return EquipmentCategory.ESCADAS_ROLANTES;
-  }
-
-  // Priority 6: OUTROS (remaining 3F_MEDIDOR equipment)
-  if (deviceType === '3F_MEDIDOR' || deviceType.includes('MEDIDOR')) {
-    return EquipmentCategory.OUTROS;
   }
 
   // Default: OUTROS
@@ -157,26 +151,26 @@ export function classifyEquipment(device) {
  * @returns {string|null} Subcategory name or null if no subcategory applies
  *
  * @example
- * classifyEquipmentSubcategory({ deviceType: 'CHILLER' }, 'climatizacao'); // 'Chillers'
- * classifyEquipmentSubcategory({ deviceType: 'BOMBA_INCENDIO' }, 'outros'); // 'Bombas de Incêndio'
+ * classifyEquipmentSubcategory({ deviceProfile: 'CHILLER' }, 'climatizacao'); // 'Chillers'
+ * classifyEquipmentSubcategory({ deviceProfile: 'BOMBA_INCENDIO' }, 'outros'); // 'Bombas de Incêndio'
  */
 export function classifyEquipmentSubcategory(device, category) {
-  const deviceType = String(device?.deviceType || '').toUpperCase();
-  const deviceProfile = String(device?.deviceProfile || '').toUpperCase();
+  // deviceProfile + identifier apenas (deviceType em desuso)
+  const deviceProfile = String(device?.deviceProfile || '').toUpperCase().trim();
   const identifier = String(device?.identifier || '').toUpperCase();
 
   if (category === EquipmentCategory.CLIMATIZACAO) {
-    if (deviceType.includes('CHILLER') || deviceProfile.includes('CHILLER')) return 'Chillers';
-    if (deviceType.includes('FANCOIL') || deviceProfile.includes('FANCOIL')) return 'Fancoils';
-    if (identifier.includes('CAG') || deviceType.includes('CENTRAL')) return 'CAG';
-    if (deviceType.includes('BOMBA') && !deviceType.includes('INCENDIO')) return 'Bombas Hidráulicas';
+    if (deviceProfile.includes('CHILLER')) return 'Chillers';
+    if (deviceProfile.includes('FANCOIL')) return 'Fancoils';
+    if (identifier.includes('CAG') || deviceProfile.includes('CENTRAL')) return 'CAG';
+    if (deviceProfile.includes('BOMBA') && !deviceProfile.includes('INCENDIO')) return 'Bombas Hidráulicas';
     return 'Outros HVAC';
   }
 
   if (category === EquipmentCategory.OUTROS) {
-    if (/ILUMINA|LUZ|LAMPADA|LED/.test(deviceType) || /ILUMINA|LUZ/.test(identifier)) return 'Iluminação';
-    if (/INCENDIO|INCÊNDIO/.test(deviceType) || /INCENDIO/.test(identifier)) return 'Bombas de Incêndio';
-    if (/GERADOR|NOBREAK|UPS/.test(deviceType)) return 'Geradores/Nobreaks';
+    if (/ILUMINA|LUZ|LAMPADA|LED/.test(deviceProfile) || /ILUMINA|LUZ/.test(identifier)) return 'Iluminação';
+    if (/INCENDIO|INCÊNDIO/.test(deviceProfile) || /INCENDIO/.test(identifier)) return 'Bombas de Incêndio';
+    if (/GERADOR|NOBREAK|UPS/.test(deviceProfile)) return 'Geradores/Nobreaks';
     return 'Geral';
   }
 
@@ -331,36 +325,34 @@ export function buildEquipmentCategoryDataForTooltip(devices) {
 
 /**
  * Check if a device is a store (Loja) device.
- * Store devices have deviceType = deviceProfile = '3F_MEDIDOR' (exact match).
+ * Store devices have deviceProfile starting with '3F_MEDIDOR' (deviceType em desuso).
  *
  * @param {Object} device - Device object
  * @returns {boolean} True if device is a store device
  *
  * @example
- * isStoreDevice({ deviceType: '3F_MEDIDOR', deviceProfile: '3F_MEDIDOR' }); // true
- * isStoreDevice({ deviceType: '3F_MEDIDOR', deviceProfile: 'CHILLER' }); // false
+ * isStoreDevice({ deviceProfile: '3F_MEDIDOR' }); // true
+ * isStoreDevice({ deviceProfile: 'CHILLER' }); // false
  */
 export function isStoreDevice(device) {
-  const deviceType = String(device?.deviceType || '').toUpperCase();
-  const deviceProfile = String(device?.deviceProfile || '').toUpperCase();
-  return deviceType === '3F_MEDIDOR' && deviceProfile === '3F_MEDIDOR';
+  const deviceProfile = String(device?.deviceProfile || '').toUpperCase().trim();
+  return deviceProfile.startsWith('3F_MEDIDOR');
 }
 
 /**
  * Check if a device is an equipment (Área Comum) device.
- * Equipment devices are 3F_MEDIDOR with deviceProfile != '3F_MEDIDOR'.
+ * Equipment = energia que NÃO é loja nem entrada (pelo deviceProfile).
  *
  * @param {Object} device - Device object
  * @returns {boolean} True if device is an equipment device
  *
  * @example
- * isEquipmentDevice({ deviceType: '3F_MEDIDOR', deviceProfile: 'CHILLER' }); // true
- * isEquipmentDevice({ deviceType: '3F_MEDIDOR', deviceProfile: '3F_MEDIDOR' }); // false
+ * isEquipmentDevice({ deviceProfile: 'CHILLER' }); // true
+ * isEquipmentDevice({ deviceProfile: '3F_MEDIDOR' }); // false
  */
 export function isEquipmentDevice(device) {
-  const deviceType = String(device?.deviceType || '').toUpperCase();
-  const deviceProfile = String(device?.deviceProfile || '').toUpperCase();
-  return deviceType === '3F_MEDIDOR' && deviceProfile !== '3F_MEDIDOR';
+  const cat = classifyEquipment(device);
+  return cat !== EquipmentCategory.LOJAS && cat !== EquipmentCategory.ENTRADA;
 }
 
 /**

--- a/src/utils/thingsboard/deviceClassification.ts
+++ b/src/utils/thingsboard/deviceClassification.ts
@@ -69,11 +69,13 @@ export function extractDeviceMetadataFromRows(
     }
   }
 
-  const deviceType = dataKeyValues['deviceType'] || '';
-  const deviceProfile = dataKeyValues['deviceProfile'] || deviceType;
+  // deviceProfile é a ÚNICA autoridade (deviceType em desuso, 2026-07-14) — o
+  // campo legado é preenchido do profile e o domínio sai do profile.
+  const deviceProfile = dataKeyValues['deviceProfile'] || '';
+  const deviceType = deviceProfile;
   const connectionStatus = dataKeyValues['connectionStatus'] || 'no_info';
 
-  const domain = getDomain(deviceType) || '';
+  const domain = getDomain(deviceProfile) || '';
   const valueField = catalog[domain]?.valueField || '';
   const primaryValue = valueField ? dataKeyValues[valueField] ?? null : null;
   const primaryTs = valueField ? dataKeyTimestamps[valueField] ?? null : null;

--- a/src/utils/thingsboard/deviceClassification.ts
+++ b/src/utils/thingsboard/deviceClassification.ts
@@ -6,7 +6,7 @@
  * aggregation can never silently diverge. No fetch, no DOM, no toast: the
  * caller (controller) owns I/O and decides UI on the typed result/`unknown[]`.
  */
-import { getDomainFromDeviceType } from '../devices/deviceItem.js';
+import { getDomainFromProfile } from '../devices/deviceItem.js';
 import { calculateDeviceStatusMasterRules } from '../devices/deviceStatus.js';
 import type { DeviceMeta, ByStatusCounts } from '../../types/device';
 
@@ -22,8 +22,8 @@ export type ProfileIndex = Record<string, { domain: string; column: string }>;
 export interface ExtractDeps {
   /** Domain catalog (provides each domain's primary `valueField`). */
   catalog: DomainCatalog;
-  /** Override for domain detection (default: lib getDomainFromDeviceType). */
-  getDomain?: (deviceType: string) => string;
+  /** Override for domain detection (default: lib getDomainFromProfile — alimentado com o deviceProfile). */
+  getDomain?: (deviceProfile: string) => string;
   /** Override for status calc (default: lib calculateDeviceStatusMasterRules). */
   calcStatus?: (args: {
     connectionStatus: string;
@@ -45,7 +45,7 @@ export function extractDeviceMetadataFromRows(
 ): DeviceMeta | null {
   if (!rows || rows.length === 0) return null;
 
-  const getDomain = deps.getDomain || getDomainFromDeviceType;
+  const getDomain = deps.getDomain || getDomainFromProfile;
   const calcStatus = deps.calcStatus || calculateDeviceStatusMasterRules;
   const catalog = deps.catalog || {};
   const delayMins = deps.delayMins ?? 1440;

--- a/tests/utils/devices/deviceInfo.test.js
+++ b/tests/utils/devices/deviceInfo.test.js
@@ -1,0 +1,80 @@
+/**
+ * RFC-0111 (endurecido 2026-07-14): deviceProfile é a ÚNICA autoridade de
+ * classificação — deviceType só quando não há profile; name/label nunca.
+ * Casos de regressão vindos da auditoria HO Soul Malls × dashboards próprios
+ * (Praia da Costa, West Plaza, Ilha Plaza, Plaza Macaé) de 2026-07-14.
+ */
+import { describe, it, expect } from 'vitest';
+import { detectContext, detectDomainAndContext } from '../../../src/utils/devices/deviceInfo.js';
+
+describe('detectContext / detectDomainAndContext — deviceProfile é a autoridade', () => {
+  it('Subestação com profile=MOTOR NÃO é entrada (deviceType/name ignorados)', () => {
+    // "3F SUBESTACAO Condominio" (Praia da Costa): deviceType sugeria SUBESTACAO,
+    // mas o profile é MOTOR — jamais entrada.
+    const d = { deviceType: 'SUBESTACAO', deviceProfile: 'MOTOR' };
+    expect(detectDomainAndContext(d)).toEqual({ domain: 'energy', context: 'motor' });
+  });
+
+  it('profile SUBESTACAO (de verdade) continua entrada', () => {
+    const d = { deviceType: '3F_MEDIDOR', deviceProfile: 'SUBESTACAO' };
+    expect(detectContext(d, 'energy')).toBe('entrada');
+  });
+
+  it('BOMBA_CAG é Climatização → equipments, não grupo bomba (CAG BLOCO A/B/C West Plaza)', () => {
+    const d = { deviceType: 'BOMBA_CAG', deviceProfile: 'BOMBA_CAG' };
+    expect(detectDomainAndContext(d)).toEqual({ domain: 'energy', context: 'equipments' });
+  });
+
+  it('BOMBA (BAS, não-CAG) continua no grupo bomba; MOTOR no grupo motor', () => {
+    expect(detectContext({ deviceProfile: 'BOMBA_HIDRAULICA' }, 'energy')).toBe('bomba');
+    expect(detectContext({ deviceProfile: 'MOTOR' }, 'energy')).toBe('motor');
+  });
+
+  it('hidrômetro com deviceType=MOTOR errado é ÁGUA (HIDR. RECALQUE_TORRE, Ilha Plaza)', () => {
+    const d = { deviceType: 'MOTOR', deviceProfile: 'HIDROMETRO' };
+    expect(detectDomainAndContext(d)).toEqual({ domain: 'water', context: 'hidrometro' });
+  });
+
+  it('loja 3F com deviceType=ELEVADOR errado é STORE (3F SPMPTELEV1 / FUN PHOTO, Macaé)', () => {
+    const d = { deviceType: 'ELEVADOR', deviceProfile: '3F_MEDIDOR' };
+    expect(detectDomainAndContext(d)).toEqual({ domain: 'energy', context: 'stores' });
+  });
+
+  it('perfis 3F_MEDIDOR variantes (arquivado) continuam stores', () => {
+    const d = { deviceType: 'QUALQUER', deviceProfile: '3F_MEDIDOR_ARQUIVADO_INSTALADO_SEM_DADOS' };
+    expect(detectContext(d, 'energy')).toBe('stores');
+  });
+
+  it('água: HIDROMETRO_AREA_COMUM + identifier BANHEIROS → banheiros; sem identifier → área comum', () => {
+    expect(
+      detectContext({ deviceProfile: 'HIDROMETRO_AREA_COMUM', identifier: 'BANHEIROS' }, 'water')
+    ).toBe('banheiros');
+    expect(detectContext({ deviceProfile: 'HIDROMETRO_AREA_COMUM' }, 'water')).toBe(
+      'hidrometro_area_comum'
+    );
+  });
+
+  it('água: HIDROMETRO_SHOPPING → hidrometro_entrada, mesmo com deviceType errado', () => {
+    const d = { deviceType: 'MOTOR', deviceProfile: 'HIDROMETRO_SHOPPING' };
+    expect(detectDomainAndContext(d)).toEqual({ domain: 'water', context: 'hidrometro_entrada' });
+  });
+
+  it('temperatura: TERMOSTATO_EXTERNAL como PROFILE resolve domínio e contexto', () => {
+    const d = { deviceType: '', deviceProfile: 'TERMOSTATO_EXTERNAL' };
+    expect(detectDomainAndContext(d)).toEqual({
+      domain: 'temperature',
+      context: 'termostato_external',
+    });
+  });
+
+  it('fallback: sem deviceProfile, deviceType ainda classifica (último recurso)', () => {
+    expect(detectDomainAndContext({ deviceType: 'HIDROMETRO', deviceProfile: '' })).toEqual({
+      domain: 'water',
+      context: 'hidrometro',
+    });
+    expect(detectDomainAndContext({ deviceType: '3F_MEDIDOR' })).toEqual({
+      domain: 'energy',
+      context: 'stores',
+    });
+  });
+});

--- a/tests/utils/devices/deviceInfo.test.js
+++ b/tests/utils/devices/deviceInfo.test.js
@@ -1,6 +1,6 @@
 /**
  * RFC-0111 (endurecido 2026-07-14): deviceProfile é a ÚNICA autoridade de
- * classificação — deviceType só quando não há profile; name/label nunca.
+ * classificação — deviceType está EM DESUSO e nunca é lido; name/label nunca.
  * Casos de regressão vindos da auditoria HO Soul Malls × dashboards próprios
  * (Praia da Costa, West Plaza, Ilha Plaza, Plaza Macaé) de 2026-07-14.
  */
@@ -67,14 +67,16 @@ describe('detectContext / detectDomainAndContext — deviceProfile é a autorida
     });
   });
 
-  it('fallback: sem deviceProfile, deviceType ainda classifica (último recurso)', () => {
+  it('deviceType em desuso: NUNCA é lido — sem deviceProfile o device cai no default', () => {
+    // Mesmo com deviceType "perfeito", sem profile o device é inclassificável
+    // e cai no default (energy/equipments) — deviceType não é fallback.
     expect(detectDomainAndContext({ deviceType: 'HIDROMETRO', deviceProfile: '' })).toEqual({
-      domain: 'water',
-      context: 'hidrometro',
+      domain: 'energy',
+      context: 'equipments',
     });
     expect(detectDomainAndContext({ deviceType: '3F_MEDIDOR' })).toEqual({
       domain: 'energy',
-      context: 'stores',
+      context: 'equipments',
     });
   });
 });


### PR DESCRIPTION
## Summary

`deviceType` is **deprecated**: it frequently arrives wrong from provisioning and misclassified real production devices. From now on, **`deviceProfile` is the ONLY classification authority** (domain/group/category) — `deviceType` is never read in decisions, not even as a fallback; `name`/`label` never classify either (`identifier`, a curated SERVER_SCOPE attribute, still can).

Motivating audit (HO Soul Malls × the 4 own dashboards, 2026-07-14) found four real misclassifications, all caused by deviceType participating in decisions:

| Device | Wrong (deviceType-driven) | Right (profile-driven) |
|---|---|---|
| 3F SUBESTACAO Condominio (Praia da Costa) — profile=MOTOR | classified as `entrada` (224.5 MWh) | `motor` — never entrada |
| CAG BLOCO A/B/C (West Plaza) — profile=BOMBA_CAG | BAS `bomba` group (18.9 MWh outside Climatização) | `equipments` (Climatização per RFC-0128) |
| HIDR. RECALQUE_TORRE (Ilha Plaza) — profile=HIDROMETRO, type=MOTOR | `energy.motor` (water total short by ~180 m³) | water |
| 3F SPMPTELEV1 / FUN PHOTO (Macaé) — profile=3F_MEDIDOR, type=ELEVADOR | `equipments` | `stores` |

## Commits (3 phases)

- **`dc86fb11` fix(classification)** — RFC-0111 hardened for the four production cases + new regression suite `tests/utils/devices/deviceInfo.test.js` (11 tests).
- **`7cd19b81` Phase 1 — `src/utils/devices/`**: `detectContext`/`detectDomainAndContext` profile-only (no fallback at all — a device without profile falls to the domain default); `createDeviceItem` had the priority INVERTED (`deviceType || deviceProfile`) — fixed; RFC-0128 `classifyEquipment`/subcategories/isStore/isEquipment rewritten profile+identifier (`BOMBA_CAG` → Climatização; Lojas = `startsWith('3F_MEDIDOR')`); RFC-0207 engine: deviceType removed from combined matching, `ConditionalRule.deviceTypes` renamed to `deviceProfiles` (it always matched the profile) with legacy-key normalization.
- **`b0ea561f` Phase 2 — widgets**: v-5.2.0 MAIN_VIEW/TELEMETRY/HEADER, v-5.4.0 and all 7 MYIO-SIM v5.2.0 controllers — ~70 decision reads converted (the deviceType-coercion "MASTER RULE" is gone). Legacy `deviceType` OUTPUT fields are kept for payload compat, filled from the profile.
- **`1d168fcf` Phase 3 — contracts/names**: `getDomainFromProfile` is the canonical export; `getDomainFromDeviceType` kept as `@deprecated` alias so already-published widgets keep working; `DomainType` deduplicated; icon/config/status util params renamed; template-cards v5/v6 prefer `deviceProfile`.

## Validation

- **641 tests green** at every phase (includes the new production-case regression suite).
- tsup build (ESM/CJS/DTS) green; `node --check` clean on all 20+ touched controllers/modules.

## Deliberately NOT touched (need owner decisions)

1. **MAIN_BAS** — deviceType is a documented fallback there (RFC-0171); BAS devices may lack profiles and there are zero tests. Needs a BAS data audit first.
2. **Pre-Setup-Constructor / Node-RED attributesSync** — they *write* the deviceType attribute (provisioning data contract).
3. **`device.ts` naming helpers** — provisioning taxonomy mirrored from data-ingestion-prod `naming-rules.ts`; renaming one side would desync the mirror.
4. External API payload fields (availability RFC-0175, alarms, annotations).
5. `DEVICE_TYPE_CONFIG` export rename — breaking, candidate for a future major.

## Deploy notes

Requires lib publish + widget sync (v-5.2.0 MAIN_VIEW/TELEMETRY/HEADER, v-5.4.0, UNIQUE) together — the UNIQUE controller calls `getDomainFromProfile` with alias fallback, so old lib + new widget also works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
