### PR TITLE
Feat/rfc 0223 allreport perdevice granularity - ED-1013

### DIFF
--- a/src/components/premium-modals/internal/collapsible-section/CollapsibleSection.ts
+++ b/src/components/premium-modals/internal/collapsible-section/CollapsibleSection.ts
@@ -1,0 +1,165 @@
+// premium-modals/internal/collapsible-section/CollapsibleSection.ts
+// RFC-0223: shared collapsible header-row renderer for GROUP and DEVICE
+// sections in AllReportModal's sectioned (1d/1h) grid. A pure string builder —
+// the whole grid is one innerHTML rebuild per render pass (matching
+// AllReportModal's existing renderTable/renderGroupedRows convention).
+// Collapse/expand AFTER the initial paint is a pure DOM show/hide
+// (AllReportModal.toggleSection), never a re-invocation of this renderer.
+
+export type CollapsibleSectionLevel = 0 | 1 | 2;
+
+export interface CollapsibleSectionHeaderOptions {
+  /** collapsedSections key this header controls, e.g. 'grp:Lojas' | 'dev:123'. */
+  sectionKey: string;
+  /** Ancestor keys (own key excluded) — drives this header's OWN visibility (hidden if any ancestor is collapsed). */
+  ancestorKeys: string[];
+  level: CollapsibleSectionLevel;
+  title: string;
+  /** e.g. "16 dias" — omitted for group headers. */
+  meta?: string;
+  /** e.g. "1.204,53 kWh" / "Média 22,4 °C". */
+  totalLabel: string;
+  collapsed: boolean;
+  colSpan: number;
+  /** AC19: this device's series fetch failed — render a distinct warning badge. */
+  incomplete?: boolean;
+}
+
+export interface CollapsibleSectionLeafRowOptions {
+  /** Ancestor keys (all sections this row is nested under) — hidden if ANY is collapsed. */
+  ancestorKeys: string[];
+  level: CollapsibleSectionLevel;
+  /** Pre-built `<td>...</td>` markup — caller owns escaping/formatting of cell content. */
+  cells: string[];
+}
+
+export const escapeHtml = (s: string): string =>
+  String(s).replace(
+    /[&<>"']/g,
+    (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c] as string
+  );
+
+export function renderCollapsibleSectionHeader(opts: CollapsibleSectionHeaderOptions): string {
+  const caret = opts.collapsed ? '▶' : '▼';
+  const ancestors = escapeHtml(opts.ancestorKeys.join(' '));
+  return `
+    <tr class="rp-section-header rp-section-header--level-${opts.level}" data-section-toggle="${escapeHtml(opts.sectionKey)}" data-ancestors="${ancestors}" role="button" tabindex="0" aria-expanded="${!opts.collapsed}">
+      <td colspan="${opts.colSpan}">
+        <span class="rp-section-caret" aria-hidden="true">${caret}</span>
+        <span class="rp-section-title">${escapeHtml(opts.title)}</span>
+        ${opts.meta ? `<span class="rp-section-meta">${escapeHtml(opts.meta)}</span>` : ''}
+        ${opts.incomplete ? `<span class="rp-section-badge">dados incompletos</span>` : ''}
+        <span class="rp-section-total">${escapeHtml(opts.totalLabel)}</span>
+      </td>
+    </tr>`;
+}
+
+export function renderCollapsibleLeafRow(opts: CollapsibleSectionLeafRowOptions): string {
+  const ancestors = escapeHtml(opts.ancestorKeys.join(' '));
+  return `
+    <tr class="rp-section-row rp-section-row--level-${opts.level}" data-ancestors="${ancestors}">
+      ${opts.cells.join('')}
+    </tr>`;
+}
+
+let stylesInjected = false;
+
+/** Idempotent style injection — same pattern as granularity-selector/styles.ts. */
+export function injectCollapsibleSectionStyles(): void {
+  if (stylesInjected || typeof document === 'undefined') return;
+  if (document.getElementById('myio-collapsible-section-styles')) {
+    stylesInjected = true;
+    return;
+  }
+  const style = document.createElement('style');
+  style.id = 'myio-collapsible-section-styles';
+  style.textContent = `
+.rp-section-header {
+  cursor: pointer;
+  user-select: none;
+}
+.rp-section-header td {
+  background: color-mix(in srgb, var(--myio-brand-700, #4A148C) 6%, var(--myio-bg, #f3f4f6));
+  font-weight: 700;
+  padding: 8px 12px !important;
+  border-top: 2px solid color-mix(in srgb, var(--myio-brand-700, #4A148C) 25%, var(--myio-border, #e5e7eb));
+}
+.rp-section-header--level-0 td {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--myio-text-muted, #6b7280);
+}
+.rp-section-header--level-1 td {
+  font-size: 13px;
+  color: var(--myio-text, #1f2937);
+  padding-left: 28px !important;
+}
+.rp-section-header--level-2 td {
+  font-size: 12px;
+  padding-left: 44px !important;
+}
+.rp-section-header:hover td {
+  background: color-mix(in srgb, var(--myio-brand-700, #4A148C) 12%, var(--myio-bg, #f3f4f6));
+}
+.rp-section-header:focus-visible {
+  outline: 2px solid var(--myio-brand-700, #4A148C);
+  outline-offset: -2px;
+}
+.rp-section-caret {
+  display: inline-block;
+  width: 14px;
+  margin-right: 6px;
+  color: var(--myio-brand-700, #4A148C);
+}
+.rp-section-meta {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--myio-text-muted, #6b7280);
+  margin-left: 8px;
+}
+.rp-section-total {
+  float: right;
+  font-size: 12px;
+  font-weight: 700;
+  color: color-mix(in srgb, var(--myio-brand-700, #4A148C) 80%, var(--myio-primary, #1565c0));
+}
+/* Semantic status color (not brand-themed on purpose — matches the existing
+   #error-container convention of a fixed, always-legible warning tone). */
+.rp-section-badge {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  background: #fef3c7;
+  color: #b45309;
+}
+.rp-section-row--level-1 td:first-child,
+.rp-section-row--level-2 td:first-child {
+  position: relative;
+}
+.rp-section-row--level-1 td:first-child {
+  padding-left: 32px !important;
+}
+.rp-section-row--level-2 td:first-child {
+  padding-left: 48px !important;
+}
+.rp-section-row--level-1 td:first-child::before,
+.rp-section-row--level-2 td:first-child::before {
+  content: '';
+  position: absolute;
+  left: 16px;
+  top: 0;
+  bottom: 0;
+  border-left: 2px solid color-mix(in srgb, var(--myio-brand-700, #4A148C) 20%, var(--myio-border, #e5e7eb));
+}
+.rp-section-row--level-2 td:first-child::before {
+  left: 32px;
+}
+`;
+  document.head.appendChild(style);
+  stylesInjected = true;
+}

--- a/src/components/premium-modals/internal/collapsible-section/index.ts
+++ b/src/components/premium-modals/internal/collapsible-section/index.ts
@@ -1,0 +1,14 @@
+// premium-modals/internal/collapsible-section — shared collapsible section
+// header/row renderer for group and device sections (RFC-0223).
+
+export {
+  renderCollapsibleSectionHeader,
+  renderCollapsibleLeafRow,
+  injectCollapsibleSectionStyles,
+  escapeHtml,
+} from './CollapsibleSection';
+export type {
+  CollapsibleSectionLevel,
+  CollapsibleSectionHeaderOptions,
+  CollapsibleSectionLeafRowOptions,
+} from './CollapsibleSection';

--- a/src/components/premium-modals/internal/engines/DateEngine.ts
+++ b/src/components/premium-modals/internal/engines/DateEngine.ts
@@ -16,3 +16,32 @@ export const rangeDaysInclusive = (start: string, end: string) => {
   }
   return out;
 };
+
+// RFC-0223: tz-pinned day/hour bucket keys — Intl.DateTimeFormat is tz-database
+// driven, so DST transition days naturally yield 23/25 distinct hour keys instead
+// of a hard-coded 24. Never use `new Date().getHours()` (browser-local-tz) for
+// these keys — it would drift from the São Paulo day boundary the operator sees.
+const dayHourParts = (timestamp: number | Date, tz: string, withHour: boolean) => {
+  const dt = typeof timestamp === 'number' ? new Date(timestamp) : timestamp;
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    ...(withHour ? { hour: '2-digit' as const, hourCycle: 'h23' as const } : {}),
+  }).formatToParts(dt);
+  const get = (type: string) => parts.find((p) => p.type === type)?.value || '';
+  return { year: get('year'), month: get('month'), day: get('day'), hour: get('hour') };
+};
+
+// 'YYYY-MM-DD' — the day bucket key, shared by 1d server buckets and 1h client bucketing.
+export const toDayKey = (timestamp: number | Date, tz = 'America/Sao_Paulo'): string => {
+  const { year, month, day } = dayHourParts(timestamp, tz, false);
+  return `${year}-${month}-${day}`;
+};
+
+// 'YYYY-MM-DDTHH' — the hour bucket key (00-23, actual local hour count on DST days).
+export const toHourKey = (timestamp: number | Date, tz = 'America/Sao_Paulo'): string => {
+  const { year, month, day, hour } = dayHourParts(timestamp, tz, true);
+  return `${year}-${month}-${day}T${hour}`;
+};

--- a/src/components/premium-modals/internal/report-mode-selector/ReportModeSelector.ts
+++ b/src/components/premium-modals/internal/report-mode-selector/ReportModeSelector.ts
@@ -1,0 +1,184 @@
+// premium-modals/internal/report-mode-selector/ReportModeSelector.ts
+// RFC-0223: thin wrapper composing the existing createGranularitySelector
+// (Diário/Horário) unchanged, adding a Consolidado segment + one bounding
+// role="radiogroup" region so all three read as a single mutually-exclusive
+// choice-set. The shared granularity-selector primitive is never modified —
+// this keeps EnergyModal (its other consumer) insulated from this feature.
+
+import { createGranularitySelector } from '../../../granularity-selector';
+import { REPORT_MODE_SELECTOR_CSS_PREFIX, injectReportModeSelectorStyles } from './styles';
+import {
+  ReportMode,
+  ReportModeSelectorInstance,
+  ReportModeSelectorParams,
+  ReportModeSelectorSettings,
+} from './types';
+
+const P = REPORT_MODE_SELECTOR_CSS_PREFIX;
+
+function isReportMode(v: unknown): v is ReportMode {
+  return v === 'consolidado' || v === '1d' || v === '1h';
+}
+
+export function createReportModeSelector(
+  container: HTMLElement,
+  params: ReportModeSelectorParams = {}
+): ReportModeSelectorInstance {
+  injectReportModeSelectorStyles();
+
+  const settings: ReportModeSelectorSettings = {
+    value: 'consolidado',
+    themeMode: 'light',
+    label: 'Modo do relatório',
+    helperText: 'Como o consumo é detalhado no relatório.',
+    horarioEnabled: true,
+    ...(params.settings || {}),
+  };
+  let mode: ReportMode =
+    isReportMode(settings.value) && (settings.value !== '1h' || settings.horarioEnabled)
+      ? settings.value
+      : 'consolidado';
+  let destroyed = false;
+
+  const root = document.createElement('div');
+  container.appendChild(root);
+  root.className = [
+    P,
+    settings.themeMode === 'dark' ? `${P}--dark` : '',
+    settings.disabled ? `${P}--disabled` : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+  root.setAttribute('role', 'radiogroup');
+  root.setAttribute('aria-label', settings.label || 'Modo do relatório');
+
+  if (settings.label) {
+    const labelEl = document.createElement('span');
+    labelEl.className = `${P}__label`;
+    labelEl.textContent = settings.label;
+    root.appendChild(labelEl);
+  }
+
+  const track = document.createElement('div');
+  track.className = `${P}__track`;
+  root.appendChild(track);
+
+  const consolidadoBtn = document.createElement('button');
+  consolidadoBtn.type = 'button';
+  consolidadoBtn.className = `${P}__btn`;
+  consolidadoBtn.dataset.mode = 'consolidado';
+  consolidadoBtn.setAttribute('role', 'radio');
+  consolidadoBtn.title = 'Consolidado';
+  consolidadoBtn.textContent = 'Consolidado';
+  consolidadoBtn.disabled = !!settings.disabled;
+  track.appendChild(consolidadoBtn);
+
+  const granMount = document.createElement('div');
+  track.appendChild(granMount);
+
+  // Composed unchanged: only the option labels are customized (Diário/Horário
+  // instead of the default 1h/1d titles). Its own onChange is a no-op safety
+  // net — handleTrackClick below owns every Consolidado<->1d/1h transition,
+  // since the library's onChange only fires on an internal-value change and
+  // would silently miss "switch away from Consolidado back to the same
+  // internal value" (e.g. Consolidado -> Diário when internal value was
+  // already '1d' from a prior session).
+  // RFC-0223 delivery phases: Horário is omitted from the options array
+  // entirely (not merely disabled) until P3 — "no dead control" means the
+  // operator never sees a clickable segment that does nothing.
+  const granularitySelector = createGranularitySelector(granMount, {
+    settings: {
+      value: mode === '1h' ? '1h' : '1d',
+      label: '',
+      themeMode: settings.themeMode,
+      disabled: settings.disabled,
+      options: settings.horarioEnabled
+        ? [
+            { value: '1d', label: 'Diário', title: 'Diário' },
+            { value: '1h', label: 'Horário', title: 'Horário' },
+          ]
+        : [{ value: '1d', label: 'Diário', title: 'Diário' }],
+    },
+    onChange: () => {
+      /* handled by handleTrackClick */
+    },
+  });
+
+  if (settings.helperText) {
+    const hint = document.createElement('div');
+    hint.className = `${P}__hint`;
+    hint.textContent = settings.helperText;
+    root.appendChild(hint);
+  }
+
+  // Single source of truth for which of the 3 segments LOOKS active: our own
+  // [aria-checked] attribute, driven by `mode` — never the nested selector's
+  // internal .active class (neutralized in styles.ts), so Consolidado can be
+  // "the active one" even while the nested selector still privately holds
+  // value='1d'/'1h' from a previous non-Consolidado selection.
+  const syncActiveUI = (): void => {
+    consolidadoBtn.setAttribute('aria-checked', String(mode === 'consolidado'));
+    granMount.querySelectorAll<HTMLButtonElement>('[data-granularity]').forEach((btn) => {
+      const active = mode !== 'consolidado' && btn.dataset.granularity === mode;
+      btn.setAttribute('role', 'radio');
+      btn.setAttribute('aria-checked', String(active));
+    });
+    if (mode !== 'consolidado') granularitySelector.setValue(mode, { silent: true });
+  };
+  syncActiveUI();
+
+  /** Aplica um novo modo. Retorna true se houve mudança real. */
+  const applyMode = (next: ReportMode, silent: boolean): boolean => {
+    if (next === mode) return false;
+    mode = next;
+    syncActiveUI();
+    if (!silent && params.onChange) {
+      // onChange pode ser async — falhas não podem quebrar a UI do seletor.
+      Promise.resolve(params.onChange(mode)).catch((err) => {
+        console.warn('[ReportModeSelector] onChange failed:', err);
+      });
+    }
+    return true;
+  };
+
+  const handleTrackClick = (e: MouseEvent): void => {
+    if (destroyed || settings.disabled) return;
+    const target = e.target as HTMLElement;
+    if (target.closest('[data-mode="consolidado"]')) {
+      applyMode('consolidado', false);
+      return;
+    }
+    const granHit = target.closest<HTMLElement>('[data-granularity]');
+    const next = granHit?.getAttribute('data-granularity');
+    if (next === '1d' || next === '1h') applyMode(next, false);
+  };
+  track.addEventListener('click', handleTrackClick);
+
+  return {
+    element: root,
+    getValue: () => mode,
+    setValue(next, opts) {
+      if (destroyed || !isReportMode(next)) return;
+      if (next === '1h' && !settings.horarioEnabled) return; // P1: no dead control, no back door either
+      applyMode(next, opts?.silent === true);
+    },
+    setThemeMode(next) {
+      settings.themeMode = next;
+      root.classList.toggle(`${P}--dark`, next === 'dark');
+      granularitySelector.setThemeMode(next);
+    },
+    setDisabled(disabled) {
+      settings.disabled = disabled;
+      root.classList.toggle(`${P}--disabled`, disabled);
+      consolidadoBtn.disabled = disabled;
+      granularitySelector.setDisabled(disabled);
+    },
+    destroy() {
+      if (destroyed) return;
+      destroyed = true;
+      track.removeEventListener('click', handleTrackClick);
+      granularitySelector.destroy();
+      root.remove();
+    },
+  };
+}

--- a/src/components/premium-modals/internal/report-mode-selector/index.ts
+++ b/src/components/premium-modals/internal/report-mode-selector/index.ts
@@ -1,0 +1,12 @@
+// premium-modals/internal/report-mode-selector — Consolidado | Diário | Horário
+// report-mode selector (RFC-0223), wrapping granularity-selector unchanged.
+
+export { createReportModeSelector } from './ReportModeSelector';
+export { REPORT_MODE_SELECTOR_CSS_PREFIX, injectReportModeSelectorStyles } from './styles';
+export type {
+  ReportMode,
+  ReportModeSelectorThemeMode,
+  ReportModeSelectorSettings,
+  ReportModeSelectorParams,
+  ReportModeSelectorInstance,
+} from './types';

--- a/src/components/premium-modals/internal/report-mode-selector/styles.ts
+++ b/src/components/premium-modals/internal/report-mode-selector/styles.ts
@@ -1,0 +1,112 @@
+// premium-modals/internal/report-mode-selector/styles.ts
+// Theming: --myio-brand-700 for the active fill (solid, matching the existing
+// #filter-btn / exclusion-info-dot convention for "on" state) and color-mix()
+// for the bounding-region border + hover tint (matching FilterOrderingModal's
+// `.chip`/`.chip.selected` pattern) — no hard-coded colors, both themes covered.
+
+export const REPORT_MODE_SELECTOR_CSS_PREFIX = 'myio-report-mode-selector';
+
+let stylesInjected = false;
+
+/** Injeta os estilos base (idempotente). */
+export function injectReportModeSelectorStyles(): void {
+  if (stylesInjected || typeof document === 'undefined') return;
+  if (document.getElementById('myio-report-mode-selector-styles')) {
+    stylesInjected = true;
+    return;
+  }
+  const P = REPORT_MODE_SELECTOR_CSS_PREFIX;
+  const style = document.createElement('style');
+  style.id = 'myio-report-mode-selector-styles';
+  style.textContent = `
+.${P} {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.${P}__label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--myio-text-muted, #6b7280);
+}
+.${P}__track {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px;
+  background: var(--myio-bg, #f9fafb);
+  border: 1px solid color-mix(in srgb, var(--myio-brand-700, #4A148C) 35%, #e5e7eb);
+  border-radius: 8px;
+  box-sizing: border-box;
+}
+.${P}--dark .${P}__track {
+  background: #111827;
+  border-color: color-mix(in srgb, var(--myio-brand-700, #4A148C) 45%, #374151);
+}
+.${P}--disabled {
+  opacity: 0.6;
+}
+.${P}__btn {
+  padding: 4px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  font-family: inherit;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--myio-text-muted, #6b7280);
+  white-space: nowrap;
+}
+.${P}__btn:hover:not([aria-checked="true"]):not(:disabled) {
+  background: color-mix(in srgb, var(--myio-brand-700, #4A148C) 10%, #fff);
+  color: var(--myio-text, #1f2937);
+}
+.${P}--dark .${P}__btn:hover:not([aria-checked="true"]):not(:disabled) {
+  background: color-mix(in srgb, var(--myio-brand-700, #4A148C) 22%, #374151);
+  color: #f3f4f6;
+}
+.${P}__btn:disabled {
+  cursor: not-allowed;
+}
+.${P}__btn[aria-checked="true"] {
+  background: var(--myio-brand-700, #4A148C);
+  color: #fff;
+  border-color: var(--myio-brand-700, #4A148C);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+/* The nested granularity-selector must blend into the same track — its own
+   pill chrome (border/background/padding) is neutralized; visual "active"
+   state for its two buttons is driven entirely by our own [aria-checked]
+   attribute (set by ReportModeSelector), not its internal .active class,
+   so Consolidado <-> Diário/Horário is always a clean single-active state. */
+.${P}__track .myio-granularity-selector {
+  background: transparent;
+  border: none;
+  padding: 0;
+  gap: 2px;
+}
+.${P}__track .myio-granularity-selector__btn {
+  border-radius: 6px;
+}
+.${P}__track .myio-granularity-selector__btn.active {
+  background: transparent;
+  color: var(--myio-text-muted, #6b7280);
+  border-color: transparent;
+  box-shadow: none;
+}
+.${P}__track .myio-granularity-selector__btn[aria-checked="true"] {
+  background: var(--myio-brand-700, #4A148C);
+  color: #fff;
+  border-color: var(--myio-brand-700, #4A148C);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+.${P}__hint {
+  font-size: 10px;
+  color: var(--myio-text-muted, #6b7280);
+}
+`;
+  document.head.appendChild(style);
+  stylesInjected = true;
+}

--- a/src/components/premium-modals/internal/report-mode-selector/types.ts
+++ b/src/components/premium-modals/internal/report-mode-selector/types.ts
@@ -1,0 +1,45 @@
+// premium-modals/internal/report-mode-selector/types.ts
+// RFC-0223: Consolidado | Diário | Horário report-mode selector — a thin
+// wrapper around the existing granularity-selector (1d/1h), adding a
+// Consolidado segment + one bounding radiogroup region. Does NOT extend the
+// shared granularity-selector primitive (kept untouched, single-consumer risk
+// stays isolated to this modal).
+
+export type ReportMode = 'consolidado' | '1d' | '1h';
+
+export type ReportModeSelectorThemeMode = 'light' | 'dark';
+
+export interface ReportModeSelectorSettings {
+  /** Valor inicial (default: 'consolidado' — RFC-0223: zero regressão por padrão). */
+  value?: ReportMode;
+  themeMode?: ReportModeSelectorThemeMode;
+  disabled?: boolean;
+  /** Rótulo do grupo acima do track (default: "Modo do relatório"). */
+  label?: string;
+  /** Texto de ajuda abaixo do track (default: frase da RFC). String vazia oculta. */
+  helperText?: string;
+  /**
+   * RFC-0223 delivery phases: `Horário` fica OCULTO até a P3 (drill-down
+   * hora-a-hora) — "no dead control", nunca um botão clicável que não faz
+   * nada. Default true (o componente é genericamente capaz das 3 opções);
+   * a P1 do AllReportModal passa `false` explicitamente e a P3 remove o flag.
+   */
+  horarioEnabled?: boolean;
+}
+
+export interface ReportModeSelectorParams {
+  settings?: ReportModeSelectorSettings;
+  /** Disparado apenas em mudança real de modo (clique repetido no ativo não dispara). */
+  onChange?: (value: ReportMode) => void | Promise<void>;
+}
+
+export interface ReportModeSelectorInstance {
+  element: HTMLElement;
+  getValue(): ReportMode;
+  /** silent: true atualiza a UI sem disparar onChange. */
+  setValue(value: ReportMode, opts?: { silent?: boolean }): void;
+  setThemeMode(mode: ReportModeSelectorThemeMode): void;
+  setDisabled(disabled: boolean): void;
+  /** Remove listeners, o granularity-selector interno e o elemento do DOM. */
+  destroy(): void;
+}

--- a/src/components/premium-modals/report-all/AllReportModal.ts
+++ b/src/components/premium-modals/report-all/AllReportModal.ts
@@ -1,6 +1,6 @@
 // report-all/AllReportModal.ts
 import { createModal } from '../internal/ModalPremiumShell';
-import { toISOWithOffset, rangeDaysInclusive } from '../internal/engines/DateEngine';
+import { toISOWithOffset, rangeDaysInclusive, toDayKey, toHourKey } from '../internal/engines/DateEngine';
 import { toCsv } from '../internal/engines/CsvExporter';
 import { fmtPt } from '../internal/engines/NumberFmt';
 import { AuthClient } from '../internal/engines/AuthClient';
@@ -16,8 +16,9 @@ import { exportGridPdf, exportGridXls } from '../../telemetry-grid-shopping/expo
 import type { TelemetryDevice } from '../../telemetry-grid-shopping/types';
 import { createParticipationChart } from '../../graphs';
 import type { ParticipationChartInstance } from '../../graphs';
-import { createGranularitySelector } from '../../granularity-selector';
-import type { GranularitySelectorInstance } from '../../granularity-selector';
+import { createReportModeSelector } from '../internal/report-mode-selector';
+import type { ReportModeSelectorInstance } from '../internal/report-mode-selector';
+import { renderCollapsibleSectionHeader, renderCollapsibleLeafRow, injectCollapsibleSectionStyles, escapeHtml } from '../internal/collapsible-section';
 import { createModalFooter } from '../footer-modal';
 import type { ModalFooterInstance } from '../footer-modal';
 
@@ -60,6 +61,43 @@ interface StoreReading {
   id?: string; // Data API item id (ingestionId) — needed for per-device series fetch (1h export)
 }
 
+// RFC-0223: per-device/day/hour section tree — the single source every
+// consumer (sectioned grid, KPIs, participation chart) reads from, so totals
+// reconcile with the visible rows by construction instead of by independent
+// implementations happening to agree (AC18).
+interface ReportSectionHourNode {
+  key: string; // 'YYYY-MM-DDTHH'
+  label: string; // 'HH:00'
+  value: number | null; // null only for temperature with no reading that hour
+  excluded: boolean; // Períodos filter (P4) — false until then
+}
+
+interface ReportSectionDayNode {
+  key: string; // 'YYYY-MM-DD'
+  label: string; // 'DD/MM'
+  value: number | null;
+  hours?: ReportSectionHourNode[]; // present only when granularity === '1h'
+  excluded: boolean;
+}
+
+interface ReportSectionDeviceNode {
+  row: StoreReading;
+  days: ReportSectionDayNode[]; // [] when coverage !== 'ok' or the device has zero readings
+  total: number | null;
+  dayCount: number; // AC16: 0 for a genuinely-empty or failed device
+  coverage: 'ok' | 'partial' | 'failed';
+}
+
+interface ReportSectionGroupNode {
+  groupLabel: string; // '—' when ungrouped (mirrors renderGroupedRows' own convention)
+  devices: ReportSectionDeviceNode[];
+  total: number | null;
+}
+
+interface ReportSectionModel {
+  groups: ReportSectionGroupNode[];
+}
+
 export class AllReportModal {
   private modal: any;
   private authClient: AuthClient;
@@ -84,16 +122,69 @@ export class AllReportModal {
   // Domain configuration
   private domainConfig: DomainConfig;
 
-  // Granularity: '1d' (daily) | '1h' (hourly)
-  private granularity: '1d' | '1h' = '1d';
+  // RFC-0223: legacy 2-way granularity, now DERIVED from reportMode (never
+  // assigned directly — the old onChange write site was removed when
+  // ReportModeSelector replaced the bare granularity toggle). Kept as a
+  // read-only getter, not deleted, so existing internal readers (exportCSV's
+  // 1h branch, enrichTemperatureAverages) keep compiling and behaving exactly
+  // as before for any reportMode other than 'consolidado'.
+  private get granularity(): '1d' | '1h' {
+    return this.reportMode === '1h' ? '1h' : '1d';
+  }
 
-  // Hourly series fetched device-by-device for the 1h CSV export (the /totals endpoint
-  // has no hourly granularity). Keyed by StoreReading.id; cache key = period, so a new
-  // load or granularity switch invalidates it.
-  private hourlySeriesCache: {
+  // RFC-0223: tz used for day/hour bucket keys — params.api.timezone override,
+  // default América/São_Paulo (matches BaseApiCfg's documented default).
+  private get timezone(): string {
+    return this.params.api.timezone || 'America/Sao_Paulo';
+  }
+
+  // RFC-0223: report temporal resolution. 'consolidado' (default) preserves today's
+  // behavior byte-for-byte — no per-device series fetch, single aggregate row per device.
+  private reportMode: 'consolidado' | '1d' | '1h' = 'consolidado';
+
+  // RFC-0223: per-device raw point series for 1d/1h sections (grid + PDF + CSV).
+  // Absorbs the old hourlySeriesCache/ensureHourlySeries (single-purpose, 1h-only,
+  // CSV-export-only) — this is the same batched-fetch mechanism generalized to
+  // also drive the on-screen sectioned grid at either granularity. Raw points are
+  // cached (NOT pre-bucketed into day/hour trees) so exportHourlyCSV's existing
+  // per-point consumer stays valid and day/hour buckets stay a single derived
+  // view (bucketByDay), never a second stored representation that could drift
+  // from the raw series.
+  // Cache key: `${startISO}|${endISO}|${granularity}|${idsKey}` (idsKey mirrors
+  // the old hourlySeriesCache's sorted-device-id-list convention).
+  // Invalidated only by a full load, a mode switch, or a device-set change — an
+  // excludedDays/excludedHours change is a pure client-side recompute and never
+  // invalidates it.
+  private deviceSeriesCache: {
     key: string;
-    series: Map<string, Array<{ timestamp: number; value: number }>>;
+    granularity: '1d' | '1h';
+    raw: Map<string, Array<{ timestamp: number; value: number }>>;
+    // Per-device fetch outcome so a swallowed failure never reads as "0 consumo".
+    coverage: Map<string, 'ok' | 'partial' | 'failed'>;
   } | null = null;
+
+  // RFC-0223: temporal (day/hour) Períodos filter. Empty set means "all included".
+  // Keys are derived via the shared tz-aware toDayKey/toHourKey formatter so they
+  // line up with both the visible day labels and the 1d server buckets.
+  private excludedDays: Set<string> = new Set(); // 'YYYY-MM-DD'
+  private excludedHours: Set<string> = new Set(); // 'YYYY-MM-DDTHH'
+
+  // RFC-0223: collapse state for group/device/day sections, namespaced by id
+  // (never by label) so a label containing the separator can't alias another
+  // section: `grp:<id>` | `dev:<id>` | `dev:<id>#day:<YYYY-MM-DD>`.
+  private collapsedSections: Set<string> = new Set();
+  // Identifies the period+mode this collapse state belongs to
+  // (`${startISO}|${endISO}|${reportMode}`) — a loadData()/mode change compares
+  // against this and resets collapsedSections to the AC6 defaults on mismatch; a
+  // Períodos filter apply re-renders without touching it, so carets persist.
+  private collapsedSectionsEpoch: string | null = null;
+
+  // RFC-0223: memoizes buildReportSectionModel() for the current render pass —
+  // every 1d/1h consumer (renderSectionedRows, computeKpis,
+  // updateParticipationChart, getEffectiveDeviceTotal) calls getReportSectionModel()
+  // instead of rebuilding the O(devices × days × hours) tree once per row.
+  // buildReportSectionModel() itself stays a pure, directly-testable function.
+  private sectionModelCache: { key: string; model: ReportSectionModel } | null = null;
 
   // When true, devices flagged via `exclude_groups_totals` for this group are dropped
   // from the report so its total reconciles with the dashboard KPIs. Toggleable in the UI.
@@ -107,8 +198,8 @@ export class AllReportModal {
   // Participation chart (right column) — created lazily on the first data load;
   // fed with the same rows the table shows (exclusion toggle + search respected).
   private participationChart: ParticipationChartInstance | null = null;
-  // Granularity selector (shared component — same pattern as EnergyModal).
-  private granularitySelector: GranularitySelectorInstance | null = null;
+  // RFC-0223: Consolidado | Diário | Horário selector (wraps granularity-selector).
+  private reportModeSelector: ReportModeSelectorInstance | null = null;
   // Footer premium: Customer · relógio · versão | Powered by MYIO | PDF/CSV/XLSX.
   // Os botões de export vivem AQUI (removidos da toolbar).
   private modalFooter: ModalFooterInstance | null = null;
@@ -275,10 +366,13 @@ export class AllReportModal {
         this.participationChart = null;
       }
 
-      // Cleanup granularity selector (tooltip + listeners)
-      if (this.granularitySelector) {
-        this.granularitySelector.destroy();
-        this.granularitySelector = null;
+      // Cleanup report-mode selector (RFC-0223: also destroys the nested
+      // granularity-selector + its tooltip). Reopening always starts at
+      // Consolidado (reportMode is reset in the constructor's field initializer,
+      // and a fresh AllReportModal instance is created per openDashboardPopupAllReport call).
+      if (this.reportModeSelector) {
+        this.reportModeSelector.destroy();
+        this.reportModeSelector = null;
       }
 
       this.authClient.clearCache();
@@ -304,8 +398,7 @@ export class AllReportModal {
               <input type="text" id="date-range" class="myio-input" readonly placeholder="Selecione o período" style="width: 300px;">
             </div>
             <div class="myio-form-group" style="margin-bottom: 0;">
-              <label class="myio-label">Granularidade</label>
-              <div id="granularity-toggle" style="display: flex; align-items: center;"></div>
+              <div id="report-mode-toggle" style="display: flex; align-items: center;"></div>
             </div>
             <button id="load-btn" class="myio-btn myio-btn-primary">
               <span class="myio-spinner" id="load-spinner" style="display: none;"></span>
@@ -314,6 +407,13 @@ export class AllReportModal {
             <!-- Exports CSV/PDF/XLS vivem no footer premium (createModalFooter) -->
             <button id="filter-btn" class="myio-btn myio-btn-secondary" style="background: var(--myio-brand-700); color: white;">
               🔍 Filtros & Ordenação
+            </button>
+            <!-- RFC-0223: Períodos filter + collapse-all — hidden until reportMode !== 'consolidado' -->
+            <button id="periods-filter-btn" class="myio-btn myio-btn-secondary" style="display: none; background: var(--myio-brand-700); color: white;">
+              📅 Períodos
+            </button>
+            <button id="collapse-all-btn" class="myio-btn myio-btn-secondary" style="display: none;">
+              Recolher tudo
             </button>
             <div class="myio-form-group" style="margin-bottom: 0; display: flex; align-items: center; gap: 6px; align-self: flex-end; padding-bottom: 8px;">
               <label for="consider-exclusion" style="display: flex; align-items: center; gap: 6px; cursor: pointer; font-size: 13px; color: var(--myio-text, #374151); white-space: nowrap;">
@@ -462,26 +562,39 @@ export class AllReportModal {
     loadBtn?.addEventListener('click', () => this.loadData());
     filterBtn?.addEventListener('click', () => this.openFilterModal());
 
-    // Granularity selector — mesmo componente da EnergyModal (createGranularitySelector).
-    // 1h só muda o CSV export (série horária por device); a tabela segue com totais.
-    const granToggle = document.getElementById('granularity-toggle');
-    if (granToggle) {
-      this.granularitySelector?.destroy();
-      this.granularitySelector = createGranularitySelector(granToggle, {
+    // RFC-0223: collapse-all/expand-all — next-action-driven label (AC7).
+    const collapseAllBtn = document.getElementById('collapse-all-btn') as HTMLButtonElement | null;
+    collapseAllBtn?.addEventListener('click', () => {
+      if (this.collapsedSections.size > 0) this.expandAllSections();
+      else this.collapseAllSections();
+    });
+
+    // RFC-0223: Consolidado | Diário | Horário selector, replacing the bare
+    // 2-way granularity toggle. Consolidado keeps today's aggregate path
+    // (byte-for-byte, no per-device series fetch); Diário/Horário drive the
+    // sectioned grid built out in later stages. onChange only resets the
+    // series cache and re-renders — the actual fetch/branch happens in
+    // loadData()/renderTable() once reportMode !== 'consolidado' is handled there.
+    const modeToggle = document.getElementById('report-mode-toggle');
+    if (modeToggle) {
+      this.reportModeSelector?.destroy();
+      this.reportModeSelector = createReportModeSelector(modeToggle, {
         settings: {
-          value: this.granularity,
-          // Padrão FIEL ao EnergyModal: pill "1h | 1d" (opções default do componente),
-          // sem label interno (o form group acima já tem "Granularidade").
-          label: '',
-          tooltip: {
-            enabled: true,
-            title: 'Granularidade',
-            text: 'Em <b>Hora</b>, o CSV exportado traz uma linha por dispositivo × hora (busca device a device). A tabela sempre mostra os totais do período.',
-          },
+          value: this.reportMode,
+          themeMode: this.params.ui?.theme === 'dark' ? 'dark' : 'light',
+          // RFC-0223 delivery phases: this PR ships P1 (Diário) only — Horário
+          // stays hidden until its own PR (P3, hourly drill-down) lands.
+          horarioEnabled: false,
         },
-        onChange: (value) => {
-          this.granularity = value;
-          this.hourlySeriesCache = null;
+        onChange: async (value) => {
+          this.reportMode = value;
+          this.deviceSeriesCache = null;
+          this.sectionModelCache = null;
+          if (!this.data.length) return;
+          await this.ensureDeviceSeriesForCurrentMode();
+          this.resetCollapsedSectionsIfEpochChanged();
+          this.renderSummary();
+          this.renderTable();
         },
       });
     }
@@ -508,7 +621,7 @@ export class AllReportModal {
     const exclusionCheckbox = document.getElementById('consider-exclusion') as HTMLInputElement | null;
     exclusionCheckbox?.addEventListener('change', () => {
       this.considerExclusion = exclusionCheckbox.checked;
-      this.remapAndRender();
+      void this.remapAndRender();
     });
 
     // Premium tooltip on the (i) icon, reusing the library InfoTooltip.
@@ -562,7 +675,13 @@ export class AllReportModal {
       const { startISO, endISO } = this.dateRangePicker.getDates();
       this.debugLog('📅 Date range selected', { startISO, endISO });
       this.exportPeriod = { startISO, endISO };
-      this.hourlySeriesCache = null;
+      // RFC-0223: a full load always invalidates the per-device series cache
+      // and the Períodos filter, even if the period/mode happens to be
+      // unchanged — "Carregar" is an explicit refresh action.
+      this.deviceSeriesCache = null;
+      this.sectionModelCache = null;
+      this.excludedDays = new Set();
+      this.excludedHours = new Set();
 
       if (!startISO || !endISO) {
         this.showError('Selecione um período válido');
@@ -595,6 +714,13 @@ export class AllReportModal {
       });
 
       this.currentPage = 1;
+
+      // RFC-0223: fetch the per-device day/hour series before the first paint
+      // when a sectioned mode is already active, so loadData() never flashes
+      // a "0 dias / dados incompletos" state for a mode the operator already
+      // had selected before clicking "Carregar".
+      await this.ensureDeviceSeriesForCurrentMode();
+      this.resetCollapsedSectionsIfEpochChanged();
 
       this.debugLog('🎨 Rendering UI components...');
       this.renderSummary();
@@ -646,6 +772,15 @@ export class AllReportModal {
     }
 
     return filtered.sort((a, b) => {
+      // RFC-0223 AC25: in 1d/1h, a value sort orders DEVICE SECTIONS by their
+      // effective (section-model) total, not the raw Consolidado consumption
+      // field — day/hour rows within a section stay chronological regardless.
+      if (this.sortField === 'consumption' && this.reportMode !== 'consolidado') {
+        const aVal = this.getEffectiveDeviceTotal(a) ?? 0;
+        const bVal = this.getEffectiveDeviceTotal(b) ?? 0;
+        return this.sortDirection === 'asc' ? aVal - bVal : bVal - aVal;
+      }
+
       const aVal = a[this.sortField];
       const bVal = b[this.sortField];
 
@@ -690,34 +825,53 @@ export class AllReportModal {
   private computeKpis(): Array<{ value: string; label: string; sub?: string }> {
     const totalConsumption = this.calculateTotalConsumption();
     const storeCount = Math.max(1, this.data.length);
-    const maxRow = this.data.reduce(
-      (best: StoreReading | null, r) => (!best || r.consumption > best.consumption ? r : best),
+    const isTemperature = (this.params.domain || 'energy') === 'temperature';
+
+    // RFC-0223: routes through getEffectiveDeviceTotal so 1d/1h KPIs reflect
+    // the section model (and, from Stage 5 on, the Périodos filter) instead of
+    // the raw Consolidado `row.consumption` — a no-op for 'consolidado' itself,
+    // since getEffectiveDeviceTotal returns row.consumption unchanged there.
+    const withTotals = this.data.map((row) => ({ row, value: this.getEffectiveDeviceTotal(row) }));
+
+    const maxEntry = withTotals.reduce(
+      (best: { row: StoreReading; value: number | null } | null, e) =>
+        e.value != null && (!best || best.value == null || e.value > best.value) ? e : best,
       null
     );
-    const minRow = this.data
-      .filter((r) => r.consumption > 0)
+    const minEntry = withTotals
+      .filter((e) => e.value != null && e.value > 0)
       .reduce(
-        (best: StoreReading | null, r) => (!best || r.consumption < best.consumption ? r : best),
+        (best: { row: StoreReading; value: number | null } | null, e) =>
+          !best || (best.value != null && e.value! < best.value) ? e : best,
         null
       );
-    const zeroCount = this.data.filter((r) => r.consumption <= 0).length;
-    const isTemperature = (this.params.domain || 'energy') === 'temperature';
+    const zeroCount = withTotals.filter((e) => (e.value ?? 0) <= 0).length;
 
     const kpis: Array<{ value: string; label: string; sub?: string }> = [
       { value: String(this.data.length), label: 'Dispositivos' },
       { value: fmtPt(totalConsumption), label: this.domainConfig.totalLabel },
-      { value: fmtPt(totalConsumption / storeCount), label: 'Média por Dispositivo' },
-      {
-        value: maxRow ? fmtPt(maxRow.consumption) : '—',
-        label: `Máximo (${this.domainConfig.unit})`,
-        ...(maxRow?.name ? { sub: maxRow.name } : {}),
-      },
-      {
-        value: minRow ? fmtPt(minRow.consumption) : '—',
-        label: `Mínimo (${this.domainConfig.unit})`,
-        ...(minRow?.name ? { sub: minRow.name } : {}),
-      },
     ];
+    // RFC-0223: in 1d/1h, calculateTotalConsumption() for temperature is
+    // ALREADY a flat mean (not a sum — see its own doc comment), so dividing it
+    // again by storeCount would silently shrink it into a meaningless number.
+    // "Média por Dispositivo" only makes sense when totalConsumption is a sum
+    // (Consolidado, and energy/water always), so it's omitted in that one
+    // combination rather than computed wrong.
+    if (!(isTemperature && this.reportMode !== 'consolidado')) {
+      kpis.push({ value: fmtPt(totalConsumption / storeCount), label: 'Média por Dispositivo' });
+    }
+    kpis.push(
+      {
+        value: maxEntry?.value != null ? fmtPt(maxEntry.value) : '—',
+        label: `Máximo (${this.domainConfig.unit})`,
+        ...(maxEntry?.row.name ? { sub: maxEntry.row.name } : {}),
+      },
+      {
+        value: minEntry?.value != null ? fmtPt(minEntry.value) : '—',
+        label: `Mínimo (${this.domainConfig.unit})`,
+        ...(minEntry?.row.name ? { sub: minEntry.row.name } : {}),
+      }
+    );
     if (!isTemperature) kpis.push({ value: String(zeroCount), label: 'Sem Consumo' });
     return kpis;
   }
@@ -725,6 +879,16 @@ export class AllReportModal {
   private renderTable(): void {
     const container = document.getElementById('table-container');
     if (!container) return;
+
+    this.updateSectionToolbarVisibility();
+
+    // RFC-0223: Diário/Horário bypass the flat/grouped Consolidado path
+    // entirely and render collapsible per-device sections instead. Consolidado
+    // falls through to the code below, unchanged (AC1/AC3).
+    if (this.reportMode !== 'consolidado') {
+      this.renderSectionedTable(container);
+      return;
+    }
 
     const paginatedData = this.getPaginatedData();
     const filteredData = this.getFilteredData();
@@ -843,7 +1007,7 @@ export class AllReportModal {
     const items = this.getFilteredData().map((row) => ({
       id: row.id || this.generateStoreId(row.identifier),
       label: row.name,
-      value: row.consumption,
+      value: this.getEffectiveDeviceTotal(row) ?? 0,
     }));
 
     if (!this.participationChart) {
@@ -869,6 +1033,434 @@ export class AllReportModal {
     if (palette) this.participationChart.updateSettings({ palette });
     this.participationChart.updateData(items);
   }
+
+  // ===== RFC-0223: Diário/Horário sectioned grid ============================
+
+  // Above this many devices, 1d/1h sections open COLLAPSED by default (AC6) so
+  // a many-device customer doesn't face a wall of expanded rows on first open.
+  private static readonly DEFAULT_COLLAPSE_DEVICE_THRESHOLD = 25;
+
+  // Sum for energy/water, null-aware mean for temperature. Missing leaves
+  // (null) are excluded entirely; an all-missing input still resolves to 0
+  // here — callers needing temperature's "no reading at all" -> "—" rule use
+  // aggregateOrNull instead (this 0-fallback would otherwise read as a
+  // fabricated 0°C average).
+  private aggregate(values: Array<number | null>): number {
+    const domain = this.params.domain || 'energy';
+    const present = values.filter((v): v is number => v != null);
+    if (!present.length) return 0;
+    return domain === 'temperature'
+      ? present.reduce((s, v) => s + v, 0) / present.length
+      : present.reduce((s, v) => s + v, 0);
+  }
+
+  // Domain-aware wrapper: energy/water still resolve an all-missing input to a
+  // real 0; temperature resolves to null ("—") instead of aggregate()'s
+  // unconditional 0-fallback, per the RFC's missing-bucket materialization rule.
+  private aggregateOrNull(values: Array<number | null>): number | null {
+    const isTemperature = (this.params.domain || 'energy') === 'temperature';
+    if (isTemperature && values.every((v) => v == null)) return null;
+    return this.aggregate(values);
+  }
+
+  // A day/device/group's leaf values for aggregation: hour values when hours
+  // exist (for energy/water sum(hours)===sum(days) by associativity; for
+  // temperature this is the REQUIRED flat mean over all included hours, not a
+  // mean-of-day-means — AC18), else the day values themselves (1d mode, where
+  // days ARE the leaves).
+  private flattenLeafValues(days: ReportSectionDayNode[]): Array<number | null> {
+    const included = days.filter((d) => !d.excluded);
+    const hasHours = included.some((d) => d.hours);
+    if (hasHours) {
+      return included.flatMap((d) => (d.hours || []).filter((h) => !h.excluded).map((h) => h.value));
+    }
+    return included.map((d) => d.value);
+  }
+
+  // A missing raw bucket (bucketByDay's `null` = "no point found") materializes
+  // per domain: energy/water -> 0 (a zero reading is meaningful, keeps the
+  // time axis continuous); temperature -> stays null ("—"), excluded from the mean.
+  private materializeMissing(value: number | null): number | null {
+    if (value != null) return value;
+    return (this.params.domain || 'energy') === 'temperature' ? null : 0;
+  }
+
+  // Buckets one device's raw points into every day of the period (continuous —
+  // a day with no matching point still gets an entry, materialized per-domain
+  // by the caller). 1d: one point per day already. 1h: points are grouped into
+  // per-day hour maps, and each day's own value is the aggregate of its hours.
+  private bucketByDay(
+    points: Array<{ timestamp: number; value: number }>,
+    days: string[],
+    granularity: '1d' | '1h'
+  ): Map<string, { value: number | null; hours?: Map<string, number | null> }> {
+    const tz = this.timezone;
+    const result = new Map<string, { value: number | null; hours?: Map<string, number | null> }>();
+    for (const day of days) {
+      result.set(day, { value: null, hours: granularity === '1h' ? new Map() : undefined });
+    }
+    if (granularity === '1d') {
+      for (const p of points) {
+        const bucket = result.get(toDayKey(p.timestamp, tz));
+        if (bucket) bucket.value = p.value;
+      }
+    } else {
+      for (const p of points) {
+        const bucket = result.get(toDayKey(p.timestamp, tz));
+        if (bucket) bucket.hours!.set(toHourKey(p.timestamp, tz), p.value);
+      }
+      for (const bucket of result.values()) {
+        bucket.value = this.aggregateOrNull(Array.from(bucket.hours!.values()));
+      }
+    }
+    return result;
+  }
+
+  // Stable collapsedSections/model-lookup key for a device — ingestionId when
+  // present, else the display identifier (still unique within one report).
+  private sectionDeviceKey(row: StoreReading): string {
+    return row.id || row.identifier;
+  }
+
+  // The single pure tree builder every 1d/1h render/KPI/chart/export path
+  // reads from — directly unit-testable via (modal as any).buildReportSectionModel().
+  private buildReportSectionModel(): ReportSectionModel {
+    const startISO = this.exportPeriod?.startISO;
+    const endISO = this.exportPeriod?.endISO;
+    const periodDays =
+      startISO && endISO ? rangeDaysInclusive(startISO.slice(0, 10), endISO.slice(0, 10)) : [];
+    const cache = this.deviceSeriesCache;
+    const isTemperature = (this.params.domain || 'energy') === 'temperature';
+
+    const buildDayNode = (
+      day: string,
+      rawValue: number | null,
+      hours?: Array<{ key: string; value: number | null }>
+    ): ReportSectionDayNode => {
+      const excluded = this.excludedDays.has(day);
+      let hourNodes: ReportSectionHourNode[] | undefined;
+      let value = this.materializeMissing(rawValue);
+      if (hours) {
+        hourNodes = hours.map((h) => ({
+          key: h.key,
+          label: `${h.key.slice(-2)}:00`,
+          value: this.materializeMissing(h.value),
+          excluded: this.excludedHours.has(h.key),
+        }));
+        value = this.aggregateOrNull(hourNodes.filter((h) => !h.excluded).map((h) => h.value));
+      }
+      return { key: day, label: `${day.slice(8, 10)}/${day.slice(5, 7)}`, value, hours: hourNodes, excluded };
+    };
+
+    const buildDevice = (row: StoreReading): ReportSectionDeviceNode => {
+      const coverage: 'ok' | 'partial' | 'failed' = row.id
+        ? cache?.coverage.get(row.id) || 'failed'
+        : 'failed';
+      const points = row.id ? cache?.raw.get(row.id) : undefined;
+
+      if (coverage === 'failed' || !points) {
+        return { row, days: [], total: null, dayCount: 0, coverage: 'failed' };
+      }
+      if (!points.length) {
+        // AC16: genuinely no readings — 0 dias, zero/dash total, no error.
+        return { row, days: [], total: isTemperature ? null : 0, dayCount: 0, coverage: 'ok' };
+      }
+
+      const buckets = this.bucketByDay(points, periodDays, cache!.granularity);
+      const days = periodDays.map((day) => {
+        const bucket = buckets.get(day)!;
+        const hours = bucket.hours
+          ? Array.from(bucket.hours.entries()).map(([key, value]) => ({ key, value }))
+          : undefined;
+        return buildDayNode(day, bucket.value, hours);
+      });
+
+      const total = this.aggregateOrNull(this.flattenLeafValues(days));
+      return { row, days, total, dayCount: periodDays.length, coverage: 'ok' };
+    };
+
+    // RFC-0182: group by groupLabel, preserving first-occurrence order — same
+    // rule as the existing renderGroupedRows(), so 1d/1h sections nest inside
+    // the same groups the Consolidado view already shows.
+    const groupOrder: string[] = [];
+    const byGroup = new Map<string, StoreReading[]>();
+    for (const row of this.data) {
+      const g = row.groupLabel || '—';
+      if (!byGroup.has(g)) {
+        byGroup.set(g, []);
+        groupOrder.push(g);
+      }
+      byGroup.get(g)!.push(row);
+    }
+
+    const groups: ReportSectionGroupNode[] = groupOrder.map((groupLabel) => {
+      const devices = byGroup.get(groupLabel)!.map(buildDevice);
+      const total = this.aggregateOrNull(devices.flatMap((d) => this.flattenLeafValues(d.days)));
+      return { groupLabel, devices, total };
+    });
+
+    return { groups };
+  }
+
+  // Memoized accessor — buildReportSectionModel() is O(devices × days × hours);
+  // this avoids rebuilding it once per row inside computeKpis/updateParticipationChart loops.
+  private getReportSectionModel(): ReportSectionModel {
+    const key = [
+      this.exportPeriod?.startISO,
+      this.exportPeriod?.endISO,
+      this.reportMode,
+      this.deviceSeriesCache?.key,
+      Array.from(this.excludedDays).sort().join(','),
+      Array.from(this.excludedHours).sort().join(','),
+      this.data.length,
+    ].join('|');
+    if (this.sectionModelCache?.key === key) return this.sectionModelCache.model;
+    const model = this.buildReportSectionModel();
+    this.sectionModelCache = { key, model };
+    return model;
+  }
+
+  // Single dispatch point: 'consolidado' is byte-for-byte row.consumption;
+  // 1d/1h reads the section model's device total instead, so every consumer
+  // (KPIs, chart, sort, PDF/CSV builders) has only ONE place to change when
+  // the Períodos filter (Stage 5) starts excluding days/hours.
+  private getEffectiveDeviceTotal(row: StoreReading): number | null {
+    if (this.reportMode === 'consolidado') return row.consumption;
+    const device = this.getReportSectionModel()
+      .groups.flatMap((g) => g.devices)
+      .find((d) => d.row === row);
+    return device ? device.total : row.consumption;
+  }
+
+  private computeDefaultCollapsedSections(model: ReportSectionModel): Set<string> {
+    const collapsed = new Set<string>();
+    const totalDevices = model.groups.reduce((n, g) => n + g.devices.length, 0);
+    if (totalDevices > AllReportModal.DEFAULT_COLLAPSE_DEVICE_THRESHOLD) {
+      for (const g of model.groups) {
+        for (const d of g.devices) collapsed.add(`dev:${this.sectionDeviceKey(d.row)}`);
+      }
+    }
+    return collapsed;
+  }
+
+  // AC21: reset collapse state to the AC6 defaults on a fresh load or a
+  // reportMode change (period+mode epoch mismatch); a Períodos filter apply
+  // (Stage 5) re-renders WITHOUT calling this, so carets persist across it.
+  private resetCollapsedSectionsIfEpochChanged(): void {
+    const epoch = `${this.exportPeriod?.startISO || ''}|${this.exportPeriod?.endISO || ''}|${this.reportMode}`;
+    if (this.collapsedSectionsEpoch === epoch) return;
+    this.collapsedSectionsEpoch = epoch;
+    this.collapsedSections =
+      this.reportMode === 'consolidado' ? new Set() : this.computeDefaultCollapsedSections(this.getReportSectionModel());
+  }
+
+  // Orchestrates the per-device series fetch for whatever mode is currently
+  // active — called from loadData() (full load) and the mode-selector's
+  // onChange (mode switch); exportHourlyCSV/exportCSV call ensureDeviceSeries
+  // directly since they already have their own error handling/UI state.
+  private async ensureDeviceSeriesForCurrentMode(): Promise<void> {
+    if (this.reportMode === 'consolidado' || !this.data.length) return;
+    try {
+      await this.ensureDeviceSeries(this.data, this.reportMode);
+      this.sectionModelCache = null;
+    } catch (err) {
+      this.debugLog('❌ Error fetching device series for sectioned report', err);
+      this.showError('Erro ao buscar séries por dispositivo para o relatório seccionado. Tente novamente.');
+    }
+  }
+
+  // Shows/hides the RFC-0223 toolbar controls. The Períodos button stays
+  // hidden until Stage 5 gives it a click handler — a visible-but-inert button
+  // would be a dead end for the operator.
+  private updateSectionToolbarVisibility(): void {
+    const sectioned = this.reportMode !== 'consolidado';
+    const collapseBtn = document.getElementById('collapse-all-btn') as HTMLButtonElement | null;
+    const periodsBtn = document.getElementById('periods-filter-btn') as HTMLButtonElement | null;
+    if (collapseBtn) collapseBtn.style.display = sectioned ? '' : 'none';
+    if (periodsBtn) periodsBtn.style.display = 'none';
+    if (sectioned) this.updateCollapseAllButtonLabel();
+  }
+
+  private updateCollapseAllButtonLabel(): void {
+    const btn = document.getElementById('collapse-all-btn') as HTMLButtonElement | null;
+    if (!btn) return;
+    btn.textContent = this.collapsedSections.size > 0 ? 'Expandir tudo' : 'Recolher tudo';
+  }
+
+  // Pure DOM show/hide — a caret click NEVER re-invokes renderTable()/renderSectionedRows().
+  // A row is hidden if ANY of its ancestor section keys are collapsed; a header
+  // row's OWN key is never in its own ancestor list, so collapsing a section
+  // never hides its own header, only its descendants.
+  private applySectionVisibility(container: HTMLElement): void {
+    container.querySelectorAll<HTMLElement>('[data-ancestors]').forEach((row) => {
+      const ancestors = (row.dataset.ancestors || '').split(' ').filter(Boolean);
+      row.style.display = ancestors.some((k) => this.collapsedSections.has(k)) ? 'none' : '';
+    });
+    container.querySelectorAll<HTMLElement>('[data-section-toggle]').forEach((header) => {
+      const key = header.dataset.sectionToggle!;
+      const collapsed = this.collapsedSections.has(key);
+      header.setAttribute('aria-expanded', String(!collapsed));
+      const caret = header.querySelector('.rp-section-caret');
+      if (caret) caret.textContent = collapsed ? '▶' : '▼';
+    });
+  }
+
+  private toggleSection(key: string): void {
+    if (this.collapsedSections.has(key)) this.collapsedSections.delete(key);
+    else this.collapsedSections.add(key);
+    const container = document.getElementById('table-container');
+    if (container) this.applySectionVisibility(container);
+    this.updateCollapseAllButtonLabel();
+  }
+
+  private collapseAllSections(): void {
+    const model = this.getReportSectionModel();
+    for (const g of model.groups) {
+      this.collapsedSections.add(`grp:${g.groupLabel}`);
+      for (const d of g.devices) this.collapsedSections.add(`dev:${this.sectionDeviceKey(d.row)}`);
+    }
+    const container = document.getElementById('table-container');
+    if (container) this.applySectionVisibility(container);
+    this.updateCollapseAllButtonLabel();
+  }
+
+  private expandAllSections(): void {
+    this.collapsedSections.clear();
+    const container = document.getElementById('table-container');
+    if (container) this.applySectionVisibility(container);
+    this.updateCollapseAllButtonLabel();
+  }
+
+  // Event delegation on the (stable, never-replaced) #table-container element —
+  // a `data-bound`-style guard prevents double-binding across re-renders, since
+  // only its innerHTML (not the element itself) is replaced on each render.
+  private setupSectionToggling(container: HTMLElement): void {
+    if (container.dataset.sectionTogglingBound === 'true') return;
+    container.dataset.sectionTogglingBound = 'true';
+
+    const activate = (target: EventTarget | null): void => {
+      const header = (target as HTMLElement | null)?.closest<HTMLElement>('[data-section-toggle]');
+      if (!header) return;
+      this.toggleSection(header.dataset.sectionToggle!);
+    };
+    container.addEventListener('click', (e) => activate(e.target));
+    container.addEventListener('keydown', (e) => {
+      if (e.key !== 'Enter' && e.key !== ' ') return;
+      const header = (e.target as HTMLElement | null)?.closest<HTMLElement>('[data-section-toggle]');
+      if (!header) return;
+      e.preventDefault();
+      activate(e.target);
+    });
+  }
+
+  // Renders the group -> device -> day row tree. Day rows carry NO further
+  // collapse in 1d/1h yet (Stage 4 adds the day -> hour second level for 1h);
+  // for now a 1h day row simply shows its (already hour-aggregated) total,
+  // matching 1d's day row exactly.
+  private renderSectionedRows(model: ReportSectionModel): string {
+    const visibleIds = new Set(this.getFilteredData().map((r) => this.sectionDeviceKey(r)));
+    const isGrouped = this.getFilteredData().some((r) => r.groupLabel);
+    const fmtValue = (v: number | null) => (v == null ? '—' : fmtPt(v));
+    const pctOfDevice = (v: number | null, deviceTotal: number | null) =>
+      v != null && deviceTotal != null && deviceTotal > 0 ? `${fmtPt((v / deviceTotal) * 100)}%` : '—';
+
+    let html = '';
+    for (const group of model.groups) {
+      const visibleDevices = group.devices.filter((d) => visibleIds.has(this.sectionDeviceKey(d.row)));
+      if (!visibleDevices.length) continue;
+
+      const groupKey = `grp:${group.groupLabel}`;
+      if (isGrouped) {
+        html += renderCollapsibleSectionHeader({
+          sectionKey: groupKey,
+          ancestorKeys: [],
+          level: 0,
+          title: group.groupLabel,
+          meta: `${visibleDevices.length} dispositivo${visibleDevices.length === 1 ? '' : 's'}`,
+          totalLabel: `${fmtValue(group.total)} ${this.domainConfig.unit}`,
+          collapsed: this.collapsedSections.has(groupKey),
+          colSpan: 3,
+        });
+      }
+      const groupAncestors = isGrouped ? [groupKey] : [];
+
+      for (const device of visibleDevices) {
+        const deviceKey = `dev:${this.sectionDeviceKey(device.row)}`;
+        html += renderCollapsibleSectionHeader({
+          sectionKey: deviceKey,
+          ancestorKeys: groupAncestors,
+          level: 1,
+          title: `${device.row.name} (${device.row.identifier})`,
+          meta: `${device.dayCount} dia${device.dayCount === 1 ? '' : 's'}`,
+          totalLabel: `${fmtValue(device.total)} ${this.domainConfig.unit}`,
+          collapsed: this.collapsedSections.has(deviceKey),
+          colSpan: 3,
+          incomplete: device.coverage === 'failed',
+        });
+
+        const dayAncestors = [...groupAncestors, deviceKey];
+        for (const day of device.days) {
+          html += renderCollapsibleLeafRow({
+            ancestorKeys: dayAncestors,
+            level: 2,
+            cells: [
+              `<td data-label="Dia">${escapeHtml(day.label)}</td>`,
+              `<td data-label="${escapeHtml(this.domainConfig.label)}" style="text-align:right;">${fmtValue(day.value)}</td>`,
+              `<td data-label="%" style="text-align:right;color:var(--myio-text-muted);">${pctOfDevice(day.value, device.total)}</td>`,
+            ],
+          });
+        }
+      }
+    }
+    return html;
+  }
+
+  private renderSectionedTable(container: HTMLElement): void {
+    injectCollapsibleSectionStyles();
+    const model = this.getReportSectionModel();
+    const visibleIds = new Set(this.getFilteredData().map((r) => this.sectionDeviceKey(r)));
+    const anyVisible = model.groups.some((g) => g.devices.some((d) => visibleIds.has(this.sectionDeviceKey(d.row))));
+
+    if (!anyVisible) {
+      // AC24: name which filter is hiding rows instead of a generic empty state.
+      const deviceFiltered = this.selectedStoreIds.size > 0 && this.selectedStoreIds.size < this.data.length;
+      container.innerHTML = `
+        <div style="text-align: center; padding: 40px; color: var(--myio-text-muted);">
+          ${
+            this.searchFilter
+              ? 'Nenhum dispositivo encontrado com o filtro aplicado.'
+              : deviceFiltered
+                ? 'Nenhum dispositivo — ajuste Filtros & Ordenação.'
+                : 'Nenhum dado encontrado.'
+          }
+        </div>
+      `;
+      this.updateParticipationChart();
+      return;
+    }
+
+    const rowsHtml = this.renderSectionedRows(model);
+    container.innerHTML = `
+      <div style="max-height: 500px; overflow-y: auto; border: 1px solid var(--myio-border); border-radius: 6px;">
+        <table class="myio-table myio-table-mobile" style="table-layout: fixed; width: 100%;">
+          <thead style="position: sticky; top: 0; background: var(--myio-bg); z-index: 1;">
+            <tr>
+              <th style="width: 62%;">Dispositivo / Dia</th>
+              <th style="text-align: right; width: 24%;">${this.domainConfig.label}</th>
+              <th style="text-align: right; width: 14%;">%</th>
+            </tr>
+          </thead>
+          <tbody>${rowsHtml}</tbody>
+        </table>
+      </div>
+    `;
+
+    this.applySectionVisibility(container);
+    this.setupSectionToggling(container);
+    this.updateParticipationChart();
+  }
+
+  // ===== end RFC-0223 sectioned grid =========================================
 
   // RFC-0182: Render rows grouped by groupLabel with section headers (Option B)
   private renderGroupedRows(rows: StoreReading[], grandTotal: number): string {
@@ -951,7 +1543,17 @@ export class AllReportModal {
   }
 
   private calculateTotalConsumption(): number {
-    return this.data.reduce((sum, row) => sum + row.consumption, 0);
+    if (this.reportMode === 'consolidado') {
+      return this.data.reduce((sum, row) => sum + row.consumption, 0);
+    }
+    // RFC-0223: pooled flat aggregate over every included leaf bucket across
+    // ALL devices — for energy/water this equals summing device totals
+    // (associative); for temperature this is a TRUE flat mean unbiased by
+    // per-device coverage disparities (same rationale as AC18's device-level
+    // flat-mean rule, one level up).
+    const allDevices = this.getReportSectionModel().groups.flatMap((g) => g.devices);
+    const pooledLeafValues = allDevices.flatMap((d) => this.flattenLeafValues(d.days));
+    return this.aggregate(pooledLeafValues);
   }
 
   private openFilterModal(): void {
@@ -1063,11 +1665,21 @@ export class AllReportModal {
       return;
     }
 
+    // RFC-0223 P1: the per-device × day sectioned CSV for Diário is P2 scope —
+    // this stays the flat per-device CSV for Consolidado AND Diário alike, but
+    // routes through getEffectiveDeviceTotal() (not raw row.consumption) so a
+    // Diário + temperature export doesn't regress to all-zero rows (the
+    // temperature enrichment fetch is intentionally skipped outside
+    // 'consolidado' — see fetchCustomerTotals). A no-op for 'consolidado'.
     const csvData = [
       // Header row only
       ['Identificador', 'Nome', `Consumo (${this.domainConfig.unit})`],
       // Data rows
-      ...sortedData.map((row) => [row.identifier, row.name, row.consumption.toFixed(2)]),
+      ...sortedData.map((row) => [
+        row.identifier,
+        row.name,
+        (this.getEffectiveDeviceTotal(row) ?? 0).toFixed(2),
+      ]),
     ];
 
     const csvContent = toCsv(csvData);
@@ -1086,7 +1698,7 @@ export class AllReportModal {
     }
 
     try {
-      const series = await this.ensureHourlySeries(sortedData);
+      const series = await this.ensureDeviceSeries(sortedData, '1h');
 
       const fmtTs = (ts: number) => {
         const d = new Date(ts);
@@ -1128,10 +1740,14 @@ export class AllReportModal {
     }
   }
 
-  // Fetches (or reuses) the per-device hourly series for the current export period.
-  // Same batching pattern as enrichTemperatureAverages (6 concurrent requests).
-  private async ensureHourlySeries(
-    rows: StoreReading[]
+  // Fetches (or reuses) the per-device series for the given granularity and
+  // the current export period. Generalizes the old ensureHourlySeries
+  // (1h-only, CSV-export-only) to also drive the on-screen sectioned grid at
+  // either granularity, with per-device coverage tracking (AC19) replacing
+  // the old silent swallow of a failed/empty device ("fica de fora do CSV").
+  private async ensureDeviceSeries(
+    rows: StoreReading[],
+    granularity: '1d' | '1h'
   ): Promise<Map<string, Array<{ timestamp: number; value: number }>>> {
     const startISO = this.exportPeriod?.startISO;
     const endISO = this.exportPeriod?.endISO;
@@ -1143,8 +1759,8 @@ export class AllReportModal {
       .filter(Boolean)
       .sort()
       .join(',');
-    const cacheKey = `${startISO}|${endISO}|${idsKey}`;
-    if (this.hourlySeriesCache?.key === cacheKey) return this.hourlySeriesCache.series;
+    const cacheKey = `${startISO}|${endISO}|${granularity}|${idsKey}`;
+    if (this.deviceSeriesCache?.key === cacheKey) return this.deviceSeriesCache.raw;
 
     const token = this.params.api.ingestionToken;
     const baseUrl = this.params.api.dataApiBaseUrl;
@@ -1153,48 +1769,67 @@ export class AllReportModal {
     const endpoint = this.domainConfig.endpoint;
     const startTime = encodeURIComponent(startISO);
     const endTime = encodeURIComponent(endISO);
-    const series = new Map<string, Array<{ timestamp: number; value: number }>>();
+    const raw = new Map<string, Array<{ timestamp: number; value: number }>>();
+    const coverage = new Map<string, 'ok' | 'partial' | 'failed'>();
 
     const targets = rows.filter((r) => r.id);
     const BATCH = 6;
     for (let i = 0; i < targets.length; i += BATCH) {
       await Promise.all(
         targets.slice(i, i + BATCH).map(async (row) => {
+          const id = row.id!;
           try {
-            const url = `${baseUrl}/telemetry/devices/${row.id}/${endpoint}?startTime=${startTime}&endTime=${endTime}&granularity=1h&deep=0`;
+            const url = `${baseUrl}/telemetry/devices/${id}/${endpoint}?startTime=${startTime}&endTime=${endTime}&granularity=${granularity}&deep=0`;
             const res = await fetch(url, {
               headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
             });
-            if (!res.ok) return;
+            if (!res.ok) {
+              coverage.set(id, 'failed');
+              return;
+            }
             const body = await res.json();
             const ent = Array.isArray(body) ? body[0] : body;
             const points = ((ent?.consumption || []) as Array<{ timestamp: unknown; value: unknown }>)
               .map((p) => ({ timestamp: new Date(p?.timestamp as string | number).getTime(), value: Number(p?.value) }))
               .filter((p) => Number.isFinite(p.timestamp) && Number.isFinite(p.value));
-            if (points.length) series.set(row.id!, points);
+            raw.set(id, points);
+            coverage.set(id, 'ok');
           } catch {
-            /* device sem série no período — fica de fora do CSV */
+            coverage.set(id, 'failed');
           }
         })
       );
     }
 
-    this.debugLog(`[AllReportModal] 1h series fetched for ${series.size}/${targets.length} devices`);
-    this.hourlySeriesCache = { key: cacheKey, series };
-    return series;
+    const okCount = Array.from(coverage.values()).filter((c) => c === 'ok').length;
+    this.debugLog(`[AllReportModal] ${granularity} series fetched for ${okCount}/${targets.length} devices`);
+
+    // RFC-0223: discard a stale in-flight result if the mode changed to a
+    // DIFFERENT granularity while this fetch was awaiting — never let it
+    // clobber a newer mode's cache (the caller still gets its data either way).
+    if (this.granularity !== granularity) return raw;
+
+    this.deviceSeriesCache = { key: cacheKey, granularity, raw, coverage };
+    return raw;
   }
 
   // Maps the report rows to the TelemetryDevice shape consumed by the shared
   // TELEMETRY grid exporters (only labelOrName/name/deviceIdentifier/val/perc are read).
   private buildExportDevices(): TelemetryDevice[] {
-    const sorted = [...this.data].sort((a, b) => b.consumption - a.consumption);
-    const total = sorted.reduce((s, r) => s + (r.consumption || 0), 0);
-    return sorted.map((r) => ({
-      labelOrName: r.name,
-      name: r.name,
-      deviceIdentifier: r.identifier,
-      val: r.consumption,
-      perc: total > 0 ? (r.consumption / total) * 100 : 0,
+    // RFC-0223: routes through getEffectiveDeviceTotal so XLS export (which has
+    // no dedicated sectioned builder — only the grid/PDF/CSV do) still reports
+    // correct 1d/1h totals instead of the raw (possibly stale/zeroed, see
+    // fetchCustomerTotals' temperature skip) Consolidado `row.consumption`. A
+    // no-op for 'consolidado' itself.
+    const withTotals = this.data.map((r) => ({ row: r, val: this.getEffectiveDeviceTotal(r) ?? 0 }));
+    const sorted = [...withTotals].sort((a, b) => b.val - a.val);
+    const total = sorted.reduce((s, e) => s + e.val, 0);
+    return sorted.map((e) => ({
+      labelOrName: e.row.name,
+      name: e.row.name,
+      deviceIdentifier: e.row.identifier,
+      val: e.val,
+      perc: total > 0 ? (e.val / total) * 100 : 0,
     })) as unknown as TelemetryDevice[];
   }
 
@@ -1222,7 +1857,13 @@ export class AllReportModal {
     if (!this.data.length) return;
 
     const chartPng = await this.participationChart?.toPngDataUrl?.().catch(() => null);
+    const chartImage = chartPng ? { ...chartPng, title: 'Participação por Dispositivo' } : null;
 
+    // RFC-0223 P1: PDF export stays on the shared exportGridPdf for every mode
+    // (byte-for-byte for Consolidado, AC1/AC3). Diário's per-device × day
+    // sectioned PDF is P2 scope — buildExportDevices() already routes through
+    // getEffectiveDeviceTotal() so the numbers here are correct for Diário
+    // too, just not yet broken down by day (that lands with the P2 PR).
     exportGridPdf(
       this.buildExportDevices(),
       this.resolveTitle(),
@@ -1232,9 +1873,7 @@ export class AllReportModal {
       {
         accentColor: this.resolveAccentHex(),
         kpis: this.computeKpis(),
-        chartImage: chartPng
-          ? { ...chartPng, title: 'Participação por Dispositivo' }
-          : null,
+        chartImage,
       },
     );
   }
@@ -1313,7 +1952,12 @@ export class AllReportModal {
     // temperatura ("total" não é semântica de temperatura) — substitui pelo valor
     // MÉDIO do período de cada sensor, via o mesmo endpoint por device usado no
     // modal de histórico do card (que funciona).
-    if ((this.params.domain || 'energy') === 'temperature') {
+    // RFC-0223: skipped outside 'consolidado' — ensureDeviceSeries() already
+    // fetches this same per-device endpoint for 1d/1h sections, and
+    // getEffectiveDeviceTotal() reads from that single source of truth
+    // instead. Doing both would double the network cost for temperature
+    // customers and risk the two fetches disagreeing at the margins (AC18).
+    if ((this.params.domain || 'energy') === 'temperature' && this.reportMode === 'consolidado') {
       await this.enrichTemperatureAverages(data, startISO, endISO, token, baseUrl);
     }
 
@@ -1366,11 +2010,20 @@ export class AllReportModal {
 
   // Re-map the cached API response under the current exclusion flag and refresh the UI.
   // No-op until data has been loaded at least once.
-  private remapAndRender(): void {
+  private async remapAndRender(): Promise<void> {
     if (!this.lastApiResponse) return;
     this.data = this.mapCustomerTotalsResponse(this.lastApiResponse);
     this.selectedStoreIds = new Set(this.data.map((s) => this.generateStoreId(s.identifier)));
     this.currentPage = 1;
+    this.sectionModelCache = null;
+    if (this.reportMode !== 'consolidado') {
+      // RFC-0223: the exclusion toggle changes the device set, which changes
+      // deviceSeriesCache's idsKey — force a refetch rather than serving a
+      // cache keyed to the previous (pre-toggle) device list.
+      this.deviceSeriesCache = null;
+      await this.ensureDeviceSeriesForCurrentMode();
+      this.resetCollapsedSectionsIfEpochChanged();
+    }
     this.renderSummary();
     this.renderTable();
   }

--- a/src/components/premium-modals/report-all/AllReportModal.ts
+++ b/src/components/premium-modals/report-all/AllReportModal.ts
@@ -169,9 +169,14 @@ export class AllReportModal {
   private excludedDays: Set<string> = new Set(); // 'YYYY-MM-DD'
   private excludedHours: Set<string> = new Set(); // 'YYYY-MM-DDTHH'
 
-  // RFC-0223: collapse state for group/device/day sections, namespaced by id
-  // (never by label) so a label containing the separator can't alias another
-  // section: `grp:<id>` | `dev:<id>` | `dev:<id>#day:<YYYY-MM-DD>`.
+  // RFC-0223: collapse state for group/device/day sections:
+  // `grp:<uri-encoded groupLabel>` | `dev:<uri-encoded id-or-identifier>` |
+  // `dev:<...>#day:<YYYY-MM-DD>`. Group keys are necessarily label-based (a
+  // group has no separate stable id) — see sectionGroupKey/
+  // sectionDeviceCollapseKey — URI-encoded specifically so a label/identifier
+  // containing a literal space (e.g. "Área Comum") can't split into more than
+  // one token when applySectionVisibility parses `data-ancestors` back with
+  // `.split(' ')` (code review H1).
   private collapsedSections: Set<string> = new Set();
   // Identifies the period+mode this collapse state belongs to
   // (`${startISO}|${endISO}|${reportMode}`) — a loadData()/mode change compares
@@ -1105,11 +1110,28 @@ export class AllReportModal {
         if (bucket) bucket.value = p.value;
       }
     } else {
+      // RFC-0223 review (L4): accumulate ALL readings per hour key first,
+      // rather than overwriting on `.set()` — on a DST fall-back day two
+      // distinct real UTC instants map onto the SAME local hour key (e.g.
+      // "...T01"), and both must contribute to that hour's value (aggregate()
+      // sums for energy, means for temperature) instead of the second
+      // reading silently discarding the first.
+      const rawHoursByDay = new Map<string, Map<string, number[]>>();
       for (const p of points) {
-        const bucket = result.get(toDayKey(p.timestamp, tz));
-        if (bucket) bucket.hours!.set(toHourKey(p.timestamp, tz), p.value);
+        const day = toDayKey(p.timestamp, tz);
+        if (!result.has(day)) continue;
+        const hourKey = toHourKey(p.timestamp, tz);
+        let rawHours = rawHoursByDay.get(day);
+        if (!rawHours) rawHoursByDay.set(day, (rawHours = new Map()));
+        const list = rawHours.get(hourKey) || [];
+        list.push(p.value);
+        rawHours.set(hourKey, list);
       }
-      for (const bucket of result.values()) {
+      for (const [day, bucket] of result) {
+        const rawHours = rawHoursByDay.get(day);
+        if (rawHours) {
+          for (const [hourKey, values] of rawHours) bucket.hours!.set(hourKey, this.aggregate(values));
+        }
         bucket.value = this.aggregateOrNull(Array.from(bucket.hours!.values()));
       }
     }
@@ -1120,6 +1142,19 @@ export class AllReportModal {
   // present, else the display identifier (still unique within one report).
   private sectionDeviceKey(row: StoreReading): string {
     return row.id || row.identifier;
+  }
+
+  // Collapse-set keys for group/device sections — URI-encoded so a label or
+  // identifier containing the data-ancestors separator (a literal space,
+  // e.g. group label "Área Comum") can never split into more than one token
+  // when applySectionVisibility parses `data-ancestors` back with .split(' ').
+  // encodeURIComponent is the identity function for plain alphanumeric
+  // strings, so existing single-word labels/ids are unaffected.
+  private sectionGroupKey(groupLabel: string): string {
+    return `grp:${encodeURIComponent(groupLabel)}`;
+  }
+  private sectionDeviceCollapseKey(row: StoreReading): string {
+    return `dev:${encodeURIComponent(this.sectionDeviceKey(row))}`;
   }
 
   // The single pure tree builder every 1d/1h render/KPI/chart/export path
@@ -1237,7 +1272,7 @@ export class AllReportModal {
     const totalDevices = model.groups.reduce((n, g) => n + g.devices.length, 0);
     if (totalDevices > AllReportModal.DEFAULT_COLLAPSE_DEVICE_THRESHOLD) {
       for (const g of model.groups) {
-        for (const d of g.devices) collapsed.add(`dev:${this.sectionDeviceKey(d.row)}`);
+        for (const d of g.devices) collapsed.add(this.sectionDeviceCollapseKey(d.row));
       }
     }
     return collapsed;
@@ -1316,8 +1351,8 @@ export class AllReportModal {
   private collapseAllSections(): void {
     const model = this.getReportSectionModel();
     for (const g of model.groups) {
-      this.collapsedSections.add(`grp:${g.groupLabel}`);
-      for (const d of g.devices) this.collapsedSections.add(`dev:${this.sectionDeviceKey(d.row)}`);
+      this.collapsedSections.add(this.sectionGroupKey(g.groupLabel));
+      for (const d of g.devices) this.collapsedSections.add(this.sectionDeviceCollapseKey(d.row));
     }
     const container = document.getElementById('table-container');
     if (container) this.applySectionVisibility(container);
@@ -1369,15 +1404,23 @@ export class AllReportModal {
       const visibleDevices = group.devices.filter((d) => visibleIds.has(this.sectionDeviceKey(d.row)));
       if (!visibleDevices.length) continue;
 
-      const groupKey = `grp:${group.groupLabel}`;
+      const groupKey = this.sectionGroupKey(group.groupLabel);
       if (isGrouped) {
+        // RFC-0223 review (M2): recomputed from visibleDevices, not
+        // group.total (the whole group's total regardless of the device
+        // filter) — so the header always reconciles with the device
+        // sections actually rendered beneath it when Filtros & Ordenação /
+        // search narrows what's visible.
+        const visibleGroupTotal = this.aggregateOrNull(
+          visibleDevices.flatMap((d) => this.flattenLeafValues(d.days))
+        );
         html += renderCollapsibleSectionHeader({
           sectionKey: groupKey,
           ancestorKeys: [],
           level: 0,
           title: group.groupLabel,
           meta: `${visibleDevices.length} dispositivo${visibleDevices.length === 1 ? '' : 's'}`,
-          totalLabel: `${fmtValue(group.total)} ${this.domainConfig.unit}`,
+          totalLabel: `${fmtValue(visibleGroupTotal)} ${this.domainConfig.unit}`,
           collapsed: this.collapsedSections.has(groupKey),
           colSpan: 3,
         });
@@ -1385,7 +1428,7 @@ export class AllReportModal {
       const groupAncestors = isGrouped ? [groupKey] : [];
 
       for (const device of visibleDevices) {
-        const deviceKey = `dev:${this.sectionDeviceKey(device.row)}`;
+        const deviceKey = this.sectionDeviceCollapseKey(device.row);
         html += renderCollapsibleSectionHeader({
           sectionKey: deviceKey,
           ancestorKeys: groupAncestors,

--- a/src/components/premium-modals/types.ts
+++ b/src/components/premium-modals/types.ts
@@ -77,6 +77,12 @@ export interface OpenAllReportParams {
   domain?: 'energy' | 'water' | 'temperature'; // Data domain (default: 'energy')
   group?: string; // RFC-0182: e.g. 'lojas' | 'entrada' | 'area_comum' | 'todos' | 'climatizavel' | 'nao_climatizavel'
   granularity?: '1d' | '1h'; // API data granularity (default: '1d')
+  /**
+   * RFC-0223: report temporal resolution — 'consolidado' (default) keeps today's
+   * single aggregate-per-device behavior; '1d'/'1h' render collapsible per-device
+   * sections (day rows / day→hour drill-down) in both the grid and the PDF.
+   */
+  reportMode?: 'consolidado' | '1d' | '1h';
   ui?: BaseUiCfg;
   api: BaseApiCfg;
   itemsList?: StoreItem[]; // RFC-0182: Optional — if absent, maps directly from API response

--- a/tests/components/premium-modals/allReportModal.ensureDeviceSeries.test.ts
+++ b/tests/components/premium-modals/allReportModal.ensureDeviceSeries.test.ts
@@ -1,0 +1,172 @@
+// AllReportModal.ensureDeviceSeries — RFC-0223 per-device series fetch, with
+// mocked global.fetch (no live network). Covers batching, per-device coverage
+// tracking (AC19), cache-key sensitivity to the device set, and the
+// in-flight-discarded-on-mode-change race the RFC calls out explicitly.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AllReportModal } from '../../../src/components/premium-modals/report-all/AllReportModal';
+import type { OpenAllReportParams } from '../../../src/components/premium-modals/types';
+
+function baseParams(overrides: Partial<OpenAllReportParams> = {}): OpenAllReportParams {
+  return {
+    customerId: 'customer-1',
+    domain: 'energy',
+    api: {
+      dataApiBaseUrl: 'https://api.example.com',
+      ingestionToken: 'token',
+    },
+    ...overrides,
+  };
+}
+
+const PERIOD = { startISO: '2026-07-01T00:00:00-03:00', endISO: '2026-07-03T23:59:59-03:00' };
+
+function jsonResponse(body: unknown, ok = true) {
+  return { ok, status: ok ? 200 : 500, json: async () => body };
+}
+
+describe('AllReportModal.ensureDeviceSeries', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches per-device points, records coverage=ok, and caches under a granularity-aware key', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({ consumption: [{ timestamp: '2026-07-01T12:00:00Z', value: 5 }] })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const modal = new AllReportModal(baseParams());
+    (modal as any).exportPeriod = PERIOD;
+    const rows = [{ identifier: 'A', name: 'A', consumption: 0, id: 'a' }];
+
+    const raw = await (modal as any).ensureDeviceSeries(rows, '1d');
+    expect(raw.get('a')).toEqual([{ timestamp: new Date('2026-07-01T12:00:00Z').getTime(), value: 5 }]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toContain('granularity=1d');
+
+    const cache = (modal as any).deviceSeriesCache;
+    expect(cache.granularity).toBe('1d');
+    expect(cache.coverage.get('a')).toBe('ok');
+
+    // Second call with the SAME rows/granularity/period reuses the cache — no new fetch.
+    await (modal as any).ensureDeviceSeries(rows, '1d');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('AC19: a non-ok response marks that device coverage=failed without throwing for the whole batch', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockImplementation((url: string) =>
+        url.includes('/devices/a/')
+          ? Promise.resolve(jsonResponse({ consumption: [{ timestamp: '2026-07-01T12:00:00Z', value: 5 }] }))
+          : Promise.resolve(jsonResponse(null, false))
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const modal = new AllReportModal(baseParams());
+    (modal as any).exportPeriod = PERIOD;
+    const rows = [
+      { identifier: 'A', name: 'A', consumption: 0, id: 'a' },
+      { identifier: 'B', name: 'B', consumption: 0, id: 'b' },
+    ];
+
+    const raw = await (modal as any).ensureDeviceSeries(rows, '1d');
+    expect(raw.has('a')).toBe(true);
+    expect(raw.has('b')).toBe(false);
+    const cache = (modal as any).deviceSeriesCache;
+    expect(cache.coverage.get('a')).toBe('ok');
+    expect(cache.coverage.get('b')).toBe('failed');
+  });
+
+  it('a thrown network error marks coverage=failed instead of propagating out of the batch', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('network down'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const modal = new AllReportModal(baseParams());
+    (modal as any).exportPeriod = PERIOD;
+    const rows = [{ identifier: 'A', name: 'A', consumption: 0, id: 'a' }];
+
+    const raw = await (modal as any).ensureDeviceSeries(rows, '1d');
+    expect(raw.size).toBe(0);
+    expect((modal as any).deviceSeriesCache.coverage.get('a')).toBe('failed');
+  });
+
+  it('batches requests in groups of 6 concurrent devices', async () => {
+    let maxConcurrent = 0;
+    let inFlight = 0;
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      inFlight++;
+      maxConcurrent = Math.max(maxConcurrent, inFlight);
+      await Promise.resolve();
+      inFlight--;
+      return jsonResponse({ consumption: [] });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const modal = new AllReportModal(baseParams());
+    (modal as any).exportPeriod = PERIOD;
+    const rows = Array.from({ length: 14 }, (_, i) => ({
+      identifier: `D${i}`,
+      name: `D${i}`,
+      consumption: 0,
+      id: `d${i}`,
+    }));
+
+    await (modal as any).ensureDeviceSeries(rows, '1d');
+    expect(fetchMock).toHaveBeenCalledTimes(14);
+    expect(maxConcurrent).toBeLessThanOrEqual(6);
+  });
+
+  it('cache key changes when the device set changes (exclusion toggle), forcing a refetch', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ consumption: [] }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const modal = new AllReportModal(baseParams());
+    (modal as any).exportPeriod = PERIOD;
+    const rowsAB = [
+      { identifier: 'A', name: 'A', consumption: 0, id: 'a' },
+      { identifier: 'B', name: 'B', consumption: 0, id: 'b' },
+    ];
+    const rowsA = [rowsAB[0]];
+
+    await (modal as any).ensureDeviceSeries(rowsAB, '1d');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    await (modal as any).ensureDeviceSeries(rowsA, '1d'); // different idsKey -> refetch
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('discards a stale in-flight result if reportMode changed to a different granularity before it resolved', async () => {
+    let resolveFirst!: (v: unknown) => void;
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise((resolve) => (resolveFirst = resolve)))
+      .mockResolvedValue(jsonResponse({ consumption: [{ timestamp: '2026-07-02T12:00:00Z', value: 9 }] }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const modal = new AllReportModal(baseParams());
+    (modal as any).exportPeriod = PERIOD;
+    const rows = [{ identifier: 'A', name: 'A', consumption: 0, id: 'a' }];
+
+    // Start a 1d fetch, but don't await it yet.
+    (modal as any).reportMode = '1d';
+    const firstFetch = (modal as any).ensureDeviceSeries(rows, '1d');
+
+    // User switches to Horário before the 1d fetch resolves — this fetch
+    // completes synchronously (mockResolvedValue) and caches under '1h'.
+    (modal as any).reportMode = '1h';
+    await (modal as any).ensureDeviceSeries(rows, '1h');
+    expect((modal as any).deviceSeriesCache.granularity).toBe('1h');
+
+    // Now the stale 1d fetch resolves — it must NOT clobber the '1h' cache.
+    resolveFirst(jsonResponse({ consumption: [{ timestamp: '2026-07-01T12:00:00Z', value: 1 }] }));
+    const staleRaw = await firstFetch;
+    expect(staleRaw.get('a')).toEqual([{ timestamp: new Date('2026-07-01T12:00:00Z').getTime(), value: 1 }]);
+    // The caller (e.g. an already-abandoned render) still gets its data, but
+    // the shared cache must still reflect the CURRENT mode ('1h'), not '1d'.
+    expect((modal as any).deviceSeriesCache.granularity).toBe('1h');
+  });
+});

--- a/tests/components/premium-modals/allReportModal.sections.test.ts
+++ b/tests/components/premium-modals/allReportModal.sections.test.ts
@@ -1,0 +1,425 @@
+// AllReportModal — RFC-0223 sectioned-grid logic tests (no show(): DateRangePicker/
+// jQuery/footer clock/participation chart are exercised elsewhere). Private state
+// and methods are set/called directly, following the DeviceReportModal.test.ts pattern.
+import { describe, it, expect } from 'vitest';
+import { AllReportModal } from '../../../src/components/premium-modals/report-all/AllReportModal';
+import type { OpenAllReportParams } from '../../../src/components/premium-modals/types';
+
+function baseParams(overrides: Partial<OpenAllReportParams> = {}): OpenAllReportParams {
+  return {
+    customerId: 'customer-1',
+    domain: 'energy',
+    api: {
+      dataApiBaseUrl: 'https://api.example.com',
+      ingestionToken: 'token',
+    },
+    ...overrides,
+  };
+}
+
+const PERIOD = { startISO: '2026-07-01T00:00:00-03:00', endISO: '2026-07-03T23:59:59-03:00' };
+const ts = (day: string, hour = 12) => new Date(`${day}T${String(hour).padStart(2, '0')}:00:00-03:00`).getTime();
+
+describe('AllReportModal.aggregate / aggregateOrNull', () => {
+  it('energy/water: sums present values, skips nulls, 0 when all missing', () => {
+    const modal = new AllReportModal(baseParams({ domain: 'energy' }));
+    expect((modal as any).aggregate([10, null, 5])).toBe(15);
+    expect((modal as any).aggregate([null, null])).toBe(0);
+    expect((modal as any).aggregateOrNull([null, null])).toBe(0);
+  });
+
+  it('temperature: means present values, aggregateOrNull returns null (not a fabricated 0) when all missing', () => {
+    const modal = new AllReportModal(baseParams({ domain: 'temperature' }));
+    expect((modal as any).aggregate([20, 22, null])).toBe(21);
+    expect((modal as any).aggregate([null, null])).toBe(0); // aggregate()'s own literal fallback
+    expect((modal as any).aggregateOrNull([null, null])).toBeNull(); // the caller-facing rule
+  });
+});
+
+describe('AllReportModal.bucketByDay', () => {
+  it('1d: one point per day passes through directly, missing days stay null', () => {
+    const modal = new AllReportModal(baseParams());
+    const points = [
+      { timestamp: ts('2026-07-01'), value: 10 },
+      { timestamp: ts('2026-07-03'), value: 5 },
+    ];
+    const buckets = (modal as any).bucketByDay(points, ['2026-07-01', '2026-07-02', '2026-07-03'], '1d');
+    expect(buckets.get('2026-07-01').value).toBe(10);
+    expect(buckets.get('2026-07-02').value).toBeNull();
+    expect(buckets.get('2026-07-03').value).toBe(5);
+  });
+
+  it('1h: groups hourly points per day and aggregates (sum for energy)', () => {
+    const modal = new AllReportModal(baseParams({ domain: 'energy' }));
+    const points = [
+      { timestamp: ts('2026-07-01', 8), value: 2 },
+      { timestamp: ts('2026-07-01', 9), value: 3 },
+    ];
+    const buckets = (modal as any).bucketByDay(points, ['2026-07-01'], '1h');
+    const day = buckets.get('2026-07-01');
+    expect(day.value).toBe(5);
+    expect(day.hours.get('2026-07-01T08')).toBe(2);
+    expect(day.hours.get('2026-07-01T09')).toBe(3);
+  });
+});
+
+describe('AllReportModal.buildReportSectionModel', () => {
+  function setup(domain: 'energy' | 'temperature', granularity: '1d' | '1h') {
+    const modal = new AllReportModal(baseParams({ domain }));
+    (modal as any).reportMode = granularity;
+    (modal as any).exportPeriod = PERIOD;
+    return modal;
+  }
+
+  it('AC16: a coverage="ok" device with zero points renders 0 dias and a domain-correct empty total', () => {
+    const modalEnergy = setup('energy', '1d');
+    (modalEnergy as any).data = [{ identifier: 'A', name: 'Device A', consumption: 0, id: 'a' }];
+    (modalEnergy as any).deviceSeriesCache = {
+      key: 'k',
+      granularity: '1d',
+      raw: new Map([['a', []]]),
+      coverage: new Map([['a', 'ok']]),
+    };
+    const model = (modalEnergy as any).buildReportSectionModel();
+    const device = model.groups[0].devices[0];
+    expect(device.dayCount).toBe(0);
+    expect(device.total).toBe(0);
+    expect(device.coverage).toBe('ok');
+
+    const modalTemp = setup('temperature', '1d');
+    (modalTemp as any).data = [{ identifier: 'A', name: 'Device A', consumption: 0, id: 'a' }];
+    (modalTemp as any).deviceSeriesCache = {
+      key: 'k',
+      granularity: '1d',
+      raw: new Map([['a', []]]),
+      coverage: new Map([['a', 'ok']]),
+    };
+    const tempDevice = (modalTemp as any).buildReportSectionModel().groups[0].devices[0];
+    expect(tempDevice.dayCount).toBe(0);
+    expect(tempDevice.total).toBeNull();
+  });
+
+  it('AC19: a failed-coverage device is distinct from AC16\'s clean empty state (total null, not 0)', () => {
+    const modal = setup('energy', '1d');
+    (modal as any).data = [{ identifier: 'B', name: 'Device B', consumption: 0, id: 'b' }];
+    (modal as any).deviceSeriesCache = {
+      key: 'k',
+      granularity: '1d',
+      raw: new Map(),
+      coverage: new Map([['b', 'failed']]),
+    };
+    const device = (modal as any).buildReportSectionModel().groups[0].devices[0];
+    expect(device.coverage).toBe('failed');
+    expect(device.total).toBeNull();
+    expect(device.dayCount).toBe(0);
+  });
+
+  it('1d device with full coverage: continuous day rows across the whole period, energy sums to the device total', () => {
+    const modal = setup('energy', '1d');
+    (modal as any).data = [{ identifier: 'A', name: 'Device A', consumption: 0, id: 'a' }];
+    (modal as any).deviceSeriesCache = {
+      key: 'k',
+      granularity: '1d',
+      raw: new Map([
+        [
+          'a',
+          [
+            { timestamp: ts('2026-07-01'), value: 10 },
+            { timestamp: ts('2026-07-03'), value: 5 },
+          ],
+        ],
+      ]),
+      coverage: new Map([['a', 'ok']]),
+    };
+    const device = (modal as any).buildReportSectionModel().groups[0].devices[0];
+    expect(device.dayCount).toBe(3);
+    expect(device.days.map((d: any) => d.value)).toEqual([10, 0, 5]); // missing day-2 -> 0 for energy
+    expect(device.total).toBe(15);
+  });
+
+  it('AC18 golden fixture: temperature device total is a FLAT mean over all hours (uneven day coverage), not a mean-of-day-means', () => {
+    const modal = setup('temperature', '1h');
+    (modal as any).data = [{ identifier: 'A', name: 'Sensor A', consumption: 0, id: 'a' }];
+    (modal as any).deviceSeriesCache = {
+      key: 'k',
+      granularity: '1h',
+      raw: new Map([
+        [
+          'a',
+          [
+            // Day 1: a single 30°C reading.
+            { timestamp: ts('2026-07-01', 12), value: 30 },
+            // Day 2: four readings averaging 20°C (10,10,30,30).
+            { timestamp: ts('2026-07-02', 8), value: 10 },
+            { timestamp: ts('2026-07-02', 9), value: 10 },
+            { timestamp: ts('2026-07-02', 10), value: 30 },
+            { timestamp: ts('2026-07-02', 11), value: 30 },
+            // Day 3: no readings at all (stays null/'—').
+          ],
+        ],
+      ]),
+      coverage: new Map([['a', 'ok']]),
+    };
+    const device = (modal as any).buildReportSectionModel().groups[0].devices[0];
+    // Mean-of-day-means would be (30 + 20) / 2 = 25 — WRONG (biased by day-1's single reading).
+    // Flat mean over all 5 leaf readings: (30+10+10+30+30)/5 = 22.
+    expect(device.total).toBe(22);
+    expect(device.days[0].value).toBe(30); // day 1 mean (single reading)
+    expect(device.days[1].value).toBe(20); // day 2 mean
+    expect(device.days[2].value).toBeNull(); // day 3: no readings -> '—'
+  });
+
+  it('groups devices by groupLabel, preserving first-occurrence order, and sums group totals (energy)', () => {
+    const modal = setup('energy', '1d');
+    (modal as any).data = [
+      { identifier: 'A', name: 'A', consumption: 0, id: 'a', groupLabel: 'Lojas' },
+      { identifier: 'B', name: 'B', consumption: 0, id: 'b', groupLabel: 'Entrada' },
+      { identifier: 'C', name: 'C', consumption: 0, id: 'c', groupLabel: 'Lojas' },
+    ];
+    (modal as any).deviceSeriesCache = {
+      key: 'k',
+      granularity: '1d',
+      raw: new Map([
+        ['a', [{ timestamp: ts('2026-07-01'), value: 10 }]],
+        ['b', [{ timestamp: ts('2026-07-01'), value: 4 }]],
+        ['c', [{ timestamp: ts('2026-07-01'), value: 6 }]],
+      ]),
+      coverage: new Map([['a', 'ok'], ['b', 'ok'], ['c', 'ok']]),
+    };
+    const model = (modal as any).buildReportSectionModel();
+    expect(model.groups.map((g: any) => g.groupLabel)).toEqual(['Lojas', 'Entrada']);
+    expect(model.groups[0].devices.length).toBe(2);
+    expect(model.groups[0].total).toBe(16); // 10 + 6
+    expect(model.groups[1].total).toBe(4);
+  });
+});
+
+describe('AllReportModal.getEffectiveDeviceTotal', () => {
+  it('consolidado: returns row.consumption unchanged (byte-for-byte, AC1/AC3)', () => {
+    const modal = new AllReportModal(baseParams());
+    (modal as any).reportMode = 'consolidado';
+    const row = { identifier: 'A', name: 'A', consumption: 42, id: 'a' };
+    expect((modal as any).getEffectiveDeviceTotal(row)).toBe(42);
+  });
+
+  it('1d/1h: returns the section model device total instead of raw consumption', () => {
+    const modal = new AllReportModal(baseParams());
+    (modal as any).reportMode = '1d';
+    (modal as any).exportPeriod = PERIOD;
+    const row = { identifier: 'A', name: 'A', consumption: 999, id: 'a' };
+    (modal as any).data = [row];
+    (modal as any).deviceSeriesCache = {
+      key: 'k',
+      granularity: '1d',
+      raw: new Map([['a', [{ timestamp: ts('2026-07-01'), value: 7 }]]]),
+      coverage: new Map([['a', 'ok']]),
+    };
+    expect((modal as any).getEffectiveDeviceTotal(row)).toBe(7); // NOT 999
+  });
+});
+
+describe('AllReportModal collapse-state defaults and epoch reset (AC6/AC21)', () => {
+  it('computeDefaultCollapsedSections: all expanded under the device-count threshold', () => {
+    const modal = new AllReportModal(baseParams());
+    const model = {
+      groups: [
+        {
+          groupLabel: '—',
+          total: 0,
+          devices: Array.from({ length: 5 }, (_, i) => ({
+            row: { identifier: `D${i}`, name: `D${i}`, consumption: 0, id: `d${i}` },
+            days: [],
+            total: 0,
+            dayCount: 0,
+            coverage: 'ok' as const,
+          })),
+        },
+      ],
+    };
+    const collapsed = (modal as any).computeDefaultCollapsedSections(model);
+    expect(collapsed.size).toBe(0);
+  });
+
+  it('computeDefaultCollapsedSections: auto-collapses every device above the threshold', () => {
+    const modal = new AllReportModal(baseParams());
+    const model = {
+      groups: [
+        {
+          groupLabel: '—',
+          total: 0,
+          devices: Array.from({ length: 30 }, (_, i) => ({
+            row: { identifier: `D${i}`, name: `D${i}`, consumption: 0, id: `d${i}` },
+            days: [],
+            total: 0,
+            dayCount: 0,
+            coverage: 'ok' as const,
+          })),
+        },
+      ],
+    };
+    const collapsed = (modal as any).computeDefaultCollapsedSections(model);
+    expect(collapsed.size).toBe(30);
+    expect(collapsed.has('dev:d0')).toBe(true);
+  });
+
+  it('resetCollapsedSectionsIfEpochChanged resets on a period/mode change but preserves within the same epoch', () => {
+    const modal = new AllReportModal(baseParams());
+    (modal as any).reportMode = '1d';
+    (modal as any).exportPeriod = PERIOD;
+    (modal as any).data = [];
+    (modal as any).deviceSeriesCache = { key: 'k', granularity: '1d', raw: new Map(), coverage: new Map() };
+
+    (modal as any).resetCollapsedSectionsIfEpochChanged();
+    (modal as any).collapsedSections.add('dev:x'); // simulate a manual toggle
+
+    // Same period+mode -> epoch unchanged -> collapsedSections preserved.
+    (modal as any).resetCollapsedSectionsIfEpochChanged();
+    expect((modal as any).collapsedSections.has('dev:x')).toBe(true);
+
+    // Mode change -> epoch changes -> resets to defaults (empty, under threshold).
+    (modal as any).reportMode = '1h';
+    (modal as any).resetCollapsedSectionsIfEpochChanged();
+    expect((modal as any).collapsedSections.has('dev:x')).toBe(false);
+  });
+});
+
+describe('AllReportModal.toggleSection / collapseAllSections / expandAllSections', () => {
+  it('toggleSection flips membership; collapseAllSections/expandAllSections set all/none', () => {
+    const modal = new AllReportModal(baseParams());
+    (modal as any).reportMode = '1d';
+    (modal as any).exportPeriod = PERIOD;
+    (modal as any).data = [
+      { identifier: 'A', name: 'A', consumption: 0, id: 'a' },
+      { identifier: 'B', name: 'B', consumption: 0, id: 'b' },
+    ];
+    (modal as any).deviceSeriesCache = {
+      key: 'k',
+      granularity: '1d',
+      raw: new Map([
+        ['a', [{ timestamp: ts('2026-07-01'), value: 1 }]],
+        ['b', [{ timestamp: ts('2026-07-01'), value: 1 }]],
+      ]),
+      coverage: new Map([['a', 'ok'], ['b', 'ok']]),
+    };
+
+    (modal as any).toggleSection('dev:a');
+    expect((modal as any).collapsedSections.has('dev:a')).toBe(true);
+    (modal as any).toggleSection('dev:a');
+    expect((modal as any).collapsedSections.has('dev:a')).toBe(false);
+
+    (modal as any).collapseAllSections();
+    expect((modal as any).collapsedSections.has('dev:a')).toBe(true);
+    expect((modal as any).collapsedSections.has('dev:b')).toBe(true);
+
+    (modal as any).expandAllSections();
+    expect((modal as any).collapsedSections.size).toBe(0);
+  });
+});
+
+describe('AllReportModal.renderSectionedRows (model -> HTML)', () => {
+  function parseRows(html: string): HTMLTableRowElement[] {
+    const table = document.createElement('table');
+    table.innerHTML = `<tbody>${html}</tbody>`;
+    return Array.from(table.querySelectorAll('tr'));
+  }
+
+  function ungroupedModal() {
+    const modal = new AllReportModal(baseParams());
+    (modal as any).reportMode = '1d';
+    (modal as any).exportPeriod = PERIOD;
+    (modal as any).data = [{ identifier: 'A', name: 'Device A', consumption: 0, id: 'a' }];
+    (modal as any).selectedStoreIds = new Set(); // no device filter active
+    (modal as any).deviceSeriesCache = {
+      key: 'k',
+      granularity: '1d',
+      raw: new Map([
+        [
+          'a',
+          [
+            { timestamp: ts('2026-07-01'), value: 10 },
+            { timestamp: ts('2026-07-03'), value: 5 },
+          ],
+        ],
+      ]),
+      coverage: new Map([['a', 'ok']]),
+    };
+    return modal;
+  }
+
+  it('ungrouped data: no group header, one device header + one row per period day', () => {
+    const modal = ungroupedModal();
+    const model = (modal as any).getReportSectionModel();
+    const rows = parseRows((modal as any).renderSectionedRows(model));
+
+    expect(rows.filter((r) => r.classList.contains('rp-section-header--level-0')).length).toBe(0);
+    const deviceHeaders = rows.filter((r) => r.classList.contains('rp-section-header--level-1'));
+    expect(deviceHeaders.length).toBe(1);
+    expect(deviceHeaders[0].dataset.sectionToggle).toBe('dev:a');
+    expect(deviceHeaders[0].dataset.ancestors).toBe(''); // no group ancestor when ungrouped
+
+    const dayRows = rows.filter((r) => r.classList.contains('rp-section-row--level-2'));
+    expect(dayRows.length).toBe(3); // 2026-07-01, 02, 03
+    expect(dayRows.every((r) => r.dataset.ancestors === 'dev:a')).toBe(true);
+    // Day-2 has no reading -> materializes to 0 (energy) and renders as such.
+    expect(dayRows[1].children[1].textContent).toBe('0,00');
+  });
+
+  it('day-row % is relative to the DEVICE total, not the whole report grand total', () => {
+    const modal = ungroupedModal();
+    const model = (modal as any).getReportSectionModel();
+    const rows = parseRows((modal as any).renderSectionedRows(model));
+    const dayRows = rows.filter((r) => r.classList.contains('rp-section-row--level-2'));
+    // Device total is 15 (10 + 0 + 5); day-1's 10 is 66,67% of the DEVICE total.
+    expect(dayRows[0].children[2].textContent).toContain('66,67%');
+  });
+
+  it('grouped data: group header wraps device headers, ancestor chain includes the group key', () => {
+    const modal = new AllReportModal(baseParams());
+    (modal as any).reportMode = '1d';
+    (modal as any).exportPeriod = PERIOD;
+    (modal as any).data = [{ identifier: 'A', name: 'Device A', consumption: 0, id: 'a', groupLabel: 'Lojas' }];
+    (modal as any).selectedStoreIds = new Set();
+    (modal as any).deviceSeriesCache = {
+      key: 'k',
+      granularity: '1d',
+      raw: new Map([['a', [{ timestamp: ts('2026-07-01'), value: 10 }]]]),
+      coverage: new Map([['a', 'ok']]),
+    };
+    const model = (modal as any).getReportSectionModel();
+    const rows = parseRows((modal as any).renderSectionedRows(model));
+
+    const groupHeader = rows.find((r) => r.classList.contains('rp-section-header--level-0'));
+    expect(groupHeader?.dataset.sectionToggle).toBe('grp:Lojas');
+    const deviceHeader = rows.find((r) => r.classList.contains('rp-section-header--level-1'));
+    expect(deviceHeader?.dataset.ancestors).toBe('grp:Lojas');
+    const dayRow = rows.find((r) => r.classList.contains('rp-section-row--level-2'));
+    expect(dayRow?.dataset.ancestors).toBe('grp:Lojas dev:a');
+  });
+
+  it('a device excluded by the device filter (Filtros & Ordenação) is omitted from the sectioned rows', () => {
+    const modal = ungroupedModal();
+    (modal as any).selectedStoreIds = new Set(['some-other-device']); // "A" not selected
+    const model = (modal as any).getReportSectionModel();
+    const html = (modal as any).renderSectionedRows(model);
+    expect(html).toBe('');
+  });
+
+  it('a device with coverage="failed" renders the "dados incompletos" badge and no day rows', () => {
+    const modal = new AllReportModal(baseParams());
+    (modal as any).reportMode = '1d';
+    (modal as any).exportPeriod = PERIOD;
+    (modal as any).data = [{ identifier: 'B', name: 'Device B', consumption: 0, id: 'b' }];
+    (modal as any).selectedStoreIds = new Set();
+    (modal as any).deviceSeriesCache = {
+      key: 'k',
+      granularity: '1d',
+      raw: new Map(),
+      coverage: new Map([['b', 'failed']]),
+    };
+    const model = (modal as any).getReportSectionModel();
+    const rows = parseRows((modal as any).renderSectionedRows(model));
+    expect(rows.length).toBe(1); // header only, no day rows
+    expect(rows[0].querySelector('.rp-section-badge')?.textContent).toBe('dados incompletos');
+    expect(rows[0].querySelector('.rp-section-total')?.textContent).toBe('— kWh');
+  });
+});

--- a/tests/components/premium-modals/allReportModal.sections.test.ts
+++ b/tests/components/premium-modals/allReportModal.sections.test.ts
@@ -61,6 +61,45 @@ describe('AllReportModal.bucketByDay', () => {
     expect(day.hours.get('2026-07-01T08')).toBe(2);
     expect(day.hours.get('2026-07-01T09')).toBe(3);
   });
+
+  it('L4 (code review): two readings colliding on the SAME hour key are summed (energy), never overwritten', () => {
+    // Two distinct real readings that map to the same hourKey — the DST
+    // fall-back scenario (two UTC instants both landing on local "...T01")
+    // is one way this happens, but the aggregation must be correct for ANY
+    // collision, not just that specific mechanism.
+    const modal = new AllReportModal(baseParams({ domain: 'energy' }));
+    const sameHour = ts('2026-07-01', 8);
+    const points = [
+      { timestamp: sameHour, value: 4 },
+      { timestamp: sameHour + 15 * 60 * 1000, value: 6 }, // 15 min later, same hour key
+    ];
+    const buckets = (modal as any).bucketByDay(points, ['2026-07-01'], '1h');
+    const day = buckets.get('2026-07-01');
+    expect(day.hours.get('2026-07-01T08')).toBe(10); // 4 + 6, NOT 6 (last-write-wins)
+    expect(day.value).toBe(10);
+  });
+
+  it('L4: a colliding hour is averaged (not summed) for temperature', () => {
+    const modal = new AllReportModal(baseParams({ domain: 'temperature' }));
+    const sameHour = ts('2026-07-01', 8);
+    const points = [
+      { timestamp: sameHour, value: 20 },
+      { timestamp: sameHour + 15 * 60 * 1000, value: 30 },
+    ];
+    const buckets = (modal as any).bucketByDay(points, ['2026-07-01'], '1h');
+    expect(buckets.get('2026-07-01').hours.get('2026-07-01T08')).toBe(25);
+  });
+
+  it('a day with zero readings still resolves value/hours consistently (no regression from the L4 refactor)', () => {
+    const modalEnergy = new AllReportModal(baseParams({ domain: 'energy' }));
+    const emptyBuckets = (modalEnergy as any).bucketByDay([], ['2026-07-01'], '1h');
+    expect(emptyBuckets.get('2026-07-01').value).toBe(0); // aggregateOrNull([]) for energy
+    expect(emptyBuckets.get('2026-07-01').hours.size).toBe(0);
+
+    const modalTemp = new AllReportModal(baseParams({ domain: 'temperature' }));
+    const emptyTempBuckets = (modalTemp as any).bucketByDay([], ['2026-07-01'], '1h');
+    expect(emptyTempBuckets.get('2026-07-01').value).toBeNull(); // aggregateOrNull([]) for temperature
+  });
 });
 
 describe('AllReportModal.buildReportSectionModel', () => {
@@ -394,6 +433,88 @@ describe('AllReportModal.renderSectionedRows (model -> HTML)', () => {
     expect(deviceHeader?.dataset.ancestors).toBe('grp:Lojas');
     const dayRow = rows.find((r) => r.classList.contains('rp-section-row--level-2'));
     expect(dayRow?.dataset.ancestors).toBe('grp:Lojas dev:a');
+  });
+
+  it('H1 (code review): group collapse works when the group label contains a space (e.g. "Área Comum")', () => {
+    const modal = new AllReportModal(baseParams());
+    (modal as any).reportMode = '1d';
+    (modal as any).exportPeriod = PERIOD;
+    (modal as any).data = [
+      { identifier: 'A', name: 'Device A', consumption: 0, id: 'a', groupLabel: 'Área Comum' },
+    ];
+    (modal as any).selectedStoreIds = new Set();
+    (modal as any).deviceSeriesCache = {
+      key: 'k',
+      granularity: '1d',
+      raw: new Map([['a', [{ timestamp: ts('2026-07-01'), value: 10 }]]]),
+      coverage: new Map([['a', 'ok']]),
+    };
+    const model = (modal as any).getReportSectionModel();
+    const rows = parseRows((modal as any).renderSectionedRows(model));
+
+    const expectedGroupKey = `grp:${encodeURIComponent('Área Comum')}`;
+    const groupHeader = rows.find((r) => r.classList.contains('rp-section-header--level-0'));
+    expect(groupHeader?.dataset.sectionToggle).toBe(expectedGroupKey);
+
+    // The bug: splitting a non-encoded "grp:Área Comum" by space yields TWO
+    // tokens, neither matching the real collapse key. Fixed: exactly one
+    // token, equal to the group's own section key.
+    const deviceHeader = rows.find((r) => r.classList.contains('rp-section-header--level-1'));
+    const ancestorTokens = (deviceHeader?.dataset.ancestors || '').split(' ').filter(Boolean);
+    expect(ancestorTokens).toEqual([expectedGroupKey]);
+
+    // Full round trip through the DOM: collapseAllSections() must actually
+    // hide this group's device header + day row via applySectionVisibility —
+    // this is exactly what H1 broke (clicking the group header, or
+    // "Recolher tudo", never hid an "Área Comum"-style group).
+    document.body.innerHTML = '<div id="table-container"><table><tbody></tbody></table></div>';
+    const tbody = document.querySelector('#table-container tbody')!;
+    tbody.innerHTML = (modal as any).renderSectionedRows(model);
+    const container = document.getElementById('table-container')!;
+
+    (modal as any).collapseAllSections();
+    const liveDeviceHeader = container.querySelector('.rp-section-header--level-1') as HTMLElement;
+    const liveDayRow = container.querySelector('.rp-section-row--level-2') as HTMLElement;
+    expect(liveDeviceHeader.style.display).toBe('none');
+    expect(liveDayRow.style.display).toBe('none');
+
+    (modal as any).expandAllSections();
+    expect(liveDeviceHeader.style.display).toBe('');
+    expect(liveDayRow.style.display).toBe('');
+  });
+
+  it('M2 (code review): group header total reconciles with visible (device-filtered) rows, not the whole group', () => {
+    const modal = new AllReportModal(baseParams({ domain: 'energy' }));
+    (modal as any).reportMode = '1d';
+    (modal as any).exportPeriod = PERIOD;
+    (modal as any).data = [
+      { identifier: 'A', name: 'Device A', consumption: 0, id: 'a', groupLabel: 'Lojas' },
+      { identifier: 'B', name: 'Device B', consumption: 0, id: 'b', groupLabel: 'Lojas' },
+    ];
+    // Device filter (Filtros & Ordenação) keeps only device A.
+    (modal as any).selectedStoreIds = new Set([(modal as any).generateStoreId('A')]);
+    (modal as any).deviceSeriesCache = {
+      key: 'k',
+      granularity: '1d',
+      raw: new Map([
+        ['a', [{ timestamp: ts('2026-07-01'), value: 10 }]],
+        ['b', [{ timestamp: ts('2026-07-01'), value: 90 }]],
+      ]),
+      coverage: new Map([['a', 'ok'], ['b', 'ok']]),
+    };
+    const model = (modal as any).getReportSectionModel();
+    // The unfiltered model total includes BOTH devices (100) — confirms the
+    // filter is genuinely active and the two totals would differ if the bug
+    // were still present.
+    expect(model.groups[0].total).toBe(100);
+
+    const rows = parseRows((modal as any).renderSectionedRows(model));
+    const deviceHeaders = rows.filter((r) => r.classList.contains('rp-section-header--level-1'));
+    expect(deviceHeaders.length).toBe(1); // only device A renders
+
+    const groupHeader = rows.find((r) => r.classList.contains('rp-section-header--level-0'));
+    expect(groupHeader?.querySelector('.rp-section-total')?.textContent).toBe('10,00 kWh'); // NOT 100,00
+    expect(groupHeader?.querySelector('.rp-section-meta')?.textContent).toBe('1 dispositivo');
   });
 
   it('a device excluded by the device filter (Filtros & Ordenação) is omitted from the sectioned rows', () => {

--- a/tests/components/premium-modals/internal/collapsibleSection.test.ts
+++ b/tests/components/premium-modals/internal/collapsibleSection.test.ts
@@ -87,6 +87,27 @@ describe('CollapsibleSection leaf row renderer', () => {
     expect(row.children.length).toBe(2);
     expect(row.children[0].textContent).toBe('15/07');
   });
+
+  it('H1 (code review): an encoded ancestor key round-trips through the space-joined data-ancestors serialization even when the source label contains a space', () => {
+    // The renderer itself just joins ancestorKeys with ' ' — callers (e.g.
+    // AllReportModal.sectionGroupKey) are responsible for encoding any key
+    // built from a label. A group label like "Área Comum" must be passed in
+    // pre-encoded (grp:%C3%81rea%20Comum), never as the raw "grp:Área Comum"
+    // — the latter would split into ['grp:Área', 'Comum'], two tokens that
+    // match nothing.
+    const groupLabel = 'Área Comum';
+    const encodedGroupKey = `grp:${encodeURIComponent(groupLabel)}`;
+    const row = parseRow(
+      renderCollapsibleLeafRow({
+        ancestorKeys: [encodedGroupKey, 'dev:123'],
+        level: 2,
+        cells: ['<td>15/07</td>', '<td>10,00</td>'],
+      })
+    );
+    const tokens = (row.dataset.ancestors || '').split(' ').filter(Boolean);
+    expect(tokens).toEqual([encodedGroupKey, 'dev:123']);
+    expect(tokens.length).toBe(2);
+  });
 });
 
 describe('escapeHtml', () => {

--- a/tests/components/premium-modals/internal/collapsibleSection.test.ts
+++ b/tests/components/premium-modals/internal/collapsibleSection.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  renderCollapsibleSectionHeader,
+  renderCollapsibleLeafRow,
+  injectCollapsibleSectionStyles,
+  escapeHtml,
+} from '../../../../src/components/premium-modals/internal/collapsible-section';
+
+function parseRow(html: string): HTMLTableRowElement {
+  const table = document.createElement('table');
+  table.innerHTML = `<tbody>${html}</tbody>`;
+  return table.querySelector('tr')!;
+}
+
+describe('CollapsibleSection header renderer', () => {
+  it('renders the collapsed state: right caret, aria-expanded=false, ancestors joined', () => {
+    const row = parseRow(
+      renderCollapsibleSectionHeader({
+        sectionKey: 'dev:123',
+        ancestorKeys: ['grp:Lojas'],
+        level: 1,
+        title: 'McDonalds (SCMAL1230B)',
+        meta: '16 dias',
+        totalLabel: '1.204,53 kWh',
+        collapsed: true,
+        colSpan: 3,
+      })
+    );
+    expect(row.dataset.sectionToggle).toBe('dev:123');
+    expect(row.dataset.ancestors).toBe('grp:Lojas');
+    expect(row.getAttribute('aria-expanded')).toBe('false');
+    expect(row.getAttribute('role')).toBe('button');
+    expect(row.querySelector('.rp-section-caret')?.textContent).toBe('▶');
+    expect(row.querySelector('.rp-section-title')?.textContent).toBe('McDonalds (SCMAL1230B)');
+    expect(row.querySelector('.rp-section-meta')?.textContent).toBe('16 dias');
+    expect(row.querySelector('.rp-section-total')?.textContent).toBe('1.204,53 kWh');
+    expect(row.querySelector('.rp-section-badge')).toBeNull();
+  });
+
+  it('renders the expanded state and the AC19 "dados incompletos" badge when incomplete', () => {
+    const row = parseRow(
+      renderCollapsibleSectionHeader({
+        sectionKey: 'dev:999',
+        ancestorKeys: [],
+        level: 1,
+        title: 'Broken Sensor',
+        meta: '0 dias',
+        totalLabel: '—',
+        collapsed: false,
+        colSpan: 3,
+        incomplete: true,
+      })
+    );
+    expect(row.getAttribute('aria-expanded')).toBe('true');
+    expect(row.querySelector('.rp-section-caret')?.textContent).toBe('▼');
+    expect(row.querySelector('.rp-section-badge')?.textContent).toBe('dados incompletos');
+  });
+
+  it('escapes device names/labels to prevent HTML injection from API-sourced strings', () => {
+    const row = parseRow(
+      renderCollapsibleSectionHeader({
+        sectionKey: 'dev:1',
+        ancestorKeys: [],
+        level: 1,
+        title: '<img src=x onerror=alert(1)>',
+        totalLabel: '0',
+        collapsed: false,
+        colSpan: 3,
+      })
+    );
+    expect(row.querySelector('.rp-section-title')?.innerHTML).not.toContain('<img');
+    expect(row.querySelector('.rp-section-title')?.textContent).toBe('<img src=x onerror=alert(1)>');
+  });
+});
+
+describe('CollapsibleSection leaf row renderer', () => {
+  it('joins ancestor keys and renders caller-provided cells verbatim', () => {
+    const row = parseRow(
+      renderCollapsibleLeafRow({
+        ancestorKeys: ['grp:Lojas', 'dev:123'],
+        level: 2,
+        cells: ['<td>15/07</td>', '<td>10,00</td>'],
+      })
+    );
+    expect(row.dataset.ancestors).toBe('grp:Lojas dev:123');
+    expect(row.classList.contains('rp-section-row--level-2')).toBe(true);
+    expect(row.children.length).toBe(2);
+    expect(row.children[0].textContent).toBe('15/07');
+  });
+});
+
+describe('escapeHtml', () => {
+  it('escapes the five reserved HTML characters', () => {
+    expect(escapeHtml(`<a href="x">&'</a>`)).toBe('&lt;a href=&quot;x&quot;&gt;&amp;&#39;&lt;/a&gt;');
+  });
+});
+
+describe('injectCollapsibleSectionStyles', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+  });
+
+  it('injects styles idempotently', () => {
+    injectCollapsibleSectionStyles();
+    injectCollapsibleSectionStyles();
+    expect(document.querySelectorAll('#myio-collapsible-section-styles').length).toBe(1);
+  });
+});

--- a/tests/components/premium-modals/internal/engines/dateEngine.dayHourKey.test.ts
+++ b/tests/components/premium-modals/internal/engines/dateEngine.dayHourKey.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { toDayKey, toHourKey } from '../../../../../src/components/premium-modals/internal/engines/DateEngine';
+
+const HOUR_MS = 60 * 60 * 1000;
+
+describe('DateEngine.toDayKey / toHourKey (RFC-0223 tz-pinned bucket keys)', () => {
+  it('toDayKey is tz-pinned, not UTC-naive (a naive toISOString().slice(0,10) would be wrong here)', () => {
+    // 2026-07-16T02:30:00Z is 2026-07-15 23:30 in America/Sao_Paulo (UTC-3, no DST since 2019).
+    const ts = new Date('2026-07-16T02:30:00Z').getTime();
+    expect(toDayKey(ts)).toBe('2026-07-15');
+    expect(toHourKey(ts)).toBe('2026-07-15T23');
+  });
+
+  it('toDayKey/toHourKey accept an explicit tz override (not hard-coded to São Paulo)', () => {
+    const ts = new Date('2026-01-10T12:00:00Z').getTime();
+    expect(toDayKey(ts, 'America/Sao_Paulo')).toBe('2026-01-10');
+    // America/New_York is UTC-5 in January (EST): 12:00Z -> 07:00 local, same day.
+    expect(toDayKey(ts, 'America/New_York')).toBe('2026-01-10');
+    expect(toHourKey(ts, 'America/New_York')).toBe('2026-01-10T07');
+  });
+
+  it('a spring-forward DST day yields 23 distinct hour keys, not a hard-coded 24 (AC17)', () => {
+    // America/New_York spring-forward: 2024-03-10, clocks jump 02:00 -> 03:00.
+    // Sample every UTC hour across a 48h window and keep only the ones landing
+    // on the transition's local calendar day.
+    const start = new Date('2024-03-10T00:00:00Z').getTime();
+    const dayKeys = new Set<string>();
+    const hourKeysForDay = new Set<string>();
+    for (let i = 0; i < 48; i++) {
+      const ts = start + i * HOUR_MS;
+      const day = toDayKey(ts, 'America/New_York');
+      dayKeys.add(day);
+      if (day === '2024-03-10') hourKeysForDay.add(toHourKey(ts, 'America/New_York'));
+    }
+    expect(hourKeysForDay.size).toBe(23);
+    expect(hourKeysForDay.has('2024-03-10T02')).toBe(false);
+  });
+
+  it('a fall-back DST day collapses the repeated local hour into one bucket key (24 distinct keys from 25 real readings)', () => {
+    // America/New_York fall-back: 2024-11-03, local 01:00-01:59 occurs twice.
+    // 25 hourly UTC samples land on this local day; the repeated local hour
+    // must aggregate under ONE key so summed consumption for "hour 01" isn't
+    // silently dropped or double-labeled.
+    const start = new Date('2024-11-03T00:00:00Z').getTime();
+    const hourKeysForDay: string[] = [];
+    for (let i = 0; i < 48; i++) {
+      const ts = start + i * HOUR_MS;
+      if (toDayKey(ts, 'America/New_York') === '2024-11-03') {
+        hourKeysForDay.push(toHourKey(ts, 'America/New_York'));
+      }
+    }
+    expect(hourKeysForDay.length).toBe(25); // 25 real hourly readings that calendar day
+    expect(new Set(hourKeysForDay).size).toBe(24); // but only 24 distinct hour buckets
+    const occurrences = hourKeysForDay.filter((k) => k === '2024-11-03T01').length;
+    expect(occurrences).toBe(2); // the repeated local hour maps twice into the same key
+  });
+
+  it('accepts a Date object as well as a numeric timestamp', () => {
+    const d = new Date('2026-07-16T02:30:00Z');
+    expect(toDayKey(d)).toBe(toDayKey(d.getTime()));
+    expect(toHourKey(d)).toBe(toHourKey(d.getTime()));
+  });
+});

--- a/tests/components/premium-modals/internal/engines/dateEngine.dayHourKey.test.ts
+++ b/tests/components/premium-modals/internal/engines/dateEngine.dayHourKey.test.ts
@@ -1,7 +1,21 @@
 import { describe, it, expect } from 'vitest';
 import { toDayKey, toHourKey } from '../../../../../src/components/premium-modals/internal/engines/DateEngine';
+import { AllReportModal } from '../../../../../src/components/premium-modals/report-all/AllReportModal';
+import type { OpenAllReportParams } from '../../../../../src/components/premium-modals/types';
 
 const HOUR_MS = 60 * 60 * 1000;
+
+function baseParams(overrides: Partial<OpenAllReportParams> = {}): OpenAllReportParams {
+  return {
+    customerId: 'customer-1',
+    domain: 'energy',
+    api: {
+      dataApiBaseUrl: 'https://api.example.com',
+      ingestionToken: 'token',
+    },
+    ...overrides,
+  };
+}
 
 describe('DateEngine.toDayKey / toHourKey (RFC-0223 tz-pinned bucket keys)', () => {
   it('toDayKey is tz-pinned, not UTC-naive (a naive toISOString().slice(0,10) would be wrong here)', () => {
@@ -53,6 +67,36 @@ describe('DateEngine.toDayKey / toHourKey (RFC-0223 tz-pinned bucket keys)', () 
     expect(new Set(hourKeysForDay).size).toBe(24); // but only 24 distinct hour buckets
     const occurrences = hourKeysForDay.filter((k) => k === '2024-11-03T01').length;
     expect(occurrences).toBe(2); // the repeated local hour maps twice into the same key
+  });
+
+  it('L4 (code review): bucketByDay sums a REAL DST fall-back collision, not just a synthetic same-hour-key pair', () => {
+    // allReportModal.sections.test.ts's L4 tests prove the aggregation logic
+    // with two timestamps 15 minutes apart (same hour key by construction).
+    // This test drives the actual mechanism the reviewer described: two
+    // real UTC instants that only collide because of the America/New_York
+    // 2024-11-03 fall-back transition (the same transition as the test
+    // above), fed straight into bucketByDay.
+    const start = new Date('2024-11-03T00:00:00Z').getTime();
+    const collidingTimestamps: number[] = [];
+    for (let i = 0; i < 48; i++) {
+      const t = start + i * HOUR_MS;
+      if (
+        toDayKey(t, 'America/New_York') === '2024-11-03' &&
+        toHourKey(t, 'America/New_York') === '2024-11-03T01'
+      ) {
+        collidingTimestamps.push(t);
+      }
+    }
+    expect(collidingTimestamps.length).toBe(2);
+
+    const modal = new AllReportModal(
+      baseParams({ domain: 'energy', api: { dataApiBaseUrl: 'x', ingestionToken: 'y', timezone: 'America/New_York' } })
+    ) as any;
+    const points = collidingTimestamps.map((timestamp, i) => ({ timestamp, value: i === 0 ? 4 : 6 }));
+    const buckets = modal.bucketByDay(points, ['2024-11-03'], '1h');
+    const day = buckets.get('2024-11-03');
+    expect(day.hours.get('2024-11-03T01')).toBe(10); // 4 + 6, NOT 6 (last-write-wins)
+    expect(day.value).toBe(10);
   });
 
   it('accepts a Date object as well as a numeric timestamp', () => {

--- a/tests/components/premium-modals/internal/reportModeSelector.test.ts
+++ b/tests/components/premium-modals/internal/reportModeSelector.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  createReportModeSelector,
+  REPORT_MODE_SELECTOR_CSS_PREFIX,
+} from '../../../../src/components/premium-modals/internal/report-mode-selector';
+
+const P = REPORT_MODE_SELECTOR_CSS_PREFIX;
+
+function getConsolidadoBtn(root: HTMLElement): HTMLButtonElement {
+  return root.querySelector<HTMLButtonElement>('[data-mode="consolidado"]')!;
+}
+
+function getGranBtns(root: HTMLElement): HTMLButtonElement[] {
+  return Array.from(root.querySelectorAll<HTMLButtonElement>('[data-granularity]'));
+}
+
+function checkedValues(root: HTMLElement): string[] {
+  return Array.from(root.querySelectorAll<HTMLElement>('[role="radio"][aria-checked="true"]')).map(
+    (el) => el.getAttribute('data-mode') || el.getAttribute('data-granularity') || ''
+  );
+}
+
+describe('report mode selector factory (RFC-0223)', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  it('renders defaults: radiogroup with Consolidado | Diário | Horário, Consolidado active', () => {
+    const sel = createReportModeSelector(container, {});
+    expect(sel.element.className).toContain(P);
+    expect(sel.element.getAttribute('role')).toBe('radiogroup');
+    expect(sel.element.querySelector(`.${P}__label`)?.textContent).toBe('Modo do relatório');
+    expect(sel.element.querySelector(`.${P}__hint`)?.textContent).toBe(
+      'Como o consumo é detalhado no relatório.'
+    );
+
+    const gran = getGranBtns(sel.element);
+    expect(gran.map((b) => b.textContent)).toEqual(['Diário', 'Horário']);
+
+    expect(sel.getValue()).toBe('consolidado');
+    expect(checkedValues(sel.element)).toEqual(['consolidado']);
+  });
+
+  it('honors initial value from settings (1d / 1h)', () => {
+    const sel = createReportModeSelector(container, { settings: { value: '1h' } });
+    expect(sel.getValue()).toBe('1h');
+    expect(checkedValues(sel.element)).toEqual(['1h']);
+  });
+
+  it('exactly one segment is checked at all times across every transition', () => {
+    const sel = createReportModeSelector(container, {});
+    const consolidado = getConsolidadoBtn(sel.element);
+    const [diario, horario] = getGranBtns(sel.element);
+
+    diario.click();
+    expect(checkedValues(sel.element)).toEqual(['1d']);
+    horario.click();
+    expect(checkedValues(sel.element)).toEqual(['1h']);
+    consolidado.click();
+    expect(checkedValues(sel.element)).toEqual(['consolidado']);
+  });
+
+  it('click changes mode and fires onChange exactly once; re-clicking the active one is a no-op', () => {
+    const onChange = vi.fn();
+    const sel = createReportModeSelector(container, { onChange });
+    const [diario] = getGranBtns(sel.element);
+
+    diario.click();
+    expect(sel.getValue()).toBe('1d');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('1d');
+
+    diario.click();
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('detects Consolidado -> Diário even when the nested granularity-selector already privately holds value=1d', () => {
+    // Mounted starting at '1d' means the nested selector's OWN internal value is
+    // already '1d'. Switching to Consolidado only changes OUR wrapper's mode —
+    // the nested selector's internal value is untouched. Clicking "Diário" again
+    // must still fire a real mode change (consolidado -> 1d) even though the
+    // nested library would consider this a no-op by its own internal value.
+    const onChange = vi.fn();
+    const sel = createReportModeSelector(container, { settings: { value: '1d' }, onChange });
+    const consolidado = getConsolidadoBtn(sel.element);
+    const [diario] = getGranBtns(sel.element);
+
+    consolidado.click();
+    expect(sel.getValue()).toBe('consolidado');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('consolidado');
+
+    diario.click();
+    expect(sel.getValue()).toBe('1d');
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(onChange).toHaveBeenNthCalledWith(2, '1d');
+    expect(checkedValues(sel.element)).toEqual(['1d']);
+  });
+
+  it('setValue with silent updates UI without firing onChange; non-silent fires', () => {
+    const onChange = vi.fn();
+    const sel = createReportModeSelector(container, { onChange });
+
+    sel.setValue('1h', { silent: true });
+    expect(sel.getValue()).toBe('1h');
+    expect(checkedValues(sel.element)).toEqual(['1h']);
+    expect(onChange).not.toHaveBeenCalled();
+
+    sel.setValue('consolidado');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('consolidado');
+
+    sel.setValue('consolidado');
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('disabled blocks clicks (initial setting and setDisabled toggle)', () => {
+    const onChange = vi.fn();
+    const sel = createReportModeSelector(container, { settings: { disabled: true }, onChange });
+    const [diario] = getGranBtns(sel.element);
+    expect(sel.element.className).toContain(`${P}--disabled`);
+    expect(getConsolidadoBtn(sel.element).disabled).toBe(true);
+
+    diario.click();
+    expect(onChange).not.toHaveBeenCalled();
+    expect(sel.getValue()).toBe('consolidado');
+
+    sel.setDisabled(false);
+    diario.click();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(sel.getValue()).toBe('1d');
+
+    sel.setDisabled(true);
+    getConsolidadoBtn(sel.element).click();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(sel.getValue()).toBe('1d');
+  });
+
+  it('setThemeMode toggles the dark modifier and propagates to the nested selector', () => {
+    const sel = createReportModeSelector(container, {});
+    expect(sel.element.classList.contains(`${P}--dark`)).toBe(false);
+
+    sel.setThemeMode('dark');
+    expect(sel.element.classList.contains(`${P}--dark`)).toBe(true);
+
+    sel.setThemeMode('light');
+    expect(sel.element.classList.contains(`${P}--dark`)).toBe(false);
+  });
+
+  it('injects styles idempotently', () => {
+    createReportModeSelector(container, {});
+    createReportModeSelector(container, {});
+    const tags = document.querySelectorAll('#myio-report-mode-selector-styles');
+    expect(tags.length).toBe(1);
+  });
+
+  it('destroy removes the element (and the nested granularity-selector) and neutralizes further API calls', () => {
+    const onChange = vi.fn();
+    const sel = createReportModeSelector(container, { onChange });
+    const el = sel.element;
+    expect(container.contains(el)).toBe(true);
+
+    sel.destroy();
+    expect(container.contains(el)).toBe(false);
+    expect(container.querySelector(`.${P}`)).toBeNull();
+
+    expect(() => {
+      sel.setValue('1h');
+      sel.destroy();
+    }).not.toThrow();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('report mode selector — RFC-0223 delivery phases (horarioEnabled)', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  it('horarioEnabled: false (P1) renders only Consolidado + Diário — no dead Horário control', () => {
+    const sel = createReportModeSelector(container, { settings: { horarioEnabled: false } });
+    const gran = getGranBtns(sel.element);
+    expect(gran.map((b) => b.textContent)).toEqual(['Diário']);
+    expect(sel.element.querySelector('[data-granularity="1h"]')).toBeNull();
+  });
+
+  it('horarioEnabled: false ignores an initial value of 1h, falling back to Consolidado', () => {
+    const sel = createReportModeSelector(container, {
+      settings: { horarioEnabled: false, value: '1h' },
+    });
+    expect(sel.getValue()).toBe('consolidado');
+  });
+
+  it('horarioEnabled: false makes setValue("1h") a no-op (no back door once the control is hidden)', () => {
+    const onChange = vi.fn();
+    const sel = createReportModeSelector(container, { settings: { horarioEnabled: false }, onChange });
+    sel.setValue('1h');
+    expect(sel.getValue()).toBe('consolidado');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('defaults to horarioEnabled: true when the caller omits the flag (component stays generically 3-way capable)', () => {
+    const sel = createReportModeSelector(container, {});
+    const gran = getGranBtns(sel.element);
+    expect(gran.map((b) => b.textContent)).toEqual(['Diário', 'Horário']);
+  });
+});


### PR DESCRIPTION
## RFC-0223 (P1): AllReport — modo Diário com seções colapsáveis por dispositivo

Ticket: https://myio.atlassian.net/browse/ED-1013
RFC: docs/rfcs/RFC-0223-AllReport-PerDevice-Granularity-Sections.md

### O que mudou

Primeira fatia entregável do RFC-0223 (fase **P1 — MVP Diário**, conforme faseamento definido no roundtable BMAD). Adiciona ao Relatório Geral (`AllReportModal`) um seletor de modo **Consolidado | Diário** (Horário permanece oculto até a fase P3, sem controle "morto" na tela) e, no modo Diário, seções colapsáveis por dispositivo com uma linha por dia.

- **Seletor de modo** (`ReportModeSelector`): compõe o `granularity-selector` existente sem alterá-lo, adiciona o segmento Consolidado + região delimitada única (radiogroup), acessível por teclado/ARIA.
- **Seções por dispositivo (Diário)**: cabeçalho colapsável com nome/identificador, nº de dias e total na unidade correta (kWh/m³/média °C); atalho colapsar/expandir tudo (rótulo reflete a próxima ação).
- **Agregação por unidade**: soma para energia/água, média para temperatura — nunca soma-de-médias (`aggregate()` com fixture de cobertura desigual testado).
- **Bucketing de dia fixado em fuso** (América/São_Paulo), validado em dias de transição de DST (23/25 horas).
- **Falha de busca por dispositivo nunca é silenciosa**: estado "dados incompletos" visível, nunca contabilizado como zero no KPI/gráfico.
- **Consolidado permanece o default, byte-a-byte idêntico ao atual** — nenhuma busca por dispositivo ocorre nesse modo.

### Fora de escopo deste PR (fases seguintes do RFC)

- PDF/CSV seccionados por dia (**P2**)
- Modo Horário com drill-down dia→hora (**P3**)
- Filtro de Períodos (**P4**)
- Padronização das seções de grupo do RFC-0182 (**P5**)

### Testes

- `npx tsc --noEmit` limpo (sem novos erros)
- Suíte completa: 264 testes passando, incluindo novos arquivos para `aggregate`/`buildReportSectionModel` (fixture AC18 de cobertura desigual), bucketing de dia/hora com DST, `ensureDeviceSeries` (fetch mockado, cobertura ok/partial/failed, race de troca de modo em voo), `ReportModeSelector` (incluindo Horário oculto) e `CollapsibleSection`.
