### PR TITLE
feat(rfc-0207): fecha Phase B, mata o laço do labelWidget e costura engine × store

### DIFF
--- a/docs/rfcs/RFC-0207-CustomerScopedDeviceClassificationProfile.md
+++ b/docs/rfcs/RFC-0207-CustomerScopedDeviceClassificationProfile.md
@@ -2,11 +2,12 @@
 
 - **RFC**: 0207
 - **Title**: Customer-Scoped Device Classification Profile (SERVER_SCOPE JSON + MENU management modal)
-- **Status** *(revisado contra o código em 2026-07-23 — ver § Estado verificado)*:
+- **Status** *(revisado contra o código em 2026-07-23 — ver § Estado verificado e § Implementação 2026-07-23)*:
   - **v1 — Implemented.** A0/A1/A1b: resolver único (`resolveGroup`/`resolveCategory`), correções dos bugs #1/#2, golden-tested.
-  - **Phase B — PARTIAL.** O **load** do atributo customer `deviceClassificationProfile` (TB SERVER_SCOPE) em `MAIN_VIEW.onInit` está implementado, e o modal premium do MENU `openDeviceProfileModal` faz **view/edit/preview**. **A persistência NÃO está operacional**: o MENU delega a `window.MyIOOrchestrator.saveDeviceClassificationProfile`, que **não existe em nenhum lugar do repositório** — salvar pelo modal lança erro. Branch `feat/rfc-0207-b-attribute-and-menu` → PR to `desenv`.
-  - **v2 — DESIGN ONLY (2026-06-23).** Árvore configurável de grupos/subcategorias (criar grupos à vontade, aninhar subcategorias, labels por config, alocação única, UPPERCASE, catálogo de deviceProfile, nós computados). **Não implementado** — o motor ainda roda `schemaVersion: 1` com regras planas. See **§ Addendum — RFC-0207 v2**.
-  - **v3 / v3.2 — DESIGN ONLY, canonical-to-implement (2026-06-23).** Engine/tree seam + `ProfileSource` swappable + divisão de responsabilidades travada (lib × MAIN_VIEW × GCDR) + store GCDR via RFC-0047. Consolida a série de feedback (GCDR v1→v5 + MyIO-Lib v4) e **absorve o arquivo `RFC-0207-v3` e os docs de feedback/reconciliação (removidos)**. **Nenhum artefato v3 existe no código** (`ProfileSource`, `BakedProfileSource`, `TbAttributeProfileSource`, `GcdrResolveProfileSource`, `resolveClassification`, `resolveSubcategory`: zero ocorrências). See **§ Addendum — RFC-0207 v3 (FINAL, compiled)** — é o contrato final a implementar, não o estado atual.
+  - **Phase B — Implemented (store = TB SERVER_SCOPE).** Load **e** save operacionais, ambos no MAIN_VIEW e contra a mesma chave (`deviceClassificationProfile`, SERVER_SCOPE do customer). `window.MyIOOrchestrator.saveDeviceClassificationProfile` existe. Ver § Implementação 2026-07-23 → D-1.
+  - **v2 — PARCIALMENTE implementado (motor pronto, produção ainda no v1).** A árvore recursiva, o walker genérico group-generic, a migração v1→v2 e a validação de invariantes existem e são golden-tested (`src/utils/devices/classificationNodeTree.ts`). O caminho que o dashboard **executa** continua sendo o par `resolveGroup`/`resolveCategory` (`schemaVersion: 1`) — a troca é um passo separado, com sua própria fronteira de reversão, porque **não é equivalente** (ver D-4). O editor do modal ainda edita o modelo plano.
+  - **v3.1 — Implemented.** `ProfileSource` + `BakedProfileSource` versionado + cadeia de degradação testada por fault injection + `TbAttributeProfileSource`/`GcdrResolveProfileSource` no MAIN_VIEW + goldens key-parity e order-sensitivity.
+  - **v3.2 — DESIGN ONLY.** A mecânica HTTP do `GcdrResolveProfileSource` (304/versionamento/cache) está implementada atrás de flag **desligada**; o **adaptador `entities ↔ ClassificationNode`** e o save via `/entities/bulk-replace` **não estão** — dependem do trabalho de backend que o próprio §v3.2-G lista. Ver D-2.
 - **Author**: Rodrigo Lago
 - **Created**: 2026-06-18
 - **Target**: `src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/` (MAIN_VIEW, MENU, TELEMETRY, TELEMETRY_INFO) + `src/utils/`
@@ -122,11 +123,16 @@ existia. Foi escrito em `14ad6257` (2026-07-23), junto com a correção:
 - `BOMBA_INCENDIO` → `outros` — mesmo teste
 - `BOMBA_CAG` → `climatizacao` — `tests/deviceClassificationProfile.buildsummary.test.ts:244`
 
-Ainda ausentes, e **não testáveis hoje** porque dependem de artefatos v3 inexistentes:
+Os outros dois foram escritos junto com os artefatos v3 de que dependiam
+(§ Implementação 2026-07-23):
 
-- **key-parity** (`keys(engine) === keys(baked) === GCDR is_system keys`) — exige `BakedProfileSource`.
-- **order-sensitivity** (o fallback nunca sombreia um irmão real) — exige `order` explícito por nó,
-  ausente no `schemaVersion: 1`.
+- ✅ **key-parity** (`keys(engine) === keys(baked)`) — `tests/deviceClassificationProfile.keyParity.test.ts`,
+  reconciliado pelo arquivo commitado `src/utils/devices/bakedProfile.generated.ts`, **nunca por rede**.
+  A terceira perna (`=== GCDR is_system keys`) entra na v3.2, pelo mesmo mecanismo de arquivo.
+- ✅ **order-sensitivity** (o fallback nunca sombreia um irmão real) —
+  `tests/deviceClassificationProfile.treeWalker.test.ts`, sobre a árvore v2 com `order` inteiro
+  explícito por nó. Cobre também "a ordem do array não decide nada" e a rejeição, por
+  `validateTree`, de um fallback que não seja o maior `order` do nível.
 
 O mesmo commit trouxe os oráculos legados do `buildsummary.test.ts` de volta à realidade da fonte
 (o `deviceType` saiu do `combinedOf` em 2026-07-14 e o teste nunca acompanhou, ficando vermelho em
@@ -134,19 +140,107 @@ O mesmo commit trouxe os oráculos legados do `buildsummary.test.ts` de volta à
 
 ### Backlog
 
-1. **Fechar a Phase B de verdade:** implementar `window.MyIOOrchestrator.saveDeviceClassificationProfile`
-   em `MAIN_VIEW` (a §D o coloca lá como dono), **ou** rebaixar explicitamente o modal para
-   read/edit/preview sem save. Hoje o botão promete o que não entrega.
-2. **Escolher e documentar o store de transição:** manter TB `SERVER_SCOPE` até a v3.2, ou migrar
-   direto para GCDR. O RFC hoje mistura as duas leituras.
-3. **Resolver o contrato de regras:** enquanto `combinedContains` for avaliado pelo motor, ou o
-   editor o expõe/valida/testa, ou ele sai do motor e do seed numa migração coordenada com teste de
-   equivalência. Manter vivo e invisível é a pior das três opções. Tratar o laço circular do
-   `labelWidget` no mesmo lote.
-4. **Separar RFC implementado de RFC futuro:** congelar o RFC-0207 como v1 implementado/parcial e
-   abrir um RFC sucessor para v3/v3.2. **Esta é a correção de causa raiz** — enquanto um único
-   arquivo tentar ser registro de entrega e especificação de futuro ao mesmo tempo, o campo `Status`
-   vai voltar a divergir do código.
+1. ✅ **Fechar a Phase B de verdade** — feito. `saveDeviceClassificationProfile` implementado no
+   `MAIN_VIEW`. Ver § Implementação 2026-07-23 → **D-1**.
+2. ✅ **Escolher e documentar o store de transição** — **TB `SERVER_SCOPE` até a v3.2**, com load e
+   save simétricos. Ver **D-1**.
+3. ✅ **Resolver o contrato de regras** — `combinedContains` foi **exposto** (renomeado
+   `profileContains`, campo renderizado no modal), e o laço circular do `labelWidget` morreu no mesmo
+   lote com a eliminação do texto combinado. Migração device-a-device em
+   `tests/deviceClassificationProfile.profileContains.test.ts`. Ver **D-3**.
+4. ⬜ **Separar RFC implementado de RFC futuro** — **não feito** (decisão de governança do
+   mantenedor; PO-I em aberto). Segue sendo a correção de causa raiz: enquanto um único arquivo
+   tentar ser registro de entrega e especificação de futuro ao mesmo tempo, o campo `Status` vai
+   voltar a divergir do código. Ver **D-5**.
+
+---
+
+## Implementação 2026-07-23 — decisões travadas
+
+> Fechamento do backlog acima. Cada decisão registra o que foi escolhido, contra
+> o que, e onde está a evidência. O que **não** foi feito está em D-4 e D-5, dito
+> com todas as letras.
+
+### D-1 — Store da v3.1: **ThingsBoard SERVER_SCOPE**, load e save simétricos
+
+Fecha o **achado 1** (persistência inexistente) e o **achado 2** (store ambíguo).
+
+- `window.MyIOOrchestrator.saveDeviceClassificationProfile` **existe**, implementado
+  no MAIN_VIEW (§D o coloca lá como dono). O botão "Salvar perfil" persiste.
+- **Por que TB e não GCDR.** O §E deste RFC define, para a v3.1, `Store: TB attr +
+  baked`; só a v3.2 troca para o GCDR. O código já **lia** do SERVER_SCOPE. Escolher
+  o GCDR agora produziria exatamente o par assimétrico que o achado 2 condena — ou
+  pior: um save contra um contrato (`/entities/bulk-replace`, adaptador
+  `entities ↔ ClassificationNode`) que o §v3.2-G lista como **trabalho restante do
+  backend**. Quem lê e quem escreve usam a mesma chave, o mesmo escopo, a mesma
+  entidade.
+- Ordem do save: **validar → persistir → só então aplicar em memória**. Um save que
+  falha não pode deixar o dashboard classificando por um perfil que o store não tem
+  (o próximo F5 desfaria a classificação sem aviso).
+- O MENU continua **endpoint-agnóstico**: não conhece chave nem URL.
+
+### D-2 — `GcdrResolveProfileSource`: mecânica pronta, adaptador pendente
+
+Atrás da flag **desligada** `window.MyIOUtils.rfc0207UseGcdrStore`.
+
+- **Implementado:** `GET /api/v1/entities/resolve?customerId=&type=CLASSIFICATION_<DOMAIN>`,
+  `X-Version-Id` → `If-None-Match` → **304 sem corpo**, cache por
+  `(customerId, domain, version)` (§v3.2-F.3).
+- **Não implementado, e falha com erro rotulado:** o adaptador
+  `entities → ClassificationNode` (§v3.2-B) e o save via `/entities/bulk-replace`.
+  Chutar a topologia aqui produziria classificação errada **silenciosa** — o pior
+  modo de falha desta feature. A cadeia de degradação converte a falha em baked,
+  então ligar a flag nunca apaga o dashboard.
+
+### D-3 — Contrato de regra: `combinedContains` foi **exposto**, não removido; e o laço circular morreu junto
+
+Fecha o **achado 3** (as duas metades).
+
+- Das três opções ("expor / remover do motor / manter vivo e invisível"), escolhida
+  **expor**. Remover levaria `COMPRESSOR`/`VENTILADOR`/`CLIMATIZA` para `outros` sem
+  substituto; expor preserva o poder de expressão e o torna auditável pela UI.
+- A regra foi renomeada para **`profileContains`** e ganhou o campo
+  **"deviceProfile contém"** no `openDeviceProfileModal`. O handler órfão `cc` (sem
+  emissor) deixou de existir.
+- **O texto combinado foi eliminado.** `combinedOf` era
+  `labelWidget + deviceProfile + label`; agora o match é sobre `deviceProfile`
+  **apenas**. Dois defeitos morreram com ele:
+  1. o **laço circular** — `labelWidget` é a saída anterior do próprio classificador,
+     de modo que um item carimbado "Climatização" se auto-sustentava;
+  2. a **classificação por nome** — `label` é texto livre do cadastro.
+- `normalizeProfile` **migra** `combinedContains` → `profileContains` (com dedupe), e
+  `validateProfile` **tolera** a chave legada, porque `resolveActiveProfile` valida
+  **antes** de normalizar — perfis de customer já persistidos (ex.: Mestre Álvaro)
+  continuam válidos e não caem para o DEFAULT.
+- **Evidência da mudança de comportamento** (é behavior-changing de propósito):
+  `tests/deviceClassificationProfile.profileContains.test.ts` traz o oráculo com a
+  semântica antiga e enumera device-a-device os **5 moves** — todos "categoria
+  específica → outros", todos causados por `label` ou `labelWidget`, incluindo o
+  caso exato observado em runtime no Moxuara.
+
+### D-4 — v2: motor pronto, produção **não** trocada (e por quê)
+
+`src/utils/devices/classificationNodeTree.ts` traz a árvore recursiva, o walker
+group-generic, `liftProfileToTree` (migração v1→v2) e `validateTree`. O golden de
+equivalência dá **diff zero** nos três domínios.
+
+**O caminho de produção continua no v1** — deliberadamente. O modelo v2 **funde**
+colunas e breakdown numa árvore só, e essa fusão **não é** uma reexpressão neutra:
+um device cujo grupo é `entrada` mas cuja categoria v1 seria `climatizacao` (ex.:
+`RELOGIO` com identifier `CAG-1`) é reportado hoje como `climatizacao` no breakdown
+e passaria a ser `entrada` no walker. O golden de equivalência **define esse caso
+pela regra de merge** — ele prova que o walker é fiel ao modelo v2, não que trocar
+o motor seja invisível. Trocar exige a sua própria *migration snapshot*, revisada
+por humano, como manda o §"Por que A0's golden e A1's snapshot são testes
+diferentes". O editor do modal também segue editando o modelo plano.
+
+### D-5 — Bifurcação documental (D-k) **não** executada
+
+O §I.1 D-k manda congelar o RFC-0207 e abrir o RFC-0208 no primeiro commit de
+implementação do v3. **Não foi feito**: é decisão de governança do mantenedor
+(PO-I ainda em aberto) e cindir o documento no meio de uma entrega tornaria a
+revisão desta mesma entrega mais difícil, não menos. Segue como o item de causa
+raiz do backlog.
 
 ### Nota de método
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "build:umd": "rollup -c",
     "minify:umd": "terser dist/myio-js-library.umd.js -o dist/myio-js-library.umd.min.js --comments=false",
     "postbuild": "node scripts/verify-dts.js",
+    "gen:baked-profile": "node scripts/gen-baked-profile.mjs",
+    "prebuild": "node scripts/gen-baked-profile.mjs --check",
     "build": "npm run clean && npm run build:tsup && npm run build:umd && npm run minify:umd",
     "lint": "eslint .",
     "test": "vitest run",

--- a/scripts/gen-baked-profile.mjs
+++ b/scripts/gen-baked-profile.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * gen-baked-profile.mjs — RFC-0207 §B.1-3: artefato BAKED derivado do seed in-code.
+ *
+ * Gera `src/utils/devices/bakedProfile.generated.ts` a partir de
+ * `DEFAULT_DEVICE_CLASSIFICATION_PROFILE`. O arquivo gerado carrega:
+ *
+ *   - `BAKED_PROFILE_VERSION` — hash sha256 (12 hex) do seed canonicalizado.
+ *     Muda sempre que o seed muda → detecta "baked estanque".
+ *   - `BAKED_PROFILE_KEYS`    — manifesto CANÔNICO de chaves (domínio, grupo,
+ *     categoria). É a fonte do golden de key-parity (§F): `keys(engine) ===
+ *     keys(baked)`. A reconciliação com o GCDR `is_system` (v3.2) é por ARQUIVO
+ *     COMMITADO, nunca por rede — o build permanece hermético (§G).
+ *
+ * O que NÃO é gerado: uma segunda cópia da árvore. O §B.1-3 é explícito —
+ * "artefato derivado, nunca editado à mão → **nunca uma 5ª cópia**". O
+ * `BakedProfileSource` serve o próprio seed sob a version gerada, então o baked
+ * é versionado e custa ~0 KB de bundle além do seed que já existe.
+ *
+ * NUNCA edite o arquivo gerado à mão. Rode:
+ *   npm run gen:baked-profile
+ *
+ * CI: `npm run gen:baked-profile -- --check` falha se o commitado divergir do
+ * que o seed produz agora (é isso que impede o artefato de apodrecer).
+ */
+
+import { build } from 'esbuild';
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync, existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, resolve, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+const SEED_TS = resolve(REPO_ROOT, 'src/utils/devices/deviceClassificationProfile.ts');
+const OUT_TS = resolve(REPO_ROOT, 'src/utils/devices/bakedProfile.generated.ts');
+
+const checkOnly = process.argv.includes('--check');
+
+/** Chaves ordenadas e estáveis (JSON canônico) para o hash não oscilar. */
+function canonical(value) {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value && typeof value === 'object') {
+    const out = {};
+    for (const k of Object.keys(value).sort()) out[k] = canonical(value[k]);
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Manifesto de chaves do seed. É deliberadamente ESTRUTURAL (domínio → grupos /
+ * categorias) e não carrega valores de membership: o key-parity compara CHAVES,
+ * não listas de match (§v3.2-B: "key-parity cobre baked ↔ GCDR-system, nunca
+ * dado customer").
+ */
+function keyManifest(profile) {
+  const out = [];
+  for (const domain of Object.keys(profile.domains ?? {}).sort()) {
+    const dom = profile.domains[domain];
+    if (!dom) continue;
+    out.push(`${domain}`);
+    for (const r of dom.groups?.rules ?? []) out.push(`${domain}.groups.${r.name}`);
+    if (dom.groups?.ocultosProfilePatterns) out.push(`${domain}.groups.ocultos`);
+    if (dom.categories) {
+      out.push(`${domain}.categories.lojas`);
+      for (const r of dom.categories.rules ?? []) out.push(`${domain}.categories.${r.name}`);
+      if (dom.categories.fallback?.name) {
+        out.push(`${domain}.categories.${dom.categories.fallback.name}`);
+      }
+    }
+  }
+  return [...new Set(out)].sort();
+}
+
+async function loadSeed() {
+  const dir = mkdtempSync(join(tmpdir(), 'myio-baked-'));
+  const outfile = join(dir, 'seed.mjs');
+  try {
+    await build({
+      entryPoints: [SEED_TS],
+      outfile,
+      bundle: true,
+      format: 'esm',
+      platform: 'node',
+      target: 'node18',
+      logLevel: 'silent',
+    });
+    const mod = await import(pathToFileURL(outfile).href);
+    return mod.DEFAULT_DEVICE_CLASSIFICATION_PROFILE;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function render(version, keys) {
+  return `// AUTO-GERADO por scripts/gen-baked-profile.mjs — NÃO EDITE À MÃO.
+//
+// RFC-0207 §B.1-3 — artefato BAKED derivado do seed in-code
+// (\`DEFAULT_DEVICE_CLASSIFICATION_PROFILE\`).
+//
+// Regenerar:  npm run gen:baked-profile
+// Verificar:  npm run gen:baked-profile -- --check   (falha se divergir do seed)
+//
+// Por que não há uma cópia da árvore aqui: o §B.1-3 exige "artefato derivado,
+// nunca editado à mão → nunca uma 5ª cópia". O \`BakedProfileSource\` serve o
+// próprio seed sob a version abaixo; este arquivo carrega apenas a VERSION e o
+// MANIFESTO DE CHAVES (a fonte de verdade do golden de key-parity, §F).
+
+/** sha256(12) do seed canonicalizado. Muda sempre que o seed muda. */
+export const BAKED_PROFILE_VERSION = ${JSON.stringify(version)};
+
+/**
+ * Manifesto canônico de chaves do seed (domínio / grupo / categoria).
+ * O golden \`key-parity\` compara isto com as chaves que o MOTOR produz.
+ * A reconciliação com o GCDR \`is_system\` (v3.2) é por arquivo commitado,
+ * nunca por fetch em build-time — o build fica hermético.
+ */
+export const BAKED_PROFILE_KEYS: readonly string[] = Object.freeze([
+${keys.map((k) => `  ${JSON.stringify(k)},`).join('\n')}
+]);
+`;
+}
+
+const seed = await loadSeed();
+if (!seed) {
+  console.error('[gen-baked-profile] DEFAULT_DEVICE_CLASSIFICATION_PROFILE não encontrado no seed');
+  process.exit(1);
+}
+
+const version = createHash('sha256').update(JSON.stringify(canonical(seed))).digest('hex').slice(0, 12);
+const keys = keyManifest(seed);
+const next = render(version, keys);
+
+if (checkOnly) {
+  const current = existsSync(OUT_TS) ? readFileSync(OUT_TS, 'utf8') : '';
+  if (current.replace(/\r\n/g, '\n') !== next.replace(/\r\n/g, '\n')) {
+    console.error(
+      '[gen-baked-profile] ✗ bakedProfile.generated.ts está DESATUALIZADO em relação ao seed.\n' +
+        '                     Rode: npm run gen:baked-profile',
+    );
+    process.exit(1);
+  }
+  console.log(`[gen-baked-profile] ✓ baked em dia (version ${version}, ${keys.length} chaves)`);
+  process.exit(0);
+}
+
+writeFileSync(OUT_TS, next, 'utf8');
+console.log(`[gen-baked-profile] escrito ${OUT_TS} (version ${version}, ${keys.length} chaves)`);

--- a/src/components/premium-modals/device-profile/openDeviceProfileModal.ts
+++ b/src/components/premium-modals/device-profile/openDeviceProfileModal.ts
@@ -31,6 +31,7 @@ import {
   resolveGroup,
   resolveCategory,
   validateProfile,
+  normalizeProfile,
   setActiveProfile,
   type DeviceClassificationProfile,
   type DomainProfile,
@@ -107,9 +108,12 @@ export function openDeviceProfileModal(params: OpenDeviceProfileModalParams) {
   } = params;
   void customerId; // retained in the public params for call-site compat; not used for I/O
 
-  // Working copy (never mutate the live profile until save)
-  const working: DeviceClassificationProfile = deepClone(
-    params.profile || DEFAULT_DEVICE_CLASSIFICATION_PROFILE,
+  // Working copy (never mutate the live profile until save).
+  // `normalizeProfile` também aplica a migração de chaves RFC-0207
+  // (`combinedContains` → `profileContains`), de modo que um perfil salvo antes
+  // de 2026-07-23 abre no editor já no vocabulário renderizável.
+  const working: DeviceClassificationProfile = normalizeProfile(
+    deepClone(params.profile || DEFAULT_DEVICE_CLASSIFICATION_PROFILE),
   );
   working.domains = working.domains || ({} as DeviceClassificationProfile['domains']);
   // Seed any missing domain from DEFAULT so every tab is editable. A custom
@@ -340,11 +344,13 @@ export function openDeviceProfileModal(params: OpenDeviceProfileModalParams) {
             accent: accentFor(r.name),
             infoIcon: '🔧',
             infoHtml: cardInfoText(
-              `Breakdown <b>${escHtml(r.name)}</b> (precedência): 1) deviceProfile exato; 2) identifier contém/prefixo.`,
+              `Breakdown <b>${escHtml(r.name)}</b> (precedência): 1) <b>deviceProfile</b> exato; 2) <b>deviceProfile contém</b> (substring); 3) identifier contém/prefixo.<br><br>
+               Só o <b>deviceProfile</b> e o <b>identifier</b> são avaliados — nunca o nome/label do device.`,
             ),
           },
           `
             <div class="mdp-field"><label>deviceProfile</label>${chipList(`cat-${i}-dp`, r.deviceProfiles || [], ro)}</div>
+            <div class="mdp-field"><label>deviceProfile contém</label>${chipList(`cat-${i}-pc`, r.profileContains || [], ro)}</div>
             <div class="mdp-field"><label>identifier contém</label>${chipList(`cat-${i}-idc`, r.identifierFallback?.identifierContains || [], ro)}</div>
             <div class="mdp-field"><label>identifier prefixo</label>${chipList(`cat-${i}-idp`, r.identifierFallback?.identifierPrefixes || [], ro)}</div>`,
         ),
@@ -417,11 +423,15 @@ export function openDeviceProfileModal(params: OpenDeviceProfileModalParams) {
     // cat-* keys only ever render on the energy tab (only energy has categories)
     const cats = d.categories;
     if (!cats) return null;
-    m = key.match(/^cat-(\d+)-(dp|cc|idc|idp)$/);
+    m = key.match(/^cat-(\d+)-(dp|pc|idc|idp)$/);
     if (m) {
       const rule = cats.rules[Number(m[1])];
       if (m[2] === 'dp') return (rule.deviceProfiles = rule.deviceProfiles || []);
-      if (m[2] === 'cc') return (rule.combinedContains = rule.combinedContains || []);
+      // RFC-0207 (2026-07-23): `profileContains` (substring sobre deviceProfile)
+      // agora é RENDERIZADO (campo "deviceProfile contém"), fechando o achado 3 da
+      // auditoria — o motor avaliava um campo que nenhum editor alcançava. A chave
+      // legada `cc`/`combinedContains` deixou de existir (migrada em normalizeProfile).
+      if (m[2] === 'pc') return (rule.profileContains = rule.profileContains || []);
       rule.identifierFallback = rule.identifierFallback || {};
       if (m[2] === 'idc')
         return (rule.identifierFallback.identifierContains = rule.identifierFallback.identifierContains || []);

--- a/src/index.ts
+++ b/src/index.ts
@@ -216,6 +216,47 @@ export {
   listDomains,
   listGroups,
 } from './utils/devices/deviceClassificationProfile.js';
+// RFC-0207 v2/v3.1: árvore recursiva de nós + walker genérico (group-generic).
+// ADITIVO: `resolveGroup`/`resolveCategory` (v1) continuam sendo o caminho que o
+// dashboard executa; o walker é provado equivalente sobre a árvore levantada do
+// seed (tests/deviceClassificationProfile.treeWalker.test.ts) e é a base do tier-2.
+export {
+  resolveClassification,
+  resolveSubcategory,
+  liftProfileToTree,
+  validateTree,
+  findNode,
+  flattenTree,
+} from './utils/devices/classificationNodeTree';
+export type {
+  ClassificationNode,
+  NodeRules,
+  NodeFormula,
+  NodeRole,
+  NodeMatchedBy,
+  ClassificationResolution,
+} from './utils/devices/classificationNodeTree';
+
+// RFC-0207 v3.1: engine × store seam. A lib é dona da INTERFACE `ProfileSource`,
+// do `BakedProfileSource` (piso offline versionado) e da cadeia de degradação;
+// as fontes CONCRETAS de I/O (TB attribute / GCDR resolve) vivem no MAIN_VIEW —
+// **a lib nunca faz fetch e nunca escreve no ThingsBoard** (§B/§D).
+export {
+  createBakedProfileSource,
+  resolveWithFallback,
+  isBakedStale,
+} from './utils/devices/profileSource';
+export type {
+  ProfileSource,
+  ResolvedProfile,
+  ProfileSourceKind,
+  ResolveWithFallbackOptions,
+} from './utils/devices/profileSource';
+export {
+  BAKED_PROFILE_VERSION,
+  BAKED_PROFILE_KEYS,
+} from './utils/devices/bakedProfile.generated';
+
 // RFC-0047: adapter for the GCDR entities classification tree (domain/column/profile)
 export { parseClassificationEntities } from './utils/devices/classificationTree';
 export type {

--- a/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/MAIN_VIEW/controller.js
+++ b/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/MAIN_VIEW/controller.js
@@ -115,6 +115,19 @@ window.MyIOUtils = window.MyIOUtils || {};
     'resolveCategory',
     'getActiveProfile',
     'setActiveProfile',
+    // RFC-0207 v3.1 — motor genérico + costura engine × store (§H-3).
+    // Sem registrar aqui, os widgets filhos não enxergam o símbolo (§C2).
+    'resolveClassification',
+    'resolveSubcategory',
+    'validateProfile',
+    'normalizeProfile',
+    'liftProfileToTree',
+    'DEFAULT_DEVICE_CLASSIFICATION_PROFILE',
+    'createBakedProfileSource',
+    'resolveWithFallback',
+    'isBakedStale',
+    'BAKED_PROFILE_VERSION',
+    'BAKED_PROFILE_KEYS',
     // modals / popups
     'openDashboardPopupEnergy',
     'openDashboardPopupWaterTank',
@@ -1180,6 +1193,295 @@ function classifyDeviceByIdentifier(identifier = '') {
   return 'outros';
 }
 
+// ===========================================================================
+// RFC-0207 v3.1 — STORE do perfil de classificação (load + save).
+//
+// §D TRAVADO: o MAIN_VIEW é o ÚNICO dono da persistência. A lib é pura (nunca
+// faz fetch, nunca escreve no ThingsBoard) e o MENU é endpoint-agnóstico (só
+// chama `window.MyIOOrchestrator.saveDeviceClassificationProfile`). A URL e a
+// chave do atributo existem APENAS aqui.
+//
+// DECISÃO DE STORE (v3.1) — ThingsBoard SERVER_SCOPE, load e save simétricos.
+//   O §E do RFC define, para a v3.1, "Store: TB attr + baked"; só a v3.2 troca
+//   para o GCDR. A auditoria (achado 2) registrou que o código LIA do
+//   SERVER_SCOPE enquanto nada escrevia em lugar nenhum. Fechamos a assimetria
+//   pelo lado que já funcionava: quem lê e quem escreve são a MESMA chave, o
+//   MESMO escopo, a MESMA entidade. `GcdrResolveProfileSource` existe abaixo,
+//   atrás de flag DESLIGADA, para que a troca de store (v3.2) seja trocar a
+//   fonte primária — não reescrever o consumidor.
+// ===========================================================================
+
+/** Chave do atributo de customer (SERVER_SCOPE). Existe só aqui. */
+const RFC0207_PROFILE_ATTR_KEY = 'deviceClassificationProfile';
+
+/**
+ * Flag de rollout do store (§H-6: flag GLOBAL durante a v3.2). DESLIGADA:
+ * o adaptador `entities → ClassificationNode` do RFC-0047 ainda não existe
+ * (§v3.2-G lista o trabalho restante), então ligar isto hoje só exercitaria a
+ * cadeia de degradação. Setável em runtime para teste:
+ *   window.MyIOUtils.rfc0207UseGcdrStore = true
+ */
+function _rfc0207UseGcdrStore() {
+  return window.MyIOUtils?.rfc0207UseGcdrStore === true;
+}
+
+function _rfc0207Jwt() {
+  return localStorage.getItem('jwt_token') || '';
+}
+
+function _rfc0207TbBase() {
+  return self.ctx?.settings?.tbBaseUrl || '';
+}
+
+/**
+ * `ProfileSource` concreto — atributo de customer no ThingsBoard (SERVER_SCOPE).
+ *
+ * `prefetched`: o `onInit` já busca TODOS os atributos do customer numa chamada
+ * só (`fetchThingsboardCustomerAttrsFromStorage`). Passar o valor já lido evita
+ * um segundo round-trip no boot; sem ele, a fonte busca sozinha (usada pelo
+ * reload pós-save e por qualquer chamada avulsa).
+ */
+function createTbAttributeProfileSource(prefetched) {
+  return {
+    name: 'tb-attribute',
+    async resolve(customerId) {
+      const MyIO = window.MyIOLibrary;
+      let raw = prefetched;
+      if (raw === undefined) {
+        const url = `${_rfc0207TbBase()}/api/plugins/telemetry/CUSTOMER/${encodeURIComponent(
+          customerId
+        )}/values/attributes/SERVER_SCOPE?keys=${RFC0207_PROFILE_ATTR_KEY}`;
+        const res = await fetch(url, {
+          headers: { 'X-Authorization': `Bearer ${_rfc0207Jwt()}` },
+        });
+        if (!res.ok) throw new Error(`TB attribute HTTP ${res.status}`);
+        const rows = await res.json();
+        raw = Array.isArray(rows)
+          ? rows.find((r) => r.key === RFC0207_PROFILE_ATTR_KEY)?.value
+          : undefined;
+      }
+      // Atributo ausente NÃO é falha: é o caminho documentado do seed default
+      // (fail-open para o comportamento default, nunca para "sem classificação").
+      if (raw === undefined || raw === null || raw === '') {
+        return {
+          version: MyIO?.BAKED_PROFILE_VERSION || 'baked',
+          source: 'baked',
+          degraded: true,
+          reason: 'tb-attribute:absent',
+          profile: MyIO?.DEFAULT_DEVICE_CLASSIFICATION_PROFILE,
+        };
+      }
+      const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+      return {
+        // O TB não versiona atributos; `updatedAt` é o melhor etag disponível.
+        version: String(parsed?.updatedAt || 'tb-attr'),
+        source: 'customer',
+        degraded: false,
+        profile: parsed,
+      };
+    },
+    /** Escreve o mesmo atributo que `resolve` lê — load e save simétricos. */
+    async save(customerId, profile) {
+      const url = `${_rfc0207TbBase()}/api/plugins/telemetry/CUSTOMER/${encodeURIComponent(
+        customerId
+      )}/attributes/SERVER_SCOPE`;
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'X-Authorization': `Bearer ${_rfc0207Jwt()}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ [RFC0207_PROFILE_ATTR_KEY]: profile }),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(`HTTP ${res.status}${text ? ': ' + text.slice(0, 160) : ''}`);
+      }
+    },
+  };
+}
+
+/** Cache do 304 por `(customerId, domain, version)` — §v3.2-F.3. */
+const _rfc0207GcdrCache = new Map();
+
+/**
+ * `ProfileSource` concreto — GCDR / RFC-0047 (`GET /entities/resolve`), atrás da
+ * flag. A MECÂNICA especificada está implementada e é a que importa para a
+ * costura: `X-Version-Id` → `If-None-Match` → **304 sem corpo**, cache por
+ * `(customerId, domain, version)`.
+ *
+ * O que NÃO está implementado, e por isso lança um erro rotulado: o adaptador
+ * `entities → ClassificationNode` (§v3.2-B). Ele depende de contrato de backend
+ * que o próprio RFC lista como trabalho restante (§v3.2-G) — chutar a topologia
+ * aqui produziria classificação errada silenciosa. Enquanto isso, a cadeia de
+ * degradação (§B.1-4) converte a falha em `BakedProfileSource`, então ligar a
+ * flag nunca apaga o dashboard.
+ */
+function createGcdrResolveProfileSource(domain = 'energy') {
+  const entityType = `CLASSIFICATION_${String(domain).toUpperCase()}`;
+  return {
+    name: 'gcdr-resolve',
+    async resolve(customerId) {
+      const orch = window.MyIOOrchestrator || {};
+      const cacheKey = `${customerId}|${domain}`;
+      const cached = _rfc0207GcdrCache.get(cacheKey);
+      const url =
+        `${orch.gcdrApiBaseUrl}/api/v1/entities/resolve` +
+        `?customerId=${encodeURIComponent(customerId)}&type=${encodeURIComponent(entityType)}`;
+      const headers = {
+        'X-API-Key': orch.gcdrApiKey || '',
+        'X-Tenant-ID': orch.gcdrTenantId || '',
+        Accept: 'application/json',
+      };
+      if (cached?.version) headers['If-None-Match'] = cached.version;
+
+      const res = await fetch(url, { headers });
+      if (res.status === 304) {
+        if (!cached) throw new Error('gcdr 304 sem cache local');
+        return cached.resolved;
+      }
+      if (!res.ok) throw new Error(`GCDR entities/resolve HTTP ${res.status}`);
+      const json = await res.json();
+      const version = res.headers.get('X-Version-Id') || String(json?.data?.version || '');
+      const payload = json?.data ?? json;
+
+      // Caminho suportado: o registry devolve o documento de perfil diretamente.
+      const doc = payload?.deviceClassificationProfile || payload?.profile;
+      if (!doc) {
+        throw new Error(
+          'adaptador entities→ClassificationNode não implementado (RFC-0207 §v3.2-B/G)'
+        );
+      }
+      const resolved = {
+        version: version || 'gcdr',
+        source: payload?.source === 'system' ? 'system' : 'customer',
+        degraded: false,
+        profile: typeof doc === 'string' ? JSON.parse(doc) : doc,
+      };
+      _rfc0207GcdrCache.set(cacheKey, { version: resolved.version, resolved });
+      return resolved;
+    },
+  };
+}
+
+/** Fonte primária ativa, segundo a flag de store. */
+function rfc0207PrimaryProfileSource(prefetched) {
+  return _rfc0207UseGcdrStore()
+    ? createGcdrResolveProfileSource('energy')
+    : createTbAttributeProfileSource(prefetched);
+}
+
+/**
+ * Carrega o perfil ativo e aplica no motor. NUNCA lança: a cadeia de degradação
+ * da lib (§B.1-4) garante o piso `baked`.
+ *
+ * @param {string} customerId
+ * @param {*} prefetched valor já lido do atributo (ou `undefined` para buscar)
+ */
+async function rfc0207LoadActiveProfile(customerId, prefetched) {
+  const MyIO = window.MyIOLibrary;
+  if (!MyIO || typeof MyIO.resolveWithFallback !== 'function') {
+    // Bundle antigo sem a costura: preserva o caminho legado (setActiveProfile
+    // direto), para não regredir dashboards que ainda não recarregaram a lib.
+    if (typeof MyIO?.setActiveProfile === 'function') {
+      let parsed = null;
+      try {
+        parsed = typeof prefetched === 'string' ? JSON.parse(prefetched) : prefetched;
+      } catch (e) {
+        LogHelper.warn('[MAIN_VIEW] RFC-0207: atributo com JSON inválido → DEFAULT:', e);
+      }
+      const applied = MyIO.setActiveProfile(parsed || null, LogHelper);
+      window.MyIOUtils.deviceClassificationProfile = applied;
+      window.MyIOUtils.deviceClassificationProfileRaw = parsed || null;
+      return applied;
+    }
+    LogHelper.error(
+      '[MAIN_VIEW] RFC-0207: MyIOLibrary sem resolveWithFallback/setActiveProfile — perfil não aplicado'
+    );
+    return null;
+  }
+
+  const resolved = await MyIO.resolveWithFallback(rfc0207PrimaryProfileSource(prefetched), {
+    customerId,
+    logger: LogHelper,
+    timeoutMs: 8000,
+    onDegraded: (info) => {
+      // Espelha em estado observável (o piso NUNCA é apresentado como verdade).
+      window.MyIOUtils.deviceClassificationProfileDegraded = info;
+    },
+  });
+
+  if (!resolved.degraded) window.MyIOUtils.deviceClassificationProfileDegraded = null;
+  const applied = MyIO.setActiveProfile(resolved.profile, LogHelper);
+  window.MyIOUtils.deviceClassificationProfile = applied;
+  window.MyIOUtils.deviceClassificationProfileRaw = resolved.profile || null;
+  window.MyIOUtils.deviceClassificationProfileSource = {
+    source: resolved.source,
+    version: resolved.version,
+    degraded: resolved.degraded,
+    reason: resolved.reason || null,
+  };
+  LogHelper.log(
+    `[MAIN_VIEW] RFC-0207: perfil aplicado (source=${resolved.source} version=${resolved.version}` +
+      `${resolved.degraded ? ' DEGRADADO: ' + resolved.reason : ''})`
+  );
+  return applied;
+}
+
+/**
+ * RFC-0207 Phase B — PERSISTÊNCIA. Exposta como
+ * `window.MyIOOrchestrator.saveDeviceClassificationProfile` (é exatamente o
+ * método que o `MENU/controller.js` chamava e que não existia em lugar nenhum,
+ * fazendo o botão "Salvar perfil" lançar).
+ *
+ * Ordem deliberada: validar → persistir → só então aplicar em memória. Um save
+ * que falha NÃO pode deixar o dashboard classificando por um perfil que o store
+ * não tem (o próximo F5 desfaria a classificação sem aviso).
+ */
+async function rfc0207SaveActiveProfile(nextProfile) {
+  const MyIO = window.MyIOLibrary;
+  if (!MyIO || typeof MyIO.validateProfile !== 'function') {
+    throw new Error('MyIOLibrary indisponível — atualize o bundle da biblioteca MyIO.');
+  }
+  const customerId =
+    window.MyIOOrchestrator?.customerTB_ID ||
+    window.MyIOUtils?.customerTB_ID ||
+    self.ctx?.settings?.customerTB_ID ||
+    '';
+  if (!customerId) throw new Error('customerTB_ID indisponível — não é possível salvar o perfil.');
+
+  const errors = MyIO.validateProfile(nextProfile);
+  if (errors.length) {
+    throw new Error(`Perfil inválido: ${errors.slice(0, 3).join('; ')}`);
+  }
+
+  if (_rfc0207UseGcdrStore()) {
+    // §v3.2-A: save = PUT /entities/bulk-replace por (customer, domain), com
+    // If-Match por domínio → 409. Não implementado enquanto o adaptador
+    // entities↔ClassificationNode não existir — falhar ALTO é melhor que
+    // gravar num store cujo formato ainda não está fechado.
+    throw new Error(
+      'Store GCDR ligado, mas o save via /entities/bulk-replace ainda não está implementado (RFC-0207 §v3.2-G). Desligue window.MyIOUtils.rfc0207UseGcdrStore para salvar no SERVER_SCOPE.'
+    );
+  }
+
+  await createTbAttributeProfileSource().save(customerId, nextProfile);
+  LogHelper.log('[MAIN_VIEW] RFC-0207: perfil persistido no SERVER_SCOPE do customer', customerId);
+
+  // Aplica no motor só depois do store confirmar.
+  const applied = MyIO.setActiveProfile(nextProfile, LogHelper);
+  window.MyIOUtils.deviceClassificationProfile = applied;
+  window.MyIOUtils.deviceClassificationProfileRaw = nextProfile;
+  window.MyIOUtils.deviceClassificationProfileDegraded = null;
+  window.MyIOUtils.deviceClassificationProfileSource = {
+    source: 'customer',
+    version: String(nextProfile?.updatedAt || 'tb-attr'),
+    degraded: false,
+    reason: null,
+  };
+  return applied;
+}
+
 /**
  * RFC-0097/RFC-0106: Classify device using deviceType as primary method
  * @param {Object} item - Device item with deviceType, deviceProfile, identifier, and label
@@ -1841,6 +2143,15 @@ Object.assign(window.MyIOUtils, {
           },
         },
 
+        // RFC-0207 Phase B: persistência do perfil de classificação. Stub que
+        // falha ALTO — o MENU chama este método e, se ele não existir, o botão
+        // "Salvar perfil" quebra silenciosamente (foi o achado 1 da auditoria).
+        saveDeviceClassificationProfile: async () => {
+          throw new Error(
+            '[Orchestrator] saveDeviceClassificationProfile chamado antes do orquestrador estar pronto.'
+          );
+        },
+
         // RFC-0180: GCDR API method stubs (replaced by real impl after merge)
         gcdrFetchCustomerRules: async () => {
           LogHelper.warn('[Orchestrator] ⚠️ gcdrFetchCustomerRules called before orchestrator is ready');
@@ -2010,27 +2321,13 @@ Object.assign(window.MyIOUtils, {
               LogHelper.log('[MAIN_VIEW] exclude_groups_totals loaded:', _excludeGroupsTotals);
             }
 
-            // RFC-0207 Phase B: customer-scoped device classification profile.
-            // Loaded BEFORE the first classification pass; the no-arg resolvers
-            // (resolveGroup/resolveCategory) the orchestrator delegates to will
-            // pick this up via setActiveProfile. Absent/invalid → DEFAULT seed.
-            try {
-              const _rawProfile = attrs?.deviceClassificationProfile;
-              const _parsedProfile =
-                typeof _rawProfile === 'string' ? JSON.parse(_rawProfile) : _rawProfile;
-              if (typeof MyIO.setActiveProfile === 'function') {
-                const _applied = MyIO.setActiveProfile(_parsedProfile, LogHelper);
-                window.MyIOUtils.deviceClassificationProfile = _applied;
-                window.MyIOUtils.deviceClassificationProfileRaw = _parsedProfile || null;
-                LogHelper.log(
-                  '[MAIN_VIEW] RFC-0207: classification profile ' +
-                    (_rawProfile ? 'loaded from SERVER_SCOPE' : 'absent → DEFAULT seed')
-                );
-              }
-            } catch (e) {
-              LogHelper.warn('[MAIN_VIEW] RFC-0207: invalid deviceClassificationProfile → DEFAULT:', e);
-              if (typeof MyIO.setActiveProfile === 'function') MyIO.setActiveProfile(null, LogHelper);
-            }
+            // RFC-0207 Phase B / v3.1: customer-scoped device classification profile.
+            // Carregado ANTES da primeira passada de classificação, através do
+            // `ProfileSource` (store = TB SERVER_SCOPE na v3.1, ver o bloco
+            // "RFC-0207 v3.1 — STORE"). `attrs` já traz o atributo desta mesma
+            // chave, então passamos o valor lido e não há round-trip extra.
+            // A cadeia de degradação garante o piso `baked` — nunca lança.
+            await rfc0207LoadActiveProfile(customerTB_ID, attrs?.[RFC0207_PROFILE_ATTR_KEY]);
 
             LogHelper.log('[MAIN_VIEW] 🔑 Parsed credentials:');
             LogHelper.log('[MAIN_VIEW]   CLIENT_ID:', CLIENT_ID ? '✅ ' + CLIENT_ID : '❌ EMPTY');
@@ -7973,6 +8270,18 @@ const MyIOOrchestrator = (() => {
         })
       );
     },
+
+    // ── RFC-0207 Phase B: persistência do perfil de classificação ────────────
+    // O MENU é endpoint-agnóstico (§D) e delega aqui; a chave/URL do store vivem
+    // só no bloco "RFC-0207 v3.1 — STORE" deste arquivo.
+    saveDeviceClassificationProfile: (nextProfile) => rfc0207SaveActiveProfile(nextProfile),
+
+    /** Recarrega o perfil do store (usado após save externo / troca de customer). */
+    reloadDeviceClassificationProfile: (customerId) =>
+      rfc0207LoadActiveProfile(
+        customerId || window.MyIOOrchestrator?.customerTB_ID || '',
+        undefined
+      ),
 
     // ── RFC-0180: GCDR API methods ───────────────────────────────────────────
     // Owned by the orchestrator so widgets (AlarmsTab, etc.) don't carry

--- a/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/MENU/controller.js
+++ b/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/MENU/controller.js
@@ -817,14 +817,15 @@ self.onInit = function () {
       window.MyIOUtils?.deviceClassificationProfile ||
       (typeof Lib.getActiveProfile === 'function' ? Lib.getActiveProfile() : null);
 
-    // RFC-0207 v3: the MENU is endpoint-agnostic. Persistence is owned by MAIN_VIEW
-    // (which stores the profile JSON in the GCDR endpoint). The MENU/lib never write
-    // to ThingsBoard. If MAIN_VIEW hasn't wired the saver yet, fail loud (no TB write).
+    // RFC-0207 §D: o MENU é endpoint-agnóstico. A persistência pertence ao
+    // MAIN_VIEW — só ele conhece a chave e a URL do store (SERVER_SCOPE na v3.1,
+    // GCDR na v3.2). O MENU e a lib nunca escrevem no ThingsBoard. Se o saver não
+    // estiver conectado, falha alto em vez de fingir que salvou.
     const saveProfile = async (next) => {
       const saver = window.MyIOOrchestrator?.saveDeviceClassificationProfile;
       if (typeof saver !== 'function') {
         throw new Error(
-          'Persistência do perfil indisponível: MAIN_VIEW.saveDeviceClassificationProfile (GCDR) não conectado.',
+          'Persistência do perfil indisponível: MAIN_VIEW.saveDeviceClassificationProfile não conectado (atualize o widget MAIN_VIEW).',
         );
       }
       await saver(next);

--- a/src/utils/devices/bakedProfile.generated.ts
+++ b/src/utils/devices/bakedProfile.generated.ts
@@ -1,0 +1,44 @@
+// AUTO-GERADO por scripts/gen-baked-profile.mjs — NÃO EDITE À MÃO.
+//
+// RFC-0207 §B.1-3 — artefato BAKED derivado do seed in-code
+// (`DEFAULT_DEVICE_CLASSIFICATION_PROFILE`).
+//
+// Regenerar:  npm run gen:baked-profile
+// Verificar:  npm run gen:baked-profile -- --check   (falha se divergir do seed)
+//
+// Por que não há uma cópia da árvore aqui: o §B.1-3 exige "artefato derivado,
+// nunca editado à mão → nunca uma 5ª cópia". O `BakedProfileSource` serve o
+// próprio seed sob a version abaixo; este arquivo carrega apenas a VERSION e o
+// MANIFESTO DE CHAVES (a fonte de verdade do golden de key-parity, §F).
+
+/** sha256(12) do seed canonicalizado. Muda sempre que o seed muda. */
+export const BAKED_PROFILE_VERSION = "d861298603d0";
+
+/**
+ * Manifesto canônico de chaves do seed (domínio / grupo / categoria).
+ * O golden `key-parity` compara isto com as chaves que o MOTOR produz.
+ * A reconciliação com o GCDR `is_system` (v3.2) é por arquivo commitado,
+ * nunca por fetch em build-time — o build fica hermético.
+ */
+export const BAKED_PROFILE_KEYS: readonly string[] = Object.freeze([
+  "energy",
+  "energy.categories.climatizacao",
+  "energy.categories.elevadores",
+  "energy.categories.escadas_rolantes",
+  "energy.categories.lojas",
+  "energy.categories.outros",
+  "energy.groups.areacomum",
+  "energy.groups.entrada",
+  "energy.groups.lojas",
+  "energy.groups.ocultos",
+  "temperature",
+  "temperature.groups.climatizavel",
+  "temperature.groups.nao_climatizavel",
+  "temperature.groups.ocultos",
+  "water",
+  "water.groups.areacomum",
+  "water.groups.caixadagua",
+  "water.groups.entrada",
+  "water.groups.lojas",
+  "water.groups.ocultos",
+]);

--- a/src/utils/devices/classificationNodeTree.ts
+++ b/src/utils/devices/classificationNodeTree.ts
@@ -1,0 +1,506 @@
+// src/utils/devices/classificationNodeTree.ts
+//
+// RFC-0207 v2/v3.1 — árvore recursiva de nós + WALKER GENÉRICO.
+//
+// O v1 tem dois modelos planos e paralelos por domínio (`groups` = colunas,
+// `categories` = breakdown). O v2 troca isso por UMA árvore ordenada de nós, em
+// que subcategoria é simplesmente `children` — de modo que criar "Estacionamento"
+// ou "Bombas Hidráulicas" é INSERIR UM NÓ (dado), nunca escrever código
+// (§I.3: "membership viaja como DADO, avaliado por um motor genérico").
+//
+// O que é motor e o que é dado (§A):
+//   - MOTOR (aqui, golden-locked): como as regras avaliam — UPPERCASE, precedência
+//     exato→solto, `order` explícito, fallback por nível, curto-circuito de ocultos.
+//   - ÁRVORE (dado autorado): quais nós existem, labels, ícones, aninhamento,
+//     `order` e as listas de membership.
+//
+// `match()` NUNCA é dado (§A): as regras são LISTAS DE VALORES limitadas
+// (`deviceProfiles` / `profileContains` / `identifierExact|Contains|Prefixes`),
+// jamais predicados ou expressões.
+//
+// ESTADO: aditivo. `resolveGroup`/`resolveCategory` (v1) seguem sendo a API que o
+// dashboard executa; este walker é provado EQUIVALENTE a eles sobre a árvore
+// levantada do seed (tests/deviceClassificationProfile.treeWalker.test.ts). A
+// troca do caminho de produção para o walker é um passo separado, com sua própria
+// fronteira de reversão.
+
+import {
+  type ClassifiableItem,
+  type ClassificationDomain,
+  type DeviceClassificationProfile,
+  type DomainProfile,
+  type IdentifierMatch,
+  type ConditionalRule,
+  getActiveProfile,
+} from './deviceClassificationProfile';
+
+// ---------------------------------------------------------------------------
+// Node shape (RFC-0207 v2 §C)
+// ---------------------------------------------------------------------------
+
+/** Papéis de nó (§R9). `derived` cobre `residual` e `total` do v2. */
+export type NodeRole =
+  | 'entrada'
+  | 'consumer'
+  | 'fallback'
+  | 'residual'
+  | 'total'
+  | 'ocultos';
+
+/** Tipos de regra LIMITADOS (§A / §R3) — listas de valores, nunca predicados. */
+export interface NodeRules {
+  /** Igualdade exata (UPPERCASE) contra `item.deviceProfile`. */
+  deviceProfiles?: string[];
+  /** Substring sobre `item.deviceProfile`. */
+  profileContains?: string[];
+  /** `identifier === valor`. */
+  identifierExact?: string[];
+  /** `identifier.includes(valor)`. */
+  identifierContains?: string[];
+  /** `identifier.startsWith(valor)`. */
+  identifierPrefixes?: string[];
+  /**
+   * Regra condicional: quando o `deviceProfile` está nesta lista, exige TAMBÉM
+   * um hit de identifier (o caso BOMBA/MOTOR + CAG).
+   */
+  conditional?: ConditionalRule;
+}
+
+export interface NodeFormula {
+  op: 'subtract' | 'sum';
+  /** `subtract`: nó base (ex.: 'entrada'). */
+  from?: string;
+  /** `subtract`: nós a subtrair. */
+  subtract?: string[];
+  /** `sum`: nós a somar. */
+  of?: string[];
+}
+
+export interface ClassificationNode {
+  /** Id estável, único na árvore do domínio. É a costura com o GCDR (`entity_key`). */
+  key: string;
+  /** Rótulo de exibição (dado — nunca hard-coded no controller). */
+  label: string;
+  description?: string;
+  icon?: string;
+  role?: NodeRole;
+  /**
+   * §B.1-1 — inteiro EXPLÍCITO. Irmãos são avaliados por `order` ascendente.
+   * Nunca dependa da ordem do array/linhas/chaves JSON: serializadores e o
+   * Postgres não garantem estabilidade.
+   */
+  order: number;
+  rules?: NodeRules;
+  children?: ClassificationNode[];
+  /** Presente só em nós computados (`residual`/`total`). */
+  formula?: NodeFormula;
+}
+
+export type NodeMatchedBy =
+  | 'ocultos'
+  | 'deviceProfile'
+  | 'profileContains'
+  | 'conditional'
+  | 'identifier'
+  | 'fallback';
+
+export interface ClassificationResolution {
+  /** Chave da folha em que o device foi alocado. */
+  key: string;
+  /** Caminho da raiz até a folha (`['climatizacao','bombas_hidraulicas']`). */
+  nodePath: string[];
+  matchedBy: NodeMatchedBy;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers de match (mesma semântica do motor v1 — UPPERCASE, trim no identifier)
+// ---------------------------------------------------------------------------
+
+const up = (v: unknown): string => String(v ?? '').toUpperCase();
+const profileOf = (i: ClassifiableItem | null | undefined): string => up(i?.deviceProfile ?? '');
+const identifierOf = (i: ClassifiableItem | null | undefined): string =>
+  up(i?.identifier ?? '').trim();
+
+function matchesIdentifier(id: string, m: IdentifierMatch | NodeRules | undefined): boolean {
+  if (!m) return false;
+  for (const v of (m as IdentifierMatch).identifierEquals ?? []) if (id === up(v)) return true;
+  for (const v of (m as NodeRules).identifierExact ?? []) if (id === up(v)) return true;
+  for (const v of m.identifierContains ?? []) if (id.includes(up(v))) return true;
+  for (const p of m.identifierPrefixes ?? []) if (id.startsWith(up(p))) return true;
+  return false;
+}
+
+/** FASE 1 — `deviceProfile` exato. Autoritativo: vence qualquer sinal solto. */
+function matchExact(dp: string, rules: NodeRules | undefined): boolean {
+  if (!rules || !dp) return false;
+  for (const c of rules.deviceProfiles ?? []) if (dp === up(c)) return true;
+  return false;
+}
+
+/** FASE 2 — sinais soltos, na ordem: profileContains → conditional → identifier. */
+function matchLoose(
+  dp: string,
+  id: string,
+  rules: NodeRules | undefined,
+): NodeMatchedBy | null {
+  if (!rules) return null;
+  if (dp) {
+    for (const p of rules.profileContains ?? []) if (dp.includes(up(p))) return 'profileContains';
+  }
+  const cond = rules.conditional;
+  if (cond && (cond.deviceProfiles ?? []).some((t) => dp === up(t))) {
+    if (matchesIdentifier(id, cond)) return 'conditional';
+  }
+  if (matchesIdentifier(id, rules)) return 'identifier';
+  return null;
+}
+
+function byOrder(a: ClassificationNode, b: ClassificationNode): number {
+  const d = (a.order ?? 0) - (b.order ?? 0);
+  // §v3.2-F.7 — desempate estável por `key` quando o `order` empata/falta.
+  return d !== 0 ? d : String(a.key).localeCompare(String(b.key));
+}
+
+/** Nós que participam da classificação (computados não classificam nada). */
+function classifiable(nodes: ClassificationNode[]): ClassificationNode[] {
+  return nodes.filter((n) => n.role !== 'residual' && n.role !== 'total');
+}
+
+// ---------------------------------------------------------------------------
+// Walker genérico
+// ---------------------------------------------------------------------------
+
+/**
+ * Aloca um device na árvore. Group-generic (§C-4): climatização e "Outros" são
+ * apenas dois nós com filhos — nenhum caso especial.
+ *
+ * Semântica, por nível:
+ *   0. **Ocultos** — qualquer nó `role:'ocultos'` casa primeiro e curto-circuita.
+ *   1. **Fase exata** — irmãos por `order` asc; o primeiro com `deviceProfiles`
+ *      exato vence. Isso é o que impede um sinal solto de um irmão anterior de
+ *      roubar um device cujo `deviceProfile` casa exatamente em outro nó
+ *      (ELEVADOR com identifier "CAG" continua elevador).
+ *   2. **Fase solta** — irmãos por `order` asc: profileContains → conditional →
+ *      identifier.
+ *   3. **Fallback do nível** — o nó `role:'fallback'`, que por invariante é o de
+ *      maior `order` no nível (§B.1-1) e portanto nunca sombreia um irmão real.
+ *   4. **Descida** — casou um nó com `children`? repete tudo entre os filhos;
+ *      o device conta UMA vez, na folha mais profunda (§I.1 D-b).
+ */
+export function resolveClassification(
+  item: ClassifiableItem | null | undefined,
+  tree: ClassificationNode[],
+): ClassificationResolution | null {
+  if (!Array.isArray(tree) || tree.length === 0) return null;
+  const dp = profileOf(item);
+  const id = identifierOf(item);
+
+  // 0 — ocultos curto-circuita a árvore inteira (em qualquer profundidade do topo)
+  for (const n of [...tree].sort(byOrder)) {
+    if (n.role !== 'ocultos') continue;
+    if (matchExact(dp, n.rules) || matchLoose(dp, id, n.rules)) {
+      return { key: n.key, nodePath: [n.key], matchedBy: 'ocultos' };
+    }
+  }
+
+  const path: string[] = [];
+  let level = classifiable(tree).filter((n) => n.role !== 'ocultos');
+  let matchedBy: NodeMatchedBy = 'fallback';
+  let current: ClassificationNode | null = null;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const siblings = [...level].sort(byOrder);
+    let hit: ClassificationNode | null = null;
+    let hitBy: NodeMatchedBy | null = null;
+
+    // 1 — fase exata
+    for (const n of siblings) {
+      if (matchExact(dp, n.rules)) {
+        hit = n;
+        hitBy = 'deviceProfile';
+        break;
+      }
+    }
+    // 2 — fase solta
+    if (!hit) {
+      for (const n of siblings) {
+        const by = matchLoose(dp, id, n.rules);
+        if (by) {
+          hit = n;
+          hitBy = by;
+          break;
+        }
+      }
+    }
+    // 3 — fallback do nível
+    if (!hit) {
+      const fb = siblings.find((n) => n.role === 'fallback');
+      if (fb) {
+        hit = fb;
+        hitBy = 'fallback';
+      }
+    }
+
+    if (!hit) break;
+    current = hit;
+    matchedBy = hitBy ?? 'fallback';
+    path.push(hit.key);
+
+    const kids = classifiable(hit.children ?? []).filter((n) => n.role !== 'ocultos');
+    if (kids.length === 0) break;
+    level = kids;
+  }
+
+  if (!current) return null;
+  return { key: current.key, nodePath: path, matchedBy };
+}
+
+/**
+ * Tier-2 GROUP-GENERIC (§C-4): dado o grupo em que o device caiu, qual
+ * subcategoria? Retorna `null` quando o grupo não tem filhos (não é um erro —
+ * significa que aquele grupo não é subdividido).
+ */
+export function resolveSubcategory(
+  item: ClassifiableItem | null | undefined,
+  groupKey: string,
+  tree: ClassificationNode[],
+): ClassificationResolution | null {
+  const group = findNode(tree, groupKey);
+  if (!group) return null;
+  const kids = classifiable(group.children ?? []);
+  if (kids.length === 0) return null;
+  const r = resolveClassification(item, kids);
+  return r ? { ...r, nodePath: [groupKey, ...r.nodePath] } : null;
+}
+
+/** Busca um nó por `key` em qualquer profundidade. */
+export function findNode(
+  tree: ClassificationNode[],
+  key: string,
+): ClassificationNode | null {
+  for (const n of tree ?? []) {
+    if (n.key === key) return n;
+    const deep = findNode(n.children ?? [], key);
+    if (deep) return deep;
+  }
+  return null;
+}
+
+/** Achata a árvore (pré-ordem, por `order`). */
+export function flattenTree(tree: ClassificationNode[]): ClassificationNode[] {
+  const out: ClassificationNode[] = [];
+  for (const n of [...(tree ?? [])].sort(byOrder)) {
+    out.push(n);
+    out.push(...flattenTree(n.children ?? []));
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Validação de árvore (§E + §B.1-1)
+// ---------------------------------------------------------------------------
+
+/**
+ * Invariantes que, se violadas, falham em silêncio na produção:
+ *   - `key`/`label` vazios ou `key` duplicada no domínio;
+ *   - mais de um `fallback` entre IRMÃOS;
+ *   - **o `fallback` não é o de maior `order` do nível** — o caso em que o
+ *     catch-all sombreia uma regra real (é a razão de existir o golden de
+ *     order-sensitivity, §F);
+ *   - `order` ausente ou não-inteiro (§B.1-1 exige explícito);
+ *   - alocação não-única: o mesmo `deviceProfile` em mais de um nó (§R5);
+ *   - `formula` apontando para uma `key` inexistente.
+ */
+export function validateTree(tree: ClassificationNode[]): string[] {
+  const errors: string[] = [];
+  const seenKeys = new Map<string, number>();
+  const seenProfiles = new Map<string, string>();
+
+  const walkLevel = (nodes: ClassificationNode[], parentPath: string): void => {
+    const fallbacks = nodes.filter((n) => n.role === 'fallback');
+    if (fallbacks.length > 1) {
+      errors.push(
+        `${parentPath}: ${fallbacks.length} nós role:'fallback' entre irmãos (esperado no máximo 1)`,
+      );
+    }
+    if (fallbacks.length === 1) {
+      const fb = fallbacks[0];
+      // "Irmão real" = nó que CLASSIFICA. `ocultos` curto-circuita antes de tudo
+      // e `residual`/`total` são computados (não recebem device), portanto nenhum
+      // dos três pode ser sombreado pelo catch-all.
+      const maxOther = nodes
+        .filter((n) => n !== fb && n.role !== 'ocultos' && n.role !== 'residual' && n.role !== 'total')
+        .reduce((m, n) => Math.max(m, n.order ?? 0), Number.NEGATIVE_INFINITY);
+      if (maxOther !== Number.NEGATIVE_INFINITY && (fb.order ?? 0) <= maxOther) {
+        errors.push(
+          `${parentPath}: fallback "${fb.key}" tem order ${fb.order} <= ${maxOther} de um irmão real — o catch-all sombrearia a regra`,
+        );
+      }
+    }
+    for (const n of nodes) {
+      const path = `${parentPath}/${n.key || '<sem key>'}`;
+      if (!n.key) errors.push(`${path}: key vazia`);
+      if (!n.label) errors.push(`${path}: label vazio`);
+      if (!Number.isInteger(n.order)) {
+        errors.push(`${path}: order ausente ou não-inteiro (RFC-0207 §B.1-1 exige explícito)`);
+      }
+      seenKeys.set(n.key, (seenKeys.get(n.key) ?? 0) + 1);
+      for (const dp of n.rules?.deviceProfiles ?? []) {
+        const k = up(dp);
+        const owner = seenProfiles.get(k);
+        if (owner && owner !== n.key) {
+          errors.push(`alocação não-única: deviceProfile "${k}" em "${owner}" e "${n.key}"`);
+        } else {
+          seenProfiles.set(k, n.key);
+        }
+      }
+      if (n.children?.length) walkLevel(n.children, path);
+    }
+  };
+  walkLevel(tree ?? [], '');
+
+  for (const [key, count] of seenKeys) {
+    if (count > 1) errors.push(`key duplicada na árvore: "${key}" (${count}x)`);
+  }
+  for (const n of flattenTree(tree ?? [])) {
+    const refs = [...(n.formula?.of ?? []), ...(n.formula?.subtract ?? [])];
+    if (n.formula?.from) refs.push(n.formula.from);
+    for (const ref of refs) {
+      if (!seenKeys.has(ref)) errors.push(`formula de "${n.key}" referencia key inexistente "${ref}"`);
+    }
+  }
+  return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Migração v1 → v2 (§J)
+// ---------------------------------------------------------------------------
+
+const LABELS: Record<string, string> = {
+  ocultos: 'Ocultos',
+  entrada: 'Entrada',
+  lojas: 'Lojas',
+  areacomum: 'Área Comum',
+  caixadagua: "Caixa d'Água",
+  banheiros: 'Banheiros',
+  climatizavel: 'Climatizável',
+  nao_climatizavel: 'Não Climatizável',
+  climatizacao: 'Climatização',
+  elevadores: 'Elevadores',
+  escadas_rolantes: 'Escadas Rolantes',
+  outros: 'Outros Equipamentos',
+};
+
+function labelFor(key: string): string {
+  return LABELS[key] ?? key.charAt(0).toUpperCase() + key.slice(1).replace(/_/g, ' ');
+}
+
+/**
+ * Levanta um domínio do documento v1 (`groups` + `categories`) para a árvore v2,
+ * com `order` inteiro EXPLÍCITO e o fallback sempre no maior `order` do nível.
+ *
+ * Modelo do merge (§C do v2): as colunas e o breakdown viram UMA lista de nós de
+ * topo. `lojas` e `entrada` são nós de coluna; as categorias do breakdown
+ * (climatização/elevadores/escadas) viram nós irmãos; `outros` é o `fallback`;
+ * `areacomum` deixa de ser um balde de devices e vira o nó COMPUTADO
+ * "Pontos Não-Mapeados" (`residual`), exatamente como o v2 §H descreve.
+ *
+ * Quando o domínio não tem `categories` (água/temperatura), a árvore é só as
+ * colunas — o walker não precisa saber a diferença.
+ */
+export function liftProfileToTree(
+  profile: DeviceClassificationProfile = getActiveProfile(),
+  domain: ClassificationDomain = 'energy',
+): ClassificationNode[] {
+  const dom: DomainProfile | undefined = profile?.domains?.[domain];
+  if (!dom) return [];
+  const tree: ClassificationNode[] = [];
+  let order = 0;
+
+  // ocultos — curto-circuito
+  tree.push({
+    key: 'ocultos',
+    label: labelFor('ocultos'),
+    role: 'ocultos',
+    order: order++,
+    rules: { profileContains: [...(dom.groups?.ocultosProfilePatterns ?? [])] },
+  });
+
+  const groupRules = (dom.groups?.rules ?? []).filter((r) => !r.fallback);
+  const groupFallback = (dom.groups?.rules ?? []).find((r) => r.fallback);
+  const cats = dom.categories;
+
+  for (const r of groupRules) {
+    tree.push({
+      key: r.name,
+      label: labelFor(r.name),
+      role: r.name === 'entrada' ? 'entrada' : 'consumer',
+      order: order++,
+      rules: { deviceProfiles: [...(r.deviceProfiles ?? [])] },
+    });
+  }
+
+  if (cats) {
+    // atalho de loja: o nó `lojas` (coluna) também carrega o storeDeviceProfile
+    const lojas = tree.find((n) => n.key === 'lojas');
+    if (lojas && cats.storeDeviceProfile) {
+      lojas.rules = lojas.rules ?? {};
+      const list = lojas.rules.deviceProfiles ?? [];
+      if (!list.some((v) => up(v) === up(cats.storeDeviceProfile))) list.push(cats.storeDeviceProfile);
+      lojas.rules.deviceProfiles = list;
+    }
+    for (const r of cats.rules) {
+      tree.push({
+        key: r.name,
+        label: labelFor(r.name),
+        role: 'consumer',
+        order: order++,
+        rules: {
+          deviceProfiles: [...(r.deviceProfiles ?? [])],
+          profileContains: r.profileContains ? [...r.profileContains] : undefined,
+          identifierExact: r.identifierFallback?.identifierEquals
+            ? [...r.identifierFallback.identifierEquals]
+            : undefined,
+          identifierContains: r.identifierFallback?.identifierContains
+            ? [...r.identifierFallback.identifierContains]
+            : undefined,
+          identifierPrefixes: r.identifierFallback?.identifierPrefixes
+            ? [...r.identifierFallback.identifierPrefixes]
+            : undefined,
+          conditional: r.conditional ? { ...r.conditional } : undefined,
+        },
+      });
+    }
+    // fallback do nível — SEMPRE o maior order (§B.1-1)
+    tree.push({
+      key: cats.fallback?.name ?? 'outros',
+      label: labelFor(cats.fallback?.name ?? 'outros'),
+      role: 'fallback',
+      order: order++,
+    });
+    // residual computado ("Pontos Não-Mapeados" / Área Comum) — §H-1
+    if (groupFallback) {
+      const consumers = tree
+        .filter((n) => n.role === 'consumer' || n.role === 'fallback')
+        .map((n) => n.key);
+      tree.push({
+        key: groupFallback.name,
+        label: labelFor(groupFallback.name),
+        role: 'residual',
+        order: order++,
+        formula: { op: 'subtract', from: 'entrada', subtract: consumers },
+      });
+    }
+  } else if (groupFallback) {
+    // domínios sem breakdown: o residual das colunas é o fallback de devices
+    tree.push({
+      key: groupFallback.name,
+      label: labelFor(groupFallback.name),
+      role: 'fallback',
+      order: order++,
+    });
+  }
+
+  return tree;
+}

--- a/src/utils/devices/deviceClassificationProfile.ts
+++ b/src/utils/devices/deviceClassificationProfile.ts
@@ -21,10 +21,17 @@
 export interface ClassifiableItem {
   deviceProfile?: string | null;
   identifier?: string | null;
-  /** Free-text fields used by the breakdown's combined-substring matching (RFC-0207 A1b). */
+  /**
+   * @deprecated NÃO é lido pelo classificador (RFC-0207, 2026-07-23).
+   * `labelWidget` é a SAÍDA ANTERIOR do próprio classificador (inferLabelWidget);
+   * lê-lo criava um laço circular auto-sustentado (um item carimbado
+   * "Climatização" voltava a casar com o padrão `CLIMATIZA` independentemente do
+   * `deviceProfile`). Mantido no tipo só porque os itens do dashboard o carregam.
+   */
   labelWidget?: string | null;
   /** @deprecated EM DESUSO (2026-07-14) — nunca é lido; classificação usa só deviceProfile/identifier. */
   deviceType?: string | null;
+  /** @deprecated NÃO é lido pelo classificador — classificar por nome/label é proibido (RFC-0207 §J). */
   label?: string | null;
   [key: string]: unknown;
 }
@@ -60,6 +67,14 @@ export type CategoryName =
   | 'outros';
 export type CategoryMatchedBy =
   | 'deviceProfile'
+  /** Substring hit on `deviceProfile` (rule `profileContains`). */
+  | 'profileContains'
+  /**
+   * @deprecated RFC-0207 (2026-07-23) — nunca mais emitido. Era o hit sobre o
+   * texto combinado (labelWidget + deviceProfile + label); o texto combinado foi
+   * eliminado (laço circular do `labelWidget` + proibição de casar por nome).
+   * Mantido na união só para não quebrar narrowing de consumidores antigos.
+   */
   | 'combined'
   | 'identifier'
   | 'conditional'
@@ -97,13 +112,24 @@ export interface ConditionalRule extends IdentifierMatch {
 /** A single (non-fallback) category rule. */
 export interface CategoryRule {
   name: Exclude<CategoryName, 'lojas'>; // lojas is handled by the store shortcut
-  /** Exact deviceProfile matches (the legacy "deviceTypes" Set). */
+  /** Exact deviceProfile matches (a legacy "deviceTypes" Set). */
   deviceProfiles: string[];
   /**
-   * Substring patterns over the COMBINED text (labelWidget + deviceProfile +
-   * label — deviceType em desuso, removido 2026-07-14), mirroring
-   * buildSummary's loose matching (A1b). This is what unifies the breakdown
-   * subcategorization into one source.
+   * Substring patterns over `deviceProfile` (ex.: `CHILLER` casa
+   * `CHILLER_SECUNDARIO`). Value list limitada — nunca um predicado.
+   *
+   * RFC-0207 (2026-07-23): substitui `combinedContains`, que casava sobre o
+   * texto COMBINADO `labelWidget + deviceProfile + label`. Duas coisas estavam
+   * erradas ali: (a) `labelWidget` é a saída anterior do próprio classificador →
+   * laço circular; (b) `label` é nome livre, e classificar por nome é proibido.
+   * `normalizeProfile` migra `combinedContains` → `profileContains` (perfis já
+   * salvos continuam válidos).
+   */
+  profileContains?: string[];
+  /**
+   * @deprecated RFC-0207 (2026-07-23) — renomeado para `profileContains` e o
+   * texto combinado deixou de existir. Perfis persistidos com esta chave são
+   * migrados por `normalizeProfile`; o motor NÃO lê este campo.
    */
   combinedContains?: string[];
   /** climatizacao-only conditional ({BOMBA,MOTOR} + identifier hit). */
@@ -194,7 +220,7 @@ export const DEFAULT_DEVICE_CLASSIFICATION_PROFILE: DeviceClassificationProfile 
             name: 'elevadores',
             // ELEVADORES_DEVICE_TYPES_SET + buildSummary ELEVADOR_PATTERNS
             deviceProfiles: ['ELEVADOR'],
-            combinedContains: ['ELEVADOR'],
+            profileContains: ['ELEVADOR'],
             identifierFallback: {
               // ELEVADORES_IDENTIFIERS_SET + buildSummary id prefix ELV-
               identifierEquals: ['ELV', 'ELEVADOR', 'ELEVADORES'],
@@ -205,7 +231,7 @@ export const DEFAULT_DEVICE_CLASSIFICATION_PROFILE: DeviceClassificationProfile 
             name: 'escadas_rolantes',
             // ESCADAS_DEVICE_TYPES_SET + buildSummary ESCADA_PATTERNS
             deviceProfiles: ['ESCADA_ROLANTE'],
-            combinedContains: ['ESCADA', 'ROLANTE'],
+            profileContains: ['ESCADA', 'ROLANTE'],
             identifierFallback: {
               // ESCADAS_IDENTIFIERS_SET + buildSummary id prefix ESC-
               identifierEquals: ['ESC', 'ESCADA', 'ESCADASROLANTES'],
@@ -223,7 +249,7 @@ export const DEFAULT_DEVICE_CLASSIFICATION_PROFILE: DeviceClassificationProfile 
             // via `conditional`/`identifierFallback` (CAG), sem depender destas
             // strings. Alinhado a equipmentCategory.js (hvacProfiles NÃO inclui bomba
             // hidráulica) e a openUpsellModal (BOMBA_HIDRAULICA = energy_common_area).
-            combinedContains: [
+            profileContains: [
               'CHILLER',
               'FANCOIL',
               'HVAC',
@@ -328,13 +354,22 @@ function identifierOf(item: ClassifiableItem | null | undefined): string {
 }
 
 /**
- * combined: `${labelWidget} ${deviceProfile} ${label}` (upper-cased).
- * deviceType está EM DESUSO e foi removido do texto combinado (2026-07-14).
- * Identifier is intentionally NOT included (buildSummary keeps it separate).
+ * RFC-0207 (2026-07-23) — o texto COMBINADO foi eliminado.
+ *
+ * Antes: `combinedOf(item) = labelWidget + deviceProfile + label`, avaliado
+ * contra `rule.combinedContains`. Dois defeitos estruturais:
+ *
+ *  1. **Laço circular** — `labelWidget` é a SAÍDA ANTERIOR do classificador
+ *     (`inferLabelWidget`). Um item carimbado "Climatização" voltava a casar
+ *     com o padrão `CLIMATIZA` e se auto-sustentava, independentemente do
+ *     `deviceProfile`. Foi assim que uma bomba hidráulica ficou presa em
+ *     climatização no Moxuara mesmo depois do fix do seed.
+ *  2. **Classificação por nome** — `label` é texto livre do cadastro;
+ *     classificar por nome é proibido (`deviceProfile` é a autoridade).
+ *
+ * O que sobrou é substring sobre `deviceProfile` — hoje a regra
+ * `profileContains`, avaliada direto em `profileOf(item)`.
  */
-function combinedOf(item: ClassifiableItem | null | undefined): string {
-  return `${up(item?.labelWidget ?? '')} ${up(item?.deviceProfile ?? '')} ${up(item?.label ?? '')}`;
-}
 
 /** Mirrors an IdentifierMatch against an already-normalized (trim+upper) id. */
 function matchesIdentifier(id: string, m: IdentifierMatch | undefined): boolean {
@@ -416,10 +451,10 @@ export function resolveGroup(
 //            deviceProfiles. This keeps precise profile matches winning over the
 //            loose text signals (so e.g. an ELEVADOR with a "CAG" label stays an
 //            elevador, matching legacy classifyDevice).
-//   Pass 2 — loose, in rule order (= buildSummary precedence): combinedContains
-//            (text), then conditional (BOMBA/MOTOR + identifier), then the
-//            identifier fallback (equals/contains/prefixes — now unconditional,
-//            like buildSummary's id-prefix checks).
+//   Pass 2 — loose, in rule order (= buildSummary precedence): profileContains
+//            (substring sobre deviceProfile), then conditional (BOMBA/MOTOR +
+//            identifier), then the identifier fallback (equals/contains/prefixes
+//            — now unconditional, like buildSummary's id-prefix checks).
 //   else  — outros / fallback (the genuine-orphan signal).
 //
 // This is a deliberate behavior change vs BOTH legacy paths; the dual-oracle
@@ -457,14 +492,14 @@ export function resolveCategory(
   }
 
   // Pass 2 — loose, in rule order (buildSummary precedence).
-  const combined = combinedOf(item);
   const id = identifierOf(item);
   for (const rule of rules) {
-    // combinedContains (text substring)
-    if (rule.combinedContains) {
-      for (const pattern of rule.combinedContains) {
-        if (combined.includes(up(pattern))) {
-          return { category: rule.name, matchedBy: 'combined' };
+    // profileContains — substring sobre deviceProfile APENAS.
+    // (Nunca sobre labelWidget/label: ver a nota do laço circular acima.)
+    if (dp && rule.profileContains) {
+      for (const pattern of rule.profileContains) {
+        if (dp.includes(up(pattern))) {
+          return { category: rule.name, matchedBy: 'profileContains' };
         }
       }
     }
@@ -560,6 +595,17 @@ export function validateProfile(profile: DeviceClassificationProfile): string[] 
         if (!Array.isArray(r.deviceProfiles)) {
           errors.push(`${domain}.categories.rules["${r?.name}"]: missing deviceProfiles array`);
         }
+        // RFC-0207 (2026-07-23) — `profileContains` passou a ser contrato vivo E
+        // renderizado pelo editor; valida a forma. A chave legada
+        // `combinedContains` é TOLERADA aqui (migrada por normalizeProfile) para
+        // não invalidar perfis já persistidos — resolveActiveProfile valida ANTES
+        // de normalizar.
+        if (r.profileContains !== undefined && !Array.isArray(r.profileContains)) {
+          errors.push(`${domain}.categories.rules["${r?.name}"].profileContains: must be an array`);
+        }
+        if (r.combinedContains !== undefined && !Array.isArray(r.combinedContains)) {
+          errors.push(`${domain}.categories.rules["${r?.name}"].combinedContains: must be an array`);
+        }
       }
       // exactly one fallback across the category family (the 'outros' bucket)
       const inlineFallbacks = catRules.filter((r) => r.fallback === true).length;
@@ -622,7 +668,17 @@ export function normalizeProfile(raw: DeviceClassificationProfile): DeviceClassi
       }
       for (const r of dom.categories.rules ?? []) {
         r.deviceProfiles = upArr(r.deviceProfiles) ?? [];
-        r.combinedContains = upArr(r.combinedContains);
+        // RFC-0207 (2026-07-23): migração de chave `combinedContains` →
+        // `profileContains`. Os VALORES são preservados 1:1; o que muda é o
+        // texto sobre o qual eles são avaliados (só `deviceProfile` agora, sem
+        // `labelWidget`/`label`). Perfis já persistidos continuam válidos.
+        const _pc = upArr(r.profileContains);
+        const _legacy = upArr(r.combinedContains);
+        if (_pc || _legacy) {
+          const merged = [..._pc ?? [], ..._legacy ?? []];
+          r.profileContains = merged.filter((v, i) => merged.indexOf(v) === i);
+        }
+        delete r.combinedContains;
         if (r.conditional) {
           // Compat: perfis JSON legados usavam a chave "deviceTypes" (que sempre
           // comparou contra o deviceProfile) — normaliza para deviceProfiles.

--- a/src/utils/devices/profileSource.ts
+++ b/src/utils/devices/profileSource.ts
@@ -1,0 +1,189 @@
+// src/utils/devices/profileSource.ts
+//
+// RFC-0207 v3.1 — Engine × store seam.
+//
+// A tese central do v3 é separar o MOTOR (como as regras avaliam — código
+// golden-locked) da ÁRVORE (quais nós existem e quais valores casam — dado
+// autorado). Este módulo é a costura: um `ProfileSource` entrega o dado; o motor
+// (`resolveGroup`/`resolveCategory`) não sabe nem se importa de onde ele veio.
+//
+// LIMITE PURO × I/O (RFC-0207 §B/§D — TRAVADO):
+//   - A LIB é dona da INTERFACE `ProfileSource`, do `BakedProfileSource` (piso
+//     offline, derivado do seed in-code) e da cadeia de degradação. **A lib NUNCA
+//     faz `fetch` e NUNCA escreve no ThingsBoard.**
+//   - O MAIN_VIEW é dono das fontes CONCRETAS de I/O (`TbAttributeProfileSource`,
+//     `GcdrResolveProfileSource`). Trocar TB→GCDR é trocar a fonte primária —
+//     o consumidor é idêntico.
+//
+// Este arquivo não importa nada além do próprio módulo de perfil.
+
+import {
+  DEFAULT_DEVICE_CLASSIFICATION_PROFILE,
+  validateProfile,
+  normalizeProfile,
+  type DeviceClassificationProfile,
+  type ProfileLogger,
+} from './deviceClassificationProfile';
+import { BAKED_PROFILE_VERSION } from './bakedProfile.generated';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** De onde o perfil efetivo veio. `baked` = piso offline (estado DEGRADADO). */
+export type ProfileSourceKind = 'customer' | 'system' | 'baked';
+
+export interface ResolvedProfile {
+  /** Etag/versão da árvore resolvida para este customer. */
+  version: string;
+  source: ProfileSourceKind;
+  /** O documento de classificação (schemaVersion 1) que o motor consome. */
+  profile: DeviceClassificationProfile;
+  /**
+   * True quando o perfil NÃO é a verdade autorada e sim o piso embutido
+   * (RFC-0207 §v3.2-F.4: "offline (baked) sempre sinalizado como degradado,
+   * nunca apresentado como verdade").
+   */
+  degraded: boolean;
+  /** Motivo da degradação, quando `degraded` (timeout/5xx/parse/validate/absent). */
+  reason?: string;
+}
+
+/**
+ * Store trocável. Uma implementação pode fazer I/O (MAIN_VIEW) ou não
+ * (`BakedProfileSource`). `resolve` PODE lançar — a cadeia de degradação
+ * (`resolveWithFallback`) é quem trata.
+ */
+export interface ProfileSource {
+  /** Nome curto para log/telemetria (ex.: 'tb-attribute', 'gcdr-resolve', 'baked'). */
+  readonly name: string;
+  resolve(customerId: string): Promise<ResolvedProfile>;
+}
+
+// ---------------------------------------------------------------------------
+// BakedProfileSource — piso offline, versionado, derivado do seed in-code
+// ---------------------------------------------------------------------------
+
+/**
+ * RFC-0207 §B.1-3: "gerado em build-time a partir do seed in-code (artefato
+ * derivado, nunca editado à mão → **nunca uma 5ª cópia**); carrega sua version."
+ *
+ * A leitura literal de "nunca uma 5ª cópia" manda NÃO duplicar a árvore no
+ * bundle. O artefato gerado (`bakedProfile.generated.ts`, escrito por
+ * `scripts/gen-baked-profile.mjs`) carrega portanto a **version** (hash do
+ * conteúdo do seed) e o **manifesto de chaves** — que é o que o golden de
+ * key-parity precisa —, e o `BakedProfileSource` serve o próprio seed sob essa
+ * version. Efeito: o baked é versionado, detecta "baked estanque" e custa ~0 KB
+ * de bundle além do seed que já existe.
+ */
+export function createBakedProfileSource(): ProfileSource {
+  return {
+    name: 'baked',
+    async resolve(): Promise<ResolvedProfile> {
+      return {
+        version: BAKED_PROFILE_VERSION,
+        source: 'baked',
+        profile: DEFAULT_DEVICE_CLASSIFICATION_PROFILE,
+        degraded: true,
+        reason: 'baked-default',
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Degradação — especificada E testável (RFC-0207 §B.1-4)
+// ---------------------------------------------------------------------------
+
+export interface ResolveWithFallbackOptions {
+  customerId: string;
+  /** Piso. Default: `createBakedProfileSource()`. */
+  baked?: ProfileSource;
+  logger?: ProfileLogger;
+  /** Timeout do source primário, em ms. 0/omitido = sem timeout. */
+  timeoutMs?: number;
+  /** Chamado quando a resolução degradou para o baked (telemetria). */
+  onDegraded?: (info: { source: string; reason: string; customerId: string; bakedVersion: string }) => void;
+}
+
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  if (!ms || ms <= 0) return p;
+  return new Promise<T>((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error(`profile source timeout after ${ms}ms`)), ms);
+    p.then(
+      (v) => {
+        clearTimeout(t);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(t);
+        reject(e);
+      },
+    );
+  });
+}
+
+/**
+ * Cadeia de degradação do RFC-0207 §B.1-4:
+ *
+ *   `primary.resolve()` OK e válido → usa
+ *   `primary.resolve()` lança (timeout / 5xx / CORS / JSON inválido) → **baked**
+ *   `primary.resolve()` devolve um perfil que não passa em `validateProfile` → **baked**
+ *
+ * **Nunca lança para o render, nunca apaga o dashboard.** Loga estruturado e
+ * espelha em `onDegraded` para telemetria.
+ */
+export async function resolveWithFallback(
+  primary: ProfileSource,
+  opts: ResolveWithFallbackOptions,
+): Promise<ResolvedProfile> {
+  const baked = opts.baked ?? createBakedProfileSource();
+  const logger = opts.logger ?? console;
+  const degrade = async (reason: string): Promise<ResolvedProfile> => {
+    const floor = await baked.resolve(opts.customerId);
+    const info = {
+      source: 'baked',
+      reason,
+      customerId: opts.customerId,
+      bakedVersion: floor.version,
+    };
+    logger.warn(`[RFC-0207] profile degraded → baked ${JSON.stringify(info)}`);
+    try {
+      opts.onDegraded?.(info);
+    } catch {
+      /* telemetria nunca derruba o render */
+    }
+    return { ...floor, degraded: true, reason };
+  };
+
+  let resolved: ResolvedProfile;
+  try {
+    resolved = await withTimeout(primary.resolve(opts.customerId), opts.timeoutMs ?? 0);
+  } catch (err) {
+    return degrade(`${primary.name}:${(err as Error)?.message || 'resolve threw'}`);
+  }
+
+  if (!resolved || !resolved.profile) {
+    return degrade(`${primary.name}:empty-response`);
+  }
+
+  const errors = validateProfile(resolved.profile);
+  if (errors.length > 0) {
+    return degrade(`${primary.name}:invalid-profile:${errors.slice(0, 3).join('; ')}`);
+  }
+
+  return {
+    ...resolved,
+    profile: normalizeProfile(resolved.profile),
+    degraded: resolved.degraded ?? false,
+  };
+}
+
+/**
+ * True quando o baked embutido não corresponde à version que a fonte autorada
+ * declara — sinal de "baked estanque" (o bundle publicado ficou para trás).
+ */
+export function isBakedStale(resolved: ResolvedProfile, authoredVersion?: string | null): boolean {
+  if (!authoredVersion) return false;
+  return resolved.source === 'baked' && resolved.version !== authoredVersion;
+}

--- a/tests/deviceClassificationProfile.buildsummary.test.ts
+++ b/tests/deviceClassificationProfile.buildsummary.test.ts
@@ -24,6 +24,12 @@
 //      removed. A device that only matched via those now stays 'outros' (like
 //      BOMBA_INCENDIO). BOMBA_CAG is unaffected (matches via conditional/identifier
 //      CAG). Oracle 2's CLIMATIZACAO_PATTERNS drops the two bomba patterns.
+//   3) TEXTO COMBINADO ELIMINADO (2026-07-23, RFC-0207): `combinedContains` virou
+//      `profileContains` — substring sobre `deviceProfile` APENAS. `labelWidget`
+//      (saída anterior do próprio classificador → laço circular) e `label` (nome
+//      livre; classificar por nome é proibido) saíram do match. O oráculo 2 abaixo
+//      passa a casar seus padrões sobre o deviceProfile. A migração device-a-device
+//      está em tests/deviceClassificationProfile.profileContains.test.ts.
 
 import { describe, it, expect } from 'vitest';
 import { resolveCategory, resolveGroup } from '../src/utils/devices/deviceClassificationProfile';
@@ -90,7 +96,7 @@ function legacyClassifyCategory(item: Item): string {
 // Only ever runs on the areacomum set; returns one of the 4 breakdown buckets.
 // ===========================================================================
 
-// Mirrors the CURRENT source combinedContains for climatizacao (bomba patterns
+// Mirrors the CURRENT source profileContains for climatizacao (bomba patterns
 // removed 2026-07-23 — hydraulic pumps are not HVAC).
 const CLIMATIZACAO_PATTERNS = [
   'CHILLER', 'FANCOIL', 'HVAC', 'AR_CONDICIONADO', 'COMPRESSOR',
@@ -101,9 +107,9 @@ const ESCADA_PATTERNS = ['ESCADA', 'ROLANTE'];
 
 function legacyBuildSummaryTop(item: Item): string {
   const toStr = (v: unknown) => String(v || '').toUpperCase();
-  // deviceType EM DESUSO (2026-07-14): removed from combined to mirror the source
-  // `combinedOf` (labelWidget + deviceProfile + label).
-  const combined = `${toStr(item.labelWidget)} ${toStr(item.deviceProfile)} ${toStr(item.label)}`;
+  // RFC-0207 (2026-07-23): o alvo do match é o `deviceProfile`, não mais o texto
+  // combinado (labelWidget + deviceProfile + label). Ver o cabeçalho, ponto 3.
+  const combined = toStr(item.deviceProfile);
   const id = toStr(item.identifier);
   const isElevadorById = id.startsWith('ELV-');
   const isEscadaById = id.startsWith('ESC-');
@@ -151,11 +157,13 @@ function keyOf(d: Item): string {
 // substring) + A1b (combined-text + CHILLER- prefix) moves:
 const EXPECTED_VS_CLASSIFYDEVICE = new Set([
   'BOMBA|BOMBA CAG 2||',          // A1: conditional CAG substring
-  'BOMBA|X||Climatizador Central', // A1b: combined CLIMATIZA (label)
   'BOMBA|CHILLER-1||',             // A1b: CHILLER- id prefix
   // NB: COMPRESSOR/VENTILADOR (deviceType-only) e BOMBA_HIDRAULICA (label) NÃO
   // constam mais — deviceType saiu do combined (2026-07-14) e as strings de bomba
-  // saíram do combinedContains (2026-07-23); todos permanecem 'outros'.
+  // saíram do seed (2026-07-23); todos permanecem 'outros'.
+  // NB2: 'BOMBA|X||Climatizador Central' saiu (2026-07-23): o sinal era o `label`,
+  // e classificar por nome deixou de ser permitido — ver
+  // tests/deviceClassificationProfile.profileContains.test.ts.
 ]);
 // vs buildSummary (only catches CAG-/FANCOIL-/CHILLER- prefixes, never bare CAG):
 const EXPECTED_VS_BUILDSUMMARY = new Set([
@@ -225,10 +233,16 @@ describe('deviceClassificationProfile — A1b buildSummary unification (dual-ora
     });
   });
 
-  it('combined-text match reports matchedBy: combined', () => {
-    expect(resolveCategory({ deviceProfile: 'BOMBA', identifier: 'X', label: 'Climatizador' })).toEqual({
+  it('profileContains match reports matchedBy: profileContains (e o label é ignorado)', () => {
+    // substring sobre o deviceProfile → casa
+    expect(resolveCategory({ deviceProfile: 'CLIMATIZACAO_CENTRAL', identifier: 'X' })).toEqual({
       category: 'climatizacao',
-      matchedBy: 'combined',
+      matchedBy: 'profileContains',
+    });
+    // o mesmo texto no `label` NÃO casa mais (RFC-0207, 2026-07-23)
+    expect(resolveCategory({ deviceProfile: 'BOMBA', identifier: 'X', label: 'Climatizador' })).toEqual({
+      category: 'outros',
+      matchedBy: 'fallback',
     });
   });
 

--- a/tests/deviceClassificationProfile.keyParity.test.ts
+++ b/tests/deviceClassificationProfile.keyParity.test.ts
@@ -1,0 +1,106 @@
+// tests/deviceClassificationProfile.keyParity.test.ts
+//
+// RFC-0207 §F — golden **key-parity**: `keys(engine) === keys(baked)`.
+//
+// A costura do v3 é o `key` do nó (== `entity_key` no GCDR). Se o motor produz
+// uma chave que o artefato baked não conhece — ou o contrário — a classificação
+// e o store falam idiomas diferentes e o sintoma aparece só em produção, mudo.
+//
+// HERMÉTICO POR CONSTRUÇÃO (§B.1-3 / §G): a paridade é reconciliada por ARQUIVO
+// COMMITADO (`bakedProfile.generated.ts`), nunca por rede. Quando o GCDR entrar
+// (v3.2), o mesmo manifesto passa a ser confrontado com a lista `is_system`
+// publicada — também por arquivo commitado.
+
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_DEVICE_CLASSIFICATION_PROFILE,
+  resolveGroup,
+  resolveCategory,
+  type ClassificationDomain,
+} from '../src/utils/devices/deviceClassificationProfile';
+import {
+  BAKED_PROFILE_KEYS,
+  BAKED_PROFILE_VERSION,
+} from '../src/utils/devices/bakedProfile.generated';
+import { createBakedProfileSource } from '../src/utils/devices/profileSource';
+
+/**
+ * Chaves que o MOTOR é capaz de produzir, derivadas do seed que ele executa.
+ * Deliberadamente calculada aqui de forma independente do gerador — se as duas
+ * derivações concordarem, o artefato reflete o motor.
+ */
+function engineKeys(): string[] {
+  const out: string[] = [];
+  const profile = DEFAULT_DEVICE_CLASSIFICATION_PROFILE;
+  for (const domain of Object.keys(profile.domains).sort()) {
+    const dom = profile.domains[domain as ClassificationDomain];
+    if (!dom) continue;
+    out.push(domain);
+    out.push(`${domain}.groups.ocultos`); // grupo implícito (ocultosProfilePatterns)
+    for (const r of dom.groups.rules) out.push(`${domain}.groups.${r.name}`);
+    if (dom.categories) {
+      out.push(`${domain}.categories.lojas`); // atalho de loja (storeDeviceProfile)
+      for (const r of dom.categories.rules) out.push(`${domain}.categories.${r.name}`);
+      out.push(`${domain}.categories.${dom.categories.fallback.name}`);
+    }
+  }
+  return [...new Set(out)].sort();
+}
+
+describe('RFC-0207 §F — golden key-parity (engine × baked)', () => {
+  it('keys(engine) === keys(baked)', () => {
+    expect(engineKeys()).toEqual([...BAKED_PROFILE_KEYS]);
+  });
+
+  it('toda chave de grupo que o motor pode RETORNAR está no manifesto', () => {
+    // Confronto por comportamento, não por leitura do seed: dispara o resolver
+    // com entradas que provocam cada bucket e confere a chave resultante.
+    const probes: { domain: ClassificationDomain; item: Record<string, string> }[] = [
+      { domain: 'energy', item: { deviceProfile: '3F_MEDIDOR' } },
+      { domain: 'energy', item: { deviceProfile: 'TRAFO' } },
+      { domain: 'energy', item: { deviceProfile: 'QUALQUER' } }, // fallback
+      { domain: 'energy', item: { deviceProfile: 'CHILLER_ARQUIVADO' } }, // ocultos
+      { domain: 'water', item: { deviceProfile: 'HIDROMETRO_SHOPPING' } },
+      { domain: 'water', item: { deviceProfile: 'HIDROMETRO' } },
+      { domain: 'water', item: { deviceProfile: 'TANK' } },
+      { domain: 'water', item: { deviceProfile: 'QUALQUER' } },
+      { domain: 'temperature', item: { deviceProfile: 'TERMOSTATO_EXTERNAL' } },
+      { domain: 'temperature', item: { deviceProfile: 'TERMOSTATO' } },
+    ];
+    for (const p of probes) {
+      const key = `${p.domain}.groups.${resolveGroup(p.item, undefined, p.domain).group}`;
+      expect(BAKED_PROFILE_KEYS, `${key} ausente no manifesto`).toContain(key);
+    }
+  });
+
+  it('toda chave de categoria que o motor pode RETORNAR está no manifesto', () => {
+    const probes = [
+      { deviceProfile: '3F_MEDIDOR' }, // lojas
+      { deviceProfile: 'CHILLER' }, // climatizacao
+      { deviceProfile: 'ELEVADOR' }, // elevadores
+      { deviceProfile: 'ESCADA_ROLANTE' }, // escadas_rolantes
+      { deviceProfile: 'GENERICO', identifier: 'NADA' }, // outros (fallback)
+    ];
+    for (const item of probes) {
+      const key = `energy.categories.${resolveCategory(item).category}`;
+      expect(BAKED_PROFILE_KEYS, `${key} ausente no manifesto`).toContain(key);
+    }
+  });
+
+  it('o baked é versionado e serve o seed do motor', async () => {
+    expect(BAKED_PROFILE_VERSION).toMatch(/^[0-9a-f]{12}$/);
+    const resolved = await createBakedProfileSource().resolve('any-customer');
+    expect(resolved.version).toBe(BAKED_PROFILE_VERSION);
+    expect(resolved.source).toBe('baked');
+    // §v3.2-F.4 — baked é sempre sinalizado como DEGRADADO, nunca como verdade
+    expect(resolved.degraded).toBe(true);
+    expect(resolved.profile).toBe(DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+  });
+
+  it('não há chave órfã no manifesto (nenhum nó fantasma)', () => {
+    const engine = new Set(engineKeys());
+    for (const k of BAKED_PROFILE_KEYS) {
+      expect(engine.has(k), `chave "${k}" existe no baked mas o motor não a produz`).toBe(true);
+    }
+  });
+});

--- a/tests/deviceClassificationProfile.profileContains.test.ts
+++ b/tests/deviceClassificationProfile.profileContains.test.ts
@@ -1,0 +1,303 @@
+// tests/deviceClassificationProfile.profileContains.test.ts
+//
+// RFC-0207 — MIGRATION SNAPSHOT: `combinedContains` (texto combinado) →
+// `profileContains` (substring sobre deviceProfile).
+//
+// Fecha DOIS achados da auditoria 2026-07-23 no mesmo lote:
+//
+//   Achado 3a — contrato de regra. `combinedContains` era avaliado pelo motor mas
+//   NENHUM campo do editor o renderizava (o handler `cc` era código inalcançável).
+//   Resolução escolhida: EXPOR — a regra foi renomeada para `profileContains` e
+//   ganhou o campo "deviceProfile contém" no `openDeviceProfileModal`.
+//
+//   Achado 3b — laço circular do `labelWidget`. O texto combinado era
+//   `labelWidget + deviceProfile + label`, e `labelWidget` é a SAÍDA ANTERIOR do
+//   próprio classificador (`inferLabelWidget`). Um item carimbado "Climatização"
+//   voltava a casar com o padrão `CLIMATIZA` e se auto-sustentava, qualquer que
+//   fosse o `deviceProfile` — foi assim que a bomba hidráulica do Moxuara ficou
+//   presa em climatização mesmo depois do fix do seed (14ad6257).
+//
+// A correção é BEHAVIOR-CHANGING (é o ponto). Este arquivo é a evidência: o
+// oráculo abaixo é a semântica ANTIGA, byte a byte, e cada device que muda de
+// balde está enumerado em EXPECTED_MOVES. CI falha se aparecer um move não
+// revisado — ou se um move revisado sumir.
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveCategory,
+  normalizeProfile,
+  DEFAULT_DEVICE_CLASSIFICATION_PROFILE,
+  type DeviceClassificationProfile,
+  type ClassifiableItem,
+} from '../src/utils/devices/deviceClassificationProfile';
+
+// ===========================================================================
+// ORÁCULO — resolveCategory com a semântica ANTERIOR (texto combinado).
+// Cópia fiel do corpo pré-migração, lendo os MESMOS valores do seed atual
+// (que apenas trocaram de chave), de modo que a única variável seja o TEXTO
+// sobre o qual os padrões são avaliados.
+// ===========================================================================
+
+const up = (v: unknown) => String(v ?? '').toUpperCase();
+
+function legacyCombinedOf(item: ClassifiableItem): string {
+  return `${up(item.labelWidget ?? '')} ${up(item.deviceProfile ?? '')} ${up(item.label ?? '')}`;
+}
+
+function legacyMatchesIdentifier(id: string, m: Record<string, string[] | undefined> | undefined) {
+  if (!m) return false;
+  for (const v of m.identifierEquals ?? []) if (id === up(v)) return true;
+  for (const v of m.identifierContains ?? []) if (id.includes(up(v))) return true;
+  for (const p of m.identifierPrefixes ?? []) if (id.startsWith(up(p))) return true;
+  return false;
+}
+
+/** resolveCategory PRÉ-migração: pass 2 casava `combinedContains` sobre o texto combinado. */
+function legacyResolveCategory(item: ClassifiableItem): string {
+  const dom = DEFAULT_DEVICE_CLASSIFICATION_PROFILE.domains.energy;
+  const cats = dom.categories!;
+  const dp = up(item.deviceProfile ?? '');
+  if (dp === up(cats.storeDeviceProfile)) return 'lojas';
+
+  for (const rule of cats.rules) {
+    for (const c of rule.deviceProfiles) if (dp && dp === up(c)) return rule.name;
+  }
+
+  const combined = legacyCombinedOf(item);
+  const id = up(item.identifier ?? '').trim();
+  for (const rule of cats.rules) {
+    // `profileContains` no seed atual carrega EXATAMENTE os valores que a chave
+    // `combinedContains` carregava antes — só o alvo do match mudou.
+    for (const pattern of rule.profileContains ?? []) {
+      if (combined.includes(up(pattern))) return rule.name;
+    }
+    if (rule.conditional && rule.conditional.deviceProfiles.some((t) => dp === up(t))) {
+      if (legacyMatchesIdentifier(id, rule.conditional as never)) return rule.name;
+    }
+    if (legacyMatchesIdentifier(id, rule.identifierFallback as never)) return rule.name;
+  }
+  return 'outros';
+}
+
+// ===========================================================================
+// FIXTURE — cobre deviceProfile exato, substring de deviceProfile, identifier,
+// e (crucialmente) os sinais de TEXTO que deixam de valer: labelWidget e label.
+// ===========================================================================
+
+interface Case {
+  name: string;
+  item: ClassifiableItem;
+}
+
+const FIXTURE: Case[] = [
+  // ---- inalterados: deviceProfile exato (pass 1) ----
+  { name: 'CHILLER exato', item: { deviceProfile: 'CHILLER', identifier: 'CH-1' } },
+  { name: 'ELEVADOR exato', item: { deviceProfile: 'ELEVADOR', identifier: 'CAG' } },
+  { name: 'ESCADA_ROLANTE exato', item: { deviceProfile: 'ESCADA_ROLANTE', identifier: 'X' } },
+  { name: 'loja 3F_MEDIDOR', item: { deviceProfile: '3F_MEDIDOR', identifier: 'L-1' } },
+
+  // ---- inalterados: substring de deviceProfile (o que sobrevive como profileContains) ----
+  { name: 'CHILLER_SECUNDARIO (substring dp)', item: { deviceProfile: 'CHILLER_SECUNDARIO', identifier: 'X' } },
+  { name: 'COMPRESSOR (substring dp)', item: { deviceProfile: 'COMPRESSOR', identifier: 'X' } },
+  { name: 'VENTILADOR (substring dp)', item: { deviceProfile: 'VENTILADOR', identifier: 'X' } },
+  { name: 'CLIMATIZACAO_GERAL (substring dp CLIMATIZA)', item: { deviceProfile: 'CLIMATIZACAO_GERAL', identifier: 'X' } },
+  { name: 'ELEVADOR_SOCIAL (substring dp)', item: { deviceProfile: 'ELEVADOR_SOCIAL', identifier: 'X' } },
+  { name: 'ESCADAS_ROLANTES (substring dp)', item: { deviceProfile: 'ESCADAS_ROLANTES', identifier: 'X' } },
+
+  // ---- inalterados: identifier ----
+  { name: 'identifier ELV-03', item: { deviceProfile: '', identifier: 'ELV-03' } },
+  { name: 'identifier CAG puro', item: { deviceProfile: '', identifier: 'CAG' } },
+  { name: 'BOMBA + CAG (conditional)', item: { deviceProfile: 'BOMBA', identifier: 'BOMBA CAG 2' } },
+  { name: 'BOMBA + CHILLER- prefixo', item: { deviceProfile: 'BOMBA', identifier: 'CHILLER-1' } },
+
+  // ---- inalterados: órfãos genuínos ----
+  { name: 'GENERIC órfão', item: { deviceProfile: 'GENERIC', identifier: 'G-1', label: 'Quadro Geral' } },
+  { name: 'MOTOR sem identifier útil', item: { deviceProfile: 'MOTOR', identifier: 'NADA' } },
+  { name: 'BOMBA_INCENDIO', item: { deviceProfile: 'BOMBA_INCENDIO', identifier: 'BI-01' } },
+
+  // ---- MOVES: o sinal era APENAS o label (nome livre) ----
+  {
+    name: 'MOVE label "Climatizador Central" → outros',
+    item: { deviceProfile: 'BOMBA', identifier: 'X', label: 'Climatizador Central' },
+  },
+  {
+    name: 'MOVE label "Escada de serviço" → outros',
+    item: { deviceProfile: 'MOTOR', identifier: 'X', label: 'Escada de serviço' },
+  },
+  {
+    name: 'MOVE label "Elevador de carga" → outros',
+    item: { deviceProfile: 'MOTOR', identifier: 'X', label: 'Elevador de carga' },
+  },
+
+  // ---- MOVES: o LAÇO CIRCULAR (labelWidget = saída anterior do classificador) ----
+  {
+    // Caso exato observado em runtime no Moxuara (achado 3 da auditoria):
+    //   combined = "CLIMATIZAÇÃO BOMBA_HIDRAULICA BOMBA HIDRÁULICA 5 L2"
+    //              ^^^^^^^^^^^^ labelWidget do próprio item
+    name: 'MOVE laço Moxuara: BOMBA_HIDRAULICA carimbada "Climatização" → outros',
+    item: {
+      deviceProfile: 'BOMBA_HIDRAULICA',
+      identifier: 'BH-05',
+      labelWidget: 'Climatização',
+      label: 'Bomba Hidráulica 5 L2',
+    },
+  },
+  {
+    name: 'MOVE laço: profile órfão carimbado "Elevadores" → outros',
+    item: { deviceProfile: 'GENERICO', identifier: 'G-9', labelWidget: 'Elevadores' },
+  },
+];
+
+function keyOf(c: Case): string {
+  return c.name;
+}
+
+// Snapshot revisado: TODO move é "categoria específica → outros", causado
+// exclusivamente por um sinal de texto que o motor não tem mais o direito de ler
+// (`label` = nome livre; `labelWidget` = saída anterior do classificador).
+const EXPECTED_MOVES = [
+  'MOVE label "Climatizador Central" → outros',
+  'MOVE label "Escada de serviço" → outros',
+  'MOVE label "Elevador de carga" → outros',
+  'MOVE laço Moxuara: BOMBA_HIDRAULICA carimbada "Climatização" → outros',
+  'MOVE laço: profile órfão carimbado "Elevadores" → outros',
+];
+
+describe('RFC-0207 — migração combinedContains → profileContains', () => {
+  it('o oráculo legado reproduz a classificação por texto combinado', () => {
+    // sanity do próprio oráculo: sem ele o snapshot abaixo não prova nada
+    expect(legacyResolveCategory({ deviceProfile: 'BOMBA', identifier: 'X', label: 'Climatizador Central' })).toBe(
+      'climatizacao',
+    );
+    expect(
+      legacyResolveCategory({ deviceProfile: 'BOMBA_HIDRAULICA', identifier: 'BH-05', labelWidget: 'Climatização' }),
+    ).toBe('climatizacao');
+  });
+
+  it('os moves são exatamente o conjunto revisado (nenhum move surpresa)', () => {
+    const moves: string[] = [];
+    for (const c of FIXTURE) {
+      const before = legacyResolveCategory(c.item);
+      const after = resolveCategory(c.item).category;
+      if (before !== after) {
+        // todo move é "categoria específica → outros"
+        expect(after, `move ${keyOf(c)} deve ir para outros`).toBe('outros');
+        expect(before, `move ${keyOf(c)} devia vir de uma categoria específica`).not.toBe('outros');
+        moves.push(keyOf(c));
+      }
+    }
+    expect(moves.sort()).toEqual([...EXPECTED_MOVES].sort());
+  });
+
+  it('nenhum device muda de balde quando o sinal é deviceProfile ou identifier', () => {
+    for (const c of FIXTURE) {
+      if (EXPECTED_MOVES.includes(c.name)) continue;
+      expect(resolveCategory(c.item).category, c.name).toBe(legacyResolveCategory(c.item));
+    }
+  });
+
+  // ------------------------------------------------------------------ laço
+  it('LAÇO FECHADO: labelWidget não realimenta mais a classificação', () => {
+    const base: ClassifiableItem = { deviceProfile: 'BOMBA_HIDRAULICA', identifier: 'BH-05' };
+    const semCarimbo = resolveCategory(base).category;
+    const comCarimbo = resolveCategory({ ...base, labelWidget: 'Climatização' }).category;
+    const comCarimboErrado = resolveCategory({ ...base, labelWidget: 'Elevadores' }).category;
+    // a classificação é IDÊNTICA com ou sem carimbo — não há mais realimentação
+    expect(semCarimbo).toBe('outros');
+    expect(comCarimbo).toBe(semCarimbo);
+    expect(comCarimboErrado).toBe(semCarimbo);
+  });
+
+  it('LABEL não classifica: o nome livre do device é irrelevante', () => {
+    const base: ClassifiableItem = { deviceProfile: 'MOTOR', identifier: 'M-1' };
+    expect(resolveCategory(base).category).toBe('outros');
+    for (const label of ['Chiller da praça', 'FANCOIL do piso 2', 'Escada Rolante Sul', 'Elevador Social']) {
+      expect(resolveCategory({ ...base, label }).category, label).toBe('outros');
+    }
+  });
+
+  // ------------------------------------------------- profileContains exposto
+  it('profileContains casa substring de deviceProfile e reporta matchedBy', () => {
+    expect(resolveCategory({ deviceProfile: 'CHILLER_SECUNDARIO', identifier: 'X' })).toEqual({
+      category: 'climatizacao',
+      matchedBy: 'profileContains',
+    });
+    expect(resolveCategory({ deviceProfile: 'ELEVADOR_SOCIAL', identifier: 'X' })).toEqual({
+      category: 'elevadores',
+      matchedBy: 'profileContains',
+    });
+  });
+
+  it('deviceProfile vazio nunca casa profileContains (string vazia não é curinga)', () => {
+    // `''.includes('CHILLER')` é false, mas `dp &&` protege contra padrões vazios
+    // vindos de um perfil de customer mal preenchido.
+    const profile = normalizeProfile(
+      JSON.parse(JSON.stringify(DEFAULT_DEVICE_CLASSIFICATION_PROFILE)) as DeviceClassificationProfile,
+    );
+    profile.domains.energy.categories!.rules[2].profileContains = [''];
+    expect(resolveCategory({ deviceProfile: '', identifier: 'NADA' }, profile).category).toBe('outros');
+    expect(resolveCategory({ deviceProfile: 'GENERIC', identifier: 'NADA' }, profile).category).toBe(
+      // padrão vazio casa qualquer profile não-vazio — é lixo do operador, mas é
+      // determinístico e visível no editor (campo renderizado), não invisível.
+      'climatizacao',
+    );
+  });
+
+  // ------------------------------------------------- migração de chave (dados)
+  it('normalizeProfile migra combinedContains → profileContains preservando valores', () => {
+    const legacy = {
+      schemaVersion: 1,
+      domains: {
+        energy: {
+          groups: {
+            ocultosProfilePatterns: ['ARQUIVADO'],
+            rules: [
+              { name: 'lojas', deviceProfiles: ['3F_MEDIDOR'] },
+              { name: 'areacomum', deviceProfiles: [], fallback: true },
+            ],
+          },
+          categories: {
+            storeDeviceProfile: '3F_MEDIDOR',
+            rules: [{ name: 'climatizacao', deviceProfiles: ['CHILLER'], combinedContains: ['hvac', 'CLIMATIZA'] }],
+            fallback: { name: 'outros' },
+          },
+        },
+      },
+    } as unknown as DeviceClassificationProfile;
+
+    const norm = normalizeProfile(legacy);
+    const rule = norm.domains.energy.categories!.rules[0];
+    expect(rule.profileContains).toEqual(['HVAC', 'CLIMATIZA']);
+    expect(rule.combinedContains).toBeUndefined();
+    // e o motor passa a avaliar esses valores sobre o deviceProfile
+    expect(resolveCategory({ deviceProfile: 'HVAC_ROOFTOP', identifier: 'X' }, norm).category).toBe('climatizacao');
+  });
+
+  it('normalizeProfile deduplica quando as duas chaves coexistem', () => {
+    const both = {
+      schemaVersion: 1,
+      domains: {
+        energy: {
+          groups: {
+            ocultosProfilePatterns: [],
+            rules: [{ name: 'areacomum', deviceProfiles: [], fallback: true }],
+          },
+          categories: {
+            storeDeviceProfile: '3F_MEDIDOR',
+            rules: [
+              {
+                name: 'climatizacao',
+                deviceProfiles: [],
+                profileContains: ['CHILLER'],
+                combinedContains: ['chiller', 'FANCOIL'],
+              },
+            ],
+            fallback: { name: 'outros' },
+          },
+        },
+      },
+    } as unknown as DeviceClassificationProfile;
+    const rule = normalizeProfile(both).domains.energy.categories!.rules[0];
+    expect(rule.profileContains).toEqual(['CHILLER', 'FANCOIL']);
+  });
+});

--- a/tests/deviceClassificationProfile.profileSource.test.ts
+++ b/tests/deviceClassificationProfile.profileSource.test.ts
@@ -1,0 +1,166 @@
+// tests/deviceClassificationProfile.profileSource.test.ts
+//
+// RFC-0207 §B.1-4 — degradação **especificada E testada** (fault injection).
+//
+// "Cadeia: cache válido (304) → resolve() 200 → em throw de resolve()
+//  (timeout/5xx/CORS/JSON inválido/validação) **cai no BakedProfileSource**;
+//  nunca lança para o render, nunca apaga o dashboard."
+//
+// Sem estes testes a degradação é prosa. Cada modo de falha abaixo é injetado.
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createBakedProfileSource,
+  resolveWithFallback,
+  isBakedStale,
+  type ProfileSource,
+  type ResolvedProfile,
+} from '../src/utils/devices/profileSource';
+import {
+  DEFAULT_DEVICE_CLASSIFICATION_PROFILE,
+  resolveCategory,
+  type DeviceClassificationProfile,
+} from '../src/utils/devices/deviceClassificationProfile';
+import { BAKED_PROFILE_VERSION } from '../src/utils/devices/bakedProfile.generated';
+
+const silentLogger = { warn: () => {} };
+
+function sourceThatThrows(name: string, err: unknown): ProfileSource {
+  return {
+    name,
+    resolve: async () => {
+      throw err;
+    },
+  };
+}
+
+function sourceThatReturns(name: string, r: Partial<ResolvedProfile>): ProfileSource {
+  return {
+    name,
+    resolve: async () =>
+      ({
+        version: 'v1',
+        source: 'customer',
+        degraded: false,
+        profile: DEFAULT_DEVICE_CLASSIFICATION_PROFILE,
+        ...r,
+      }) as ResolvedProfile,
+  };
+}
+
+/** Perfil de customer válido, com uma regra própria, para o caminho feliz. */
+function customerProfile(): DeviceClassificationProfile {
+  const p = JSON.parse(JSON.stringify(DEFAULT_DEVICE_CLASSIFICATION_PROFILE)) as DeviceClassificationProfile;
+  p.domains.energy.categories!.rules[2].deviceProfiles.push('BOMBA_CAG');
+  return p;
+}
+
+describe('RFC-0207 §B.1-4 — cadeia de degradação do ProfileSource', () => {
+  it('caminho feliz: usa o perfil da fonte primária, normalizado, sem degradar', async () => {
+    const src = sourceThatReturns('primary', { profile: customerProfile(), version: 'etag-42' });
+    const out = await resolveWithFallback(src, { customerId: 'c1', logger: silentLogger });
+    expect(out.source).toBe('customer');
+    expect(out.version).toBe('etag-42');
+    expect(out.degraded).toBe(false);
+    // a regra do customer está de fato ativa no perfil devolvido
+    expect(resolveCategory({ deviceProfile: 'BOMBA_CAG', identifier: 'X' }, out.profile).category).toBe(
+      'climatizacao',
+    );
+  });
+
+  // ---------------------------------------------------------------- injeções
+  it.each([
+    ['timeout', new Error('network timeout')],
+    ['5xx', new Error('HTTP 500: Internal Server Error')],
+    ['CORS', new TypeError('Failed to fetch')],
+    ['JSON inválido', new SyntaxError('Unexpected token < in JSON at position 0')],
+  ])('resolve() falha (%s) → cai no baked e NÃO lança', async (_label, err) => {
+    const out = await resolveWithFallback(sourceThatThrows('gcdr-resolve', err), {
+      customerId: 'c1',
+      logger: silentLogger,
+    });
+    expect(out.source).toBe('baked');
+    expect(out.degraded).toBe(true);
+    expect(out.profile).toBe(DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    expect(out.reason).toContain('gcdr-resolve');
+  });
+
+  it('perfil inválido (schema quebrado) → cai no baked, nunca aplica lixo', async () => {
+    const broken = { schemaVersion: 1, domains: {} } as unknown as DeviceClassificationProfile;
+    const out = await resolveWithFallback(sourceThatReturns('tb-attribute', { profile: broken }), {
+      customerId: 'c1',
+      logger: silentLogger,
+    });
+    expect(out.source).toBe('baked');
+    expect(out.reason).toContain('invalid-profile');
+  });
+
+  it('resposta vazia → cai no baked', async () => {
+    const out = await resolveWithFallback(sourceThatReturns('tb-attribute', { profile: undefined as never }), {
+      customerId: 'c1',
+      logger: silentLogger,
+    });
+    expect(out.source).toBe('baked');
+    expect(out.reason).toContain('empty-response');
+  });
+
+  it('resolve() pendurado além do timeout → cai no baked (o dashboard não trava)', async () => {
+    const hung: ProfileSource = { name: 'hung', resolve: () => new Promise<ResolvedProfile>(() => {}) };
+    const out = await resolveWithFallback(hung, {
+      customerId: 'c1',
+      logger: silentLogger,
+      timeoutMs: 25,
+    });
+    expect(out.source).toBe('baked');
+    expect(out.reason).toMatch(/timeout/i);
+  });
+
+  // ---------------------------------------------------------------- logging
+  it('a degradação é logada estruturada e espelhada em onDegraded (telemetria)', async () => {
+    const warn = vi.fn();
+    const onDegraded = vi.fn();
+    await resolveWithFallback(sourceThatThrows('gcdr-resolve', new Error('boom')), {
+      customerId: 'cust-77',
+      logger: { warn },
+      onDegraded,
+    });
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain('degraded');
+    expect(onDegraded).toHaveBeenCalledWith({
+      source: 'baked',
+      reason: expect.stringContaining('gcdr-resolve'),
+      customerId: 'cust-77',
+      bakedVersion: BAKED_PROFILE_VERSION,
+    });
+  });
+
+  it('um onDegraded que explode NÃO derruba a resolução (telemetria não é crítica)', async () => {
+    const out = await resolveWithFallback(sourceThatThrows('x', new Error('boom')), {
+      customerId: 'c1',
+      logger: silentLogger,
+      onDegraded: () => {
+        throw new Error('telemetry down');
+      },
+    });
+    expect(out.source).toBe('baked');
+  });
+
+  // ------------------------------------------------------------ baked estanque
+  it('isBakedStale detecta bundle atrasado em relação à version autorada', () => {
+    const baked = {
+      version: BAKED_PROFILE_VERSION,
+      source: 'baked',
+      profile: DEFAULT_DEVICE_CLASSIFICATION_PROFILE,
+      degraded: true,
+    } as ResolvedProfile;
+    expect(isBakedStale(baked, 'outra-version')).toBe(true);
+    expect(isBakedStale(baked, BAKED_PROFILE_VERSION)).toBe(false);
+    expect(isBakedStale(baked, null)).toBe(false); // sem referência ⇒ não afirma nada
+  });
+
+  it('o BakedProfileSource nunca lança e sempre entrega um perfil utilizável', async () => {
+    const out = await createBakedProfileSource().resolve('qualquer-customer');
+    expect(out.profile.domains.energy).toBeDefined();
+    expect(resolveCategory({ deviceProfile: 'CHILLER' }, out.profile).category).toBe('climatizacao');
+  });
+});

--- a/tests/deviceClassificationProfile.treeWalker.test.ts
+++ b/tests/deviceClassificationProfile.treeWalker.test.ts
@@ -1,0 +1,336 @@
+// tests/deviceClassificationProfile.treeWalker.test.ts
+//
+// RFC-0207 v2/v3.1 — walker genérico sobre a árvore de nós.
+//
+// Dois goldens moram aqui:
+//
+//   1. EQUIVALÊNCIA v1 ↔ v2 (§J): a árvore levantada do seed (`liftProfileToTree`)
+//      classifica CADA device do fixture na mesma folha que o par
+//      `resolveGroup`/`resolveCategory` do v1. Diff esperado: **ZERO**. Este é o
+//      teste que autoriza, num passo futuro, trocar o caminho de produção para o
+//      walker — sem ele a troca seria fé.
+//
+//   2. ORDER-SENSITIVITY (§F): o `order` é o que torna a avaliação determinística,
+//      e o fallback nunca pode sombrear um irmão real.
+
+import { describe, it, expect } from 'vitest';
+import {
+  resolveGroup,
+  resolveCategory,
+  DEFAULT_DEVICE_CLASSIFICATION_PROFILE,
+  type ClassificationDomain,
+  type ClassifiableItem,
+} from '../src/utils/devices/deviceClassificationProfile';
+import {
+  liftProfileToTree,
+  resolveClassification,
+  resolveSubcategory,
+  validateTree,
+  findNode,
+  flattenTree,
+  type ClassificationNode,
+} from '../src/utils/devices/classificationNodeTree';
+
+const PROFILE = DEFAULT_DEVICE_CLASSIFICATION_PROFILE;
+
+// ===========================================================================
+// ORÁCULO v1 — a folha que o par groups/categories produz hoje.
+//
+// O merge do v2 (§C) funde colunas e breakdown numa lista só de nós de topo,
+// então a folha equivalente é: a COLUNA quando ela é decisiva (ocultos / lojas /
+// entrada) e a CATEGORIA quando o device caiu no residual.
+// ===========================================================================
+function v1Leaf(item: ClassifiableItem, domain: ClassificationDomain): string {
+  const g = resolveGroup(item, PROFILE, domain).group;
+  if (domain !== 'energy') return g;
+  if (g === 'ocultos' || g === 'lojas' || g === 'entrada') return g;
+  return resolveCategory(item, PROFILE, domain).category;
+}
+
+// ===========================================================================
+// FIXTURE compartilhado — cobre cada caminho do motor.
+// ===========================================================================
+const ENERGY_FIXTURE: ClassifiableItem[] = [
+  { deviceProfile: '3F_MEDIDOR', identifier: 'L-01' },
+  { deviceProfile: 'TRAFO', identifier: 'T-01' },
+  { deviceProfile: 'ENTRADA', identifier: 'E-01' },
+  { deviceProfile: 'RELOGIO', identifier: 'R-01' },
+  { deviceProfile: 'SUBESTACAO', identifier: 'S-01' },
+  { deviceProfile: 'CHILLER', identifier: 'CH-01' },
+  { deviceProfile: 'AR_CONDICIONADO', identifier: 'AC-01' },
+  { deviceProfile: 'HVAC', identifier: 'H-01' },
+  { deviceProfile: 'FANCOIL', identifier: 'F-01' },
+  { deviceProfile: 'ELEVADOR', identifier: 'CAG' }, // exato vence sinal solto
+  { deviceProfile: 'ESCADA_ROLANTE', identifier: 'X' },
+  { deviceProfile: 'CHILLER_SECUNDARIO', identifier: 'X' }, // profileContains
+  { deviceProfile: 'ELEVADOR_SOCIAL', identifier: 'X' },
+  { deviceProfile: 'ESCADAS_ROLANTES', identifier: 'X' },
+  { deviceProfile: 'COMPRESSOR', identifier: 'X' },
+  { deviceProfile: 'VENTILADOR', identifier: 'X' },
+  { deviceProfile: 'CLIMATIZACAO_GERAL', identifier: 'X' },
+  { deviceProfile: 'BOMBA', identifier: 'CAG' }, // conditional
+  { deviceProfile: 'BOMBA', identifier: 'BOMBA CAG 2' },
+  { deviceProfile: 'MOTOR', identifier: 'FANCOIL-3' },
+  { deviceProfile: 'MOTOR', identifier: 'NADA' }, // órfão
+  { deviceProfile: '', identifier: 'ELV-03' }, // só identifier
+  { deviceProfile: '', identifier: 'CAG' },
+  { deviceProfile: '', identifier: 'ESC-2' },
+  { deviceProfile: '', identifier: 'CHILLER-9' },
+  { deviceProfile: 'GENERICO', identifier: 'G-1' },
+  { deviceProfile: 'BOMBA_HIDRAULICA', identifier: 'BH-1' },
+  { deviceProfile: 'BOMBA_INCENDIO', identifier: 'BI-1' },
+  { deviceProfile: 'BOMBA_CAG', identifier: 'CAG-01' },
+  { deviceProfile: 'CHILLER_ARQUIVADO', identifier: 'X' }, // ocultos
+  { deviceProfile: 'MEDIDOR_INATIVO', identifier: 'X' },
+  { deviceProfile: 'X_SEM_DADOS', identifier: 'X' },
+];
+
+const WATER_FIXTURE: ClassifiableItem[] = [
+  { deviceProfile: 'HIDROMETRO_SHOPPING', identifier: 'HS-1' },
+  { deviceProfile: 'HIDROMETRO', identifier: 'H-1' },
+  { deviceProfile: 'TANK', identifier: 'T-1' },
+  { deviceProfile: 'CAIXA_DAGUA', identifier: 'C-1' },
+  { deviceProfile: 'HIDROMETRO_AREA_COMUM', identifier: 'HA-1' },
+  { deviceProfile: 'HIDROMETRO_ARQUIVADO', identifier: 'X' },
+  { deviceProfile: 'DESCONHECIDO', identifier: 'X' },
+];
+
+const TEMPERATURE_FIXTURE: ClassifiableItem[] = [
+  { deviceProfile: 'TERMOSTATO', identifier: 'T-1' },
+  { deviceProfile: 'TERMOSTATO_EXTERNAL', identifier: 'TE-1' },
+  { deviceProfile: 'TERMOSTATO_REMOVIDO', identifier: 'X' },
+  { deviceProfile: 'OUTRO', identifier: 'X' },
+];
+
+function keyOf(i: ClassifiableItem): string {
+  return `${i.deviceProfile ?? ''}|${i.identifier ?? ''}`;
+}
+
+// ===========================================================================
+// GOLDEN 1 — equivalência v1 ↔ walker(árvore levantada)
+// ===========================================================================
+describe('RFC-0207 §J — golden de equivalência v1 ↔ árvore v2 (diff esperado: ZERO)', () => {
+  it.each([
+    ['energy', ENERGY_FIXTURE],
+    ['water', WATER_FIXTURE],
+    ['temperature', TEMPERATURE_FIXTURE],
+  ] as [ClassificationDomain, ClassifiableItem[]][])(
+    'domínio %s: nenhum device muda de folha',
+    (domain, fixture) => {
+      const tree = liftProfileToTree(PROFILE, domain);
+      const diffs: string[] = [];
+      for (const item of fixture) {
+        const expected = v1Leaf(item, domain);
+        const actual = resolveClassification(item, tree)?.key;
+        if (expected !== actual) diffs.push(`${keyOf(item)}: v1=${expected} walker=${actual}`);
+      }
+      expect(diffs).toEqual([]);
+    },
+  );
+
+  it('item nulo cai no fallback nos dois motores (nunca lança)', () => {
+    const tree = liftProfileToTree(PROFILE, 'energy');
+    expect(resolveClassification(null, tree)?.key).toBe('outros');
+    expect(v1Leaf(null as never, 'energy')).toBe('outros');
+  });
+
+  it('a árvore levantada passa em validateTree (order explícito, 1 fallback por nível)', () => {
+    for (const domain of ['energy', 'water', 'temperature'] as ClassificationDomain[]) {
+      expect(validateTree(liftProfileToTree(PROFILE, domain)), domain).toEqual([]);
+    }
+  });
+
+  it('todo nó da árvore levantada carrega order inteiro EXPLÍCITO (§B.1-1)', () => {
+    for (const n of flattenTree(liftProfileToTree(PROFILE, 'energy'))) {
+      expect(Number.isInteger(n.order), `${n.key} sem order inteiro`).toBe(true);
+    }
+  });
+
+  it('areacomum vira nó COMPUTADO (residual), não um balde de devices', () => {
+    const tree = liftProfileToTree(PROFILE, 'energy');
+    const residual = findNode(tree, 'areacomum');
+    expect(residual?.role).toBe('residual');
+    expect(residual?.formula).toEqual({
+      op: 'subtract',
+      from: 'entrada',
+      subtract: expect.arrayContaining(['lojas', 'climatizacao', 'elevadores', 'escadas_rolantes', 'outros']),
+    });
+    // e nenhum device é alocado nele (nós computados não classificam)
+    for (const item of ENERGY_FIXTURE) {
+      expect(resolveClassification(item, tree)?.key).not.toBe('areacomum');
+    }
+  });
+});
+
+// ===========================================================================
+// GOLDEN 2 — order-sensitivity (§F)
+// ===========================================================================
+describe('RFC-0207 §F — golden order-sensitivity', () => {
+  /** Dois irmãos que casam o MESMO device; só o `order` decide. */
+  function ambiguousTree(fallbackOrder: number): ClassificationNode[] {
+    return [
+      { key: 'alfa', label: 'Alfa', role: 'consumer', order: 1, rules: { profileContains: ['BOMBA'] } },
+      { key: 'beta', label: 'Beta', role: 'consumer', order: 2, rules: { profileContains: ['BOMBA'] } },
+      { key: 'resto', label: 'Resto', role: 'fallback', order: fallbackOrder },
+    ];
+  }
+
+  it('irmãos ambíguos: vence o menor `order` — e inverter o order inverte o resultado', () => {
+    const item = { deviceProfile: 'BOMBA_HIDRAULICA' };
+    const tree = ambiguousTree(9);
+    expect(resolveClassification(item, tree)?.key).toBe('alfa');
+
+    const inverted = ambiguousTree(9).map((n) =>
+      n.key === 'alfa' ? { ...n, order: 5 } : n,
+    ) as ClassificationNode[];
+    expect(resolveClassification(item, inverted)?.key).toBe('beta');
+  });
+
+  it('a ordem do ARRAY não decide nada — só o campo `order` (§B.1-1)', () => {
+    const item = { deviceProfile: 'BOMBA_HIDRAULICA' };
+    const tree = ambiguousTree(9);
+    const shuffled = [tree[2], tree[1], tree[0]];
+    expect(resolveClassification(item, shuffled)?.key).toBe('alfa');
+  });
+
+  it('o fallback NUNCA sombreia um irmão real, mesmo com order menor', () => {
+    // fallback com order 0 (antes de todos) — o walker só o consulta depois de
+    // esgotar as fases exata e solta, então o irmão real continua vencendo.
+    const tree = ambiguousTree(0);
+    expect(resolveClassification({ deviceProfile: 'BOMBA_HIDRAULICA' }, tree)?.key).toBe('alfa');
+    // e um device que não casa em ninguém cai no fallback
+    expect(resolveClassification({ deviceProfile: 'NADA' }, tree)?.key).toBe('resto');
+  });
+
+  it('validateTree REJEITA um fallback que não é o maior order do nível', () => {
+    const errors = validateTree(ambiguousTree(0));
+    expect(errors.some((e) => /sombrearia a regra/.test(e))).toBe(true);
+    expect(validateTree(ambiguousTree(9))).toEqual([]);
+  });
+
+  it('validateTree rejeita >1 fallback entre irmãos, key duplicada e formula órfã', () => {
+    const bad: ClassificationNode[] = [
+      { key: 'a', label: 'A', role: 'fallback', order: 1 },
+      { key: 'a', label: 'A2', role: 'fallback', order: 2 },
+      { key: 'c', label: 'C', role: 'total', order: 3, formula: { op: 'sum', of: ['inexistente'] } },
+    ];
+    const errors = validateTree(bad);
+    expect(errors.some((e) => /fallback.*irmãos/.test(e))).toBe(true);
+    expect(errors.some((e) => /key duplicada/.test(e))).toBe(true);
+    expect(errors.some((e) => /key inexistente "inexistente"/.test(e))).toBe(true);
+  });
+
+  it('validateTree rejeita alocação não-única do mesmo deviceProfile (§R5)', () => {
+    const bad: ClassificationNode[] = [
+      { key: 'a', label: 'A', order: 1, rules: { deviceProfiles: ['MOTOR'] } },
+      { key: 'b', label: 'B', order: 2, rules: { deviceProfiles: ['MOTOR'] } },
+    ];
+    expect(validateTree(bad).some((e) => /alocação não-única.*MOTOR/.test(e))).toBe(true);
+  });
+
+  it('validateTree exige order inteiro explícito', () => {
+    const bad = [{ key: 'a', label: 'A' }] as unknown as ClassificationNode[];
+    expect(validateTree(bad).some((e) => /order ausente ou não-inteiro/.test(e))).toBe(true);
+  });
+});
+
+// ===========================================================================
+// Tier-2 group-generic (§C-4)
+// ===========================================================================
+describe('RFC-0207 §C-4 — tier-2 group-generic (subcategoria = DADO, sem código novo)', () => {
+  /** Climatização com filhos — o exemplo do §J, expresso só como dado. */
+  const treeWithChildren: ClassificationNode[] = [
+    { key: 'ocultos', label: 'Ocultos', role: 'ocultos', order: 0, rules: { profileContains: ['ARQUIVADO'] } },
+    { key: 'lojas', label: 'Lojas', role: 'consumer', order: 1, rules: { deviceProfiles: ['3F_MEDIDOR'] } },
+    {
+      key: 'climatizacao',
+      label: 'Climatização',
+      role: 'consumer',
+      order: 2,
+      rules: { profileContains: ['CHILLER', 'FANCOIL', 'BOMBA'], identifierContains: ['CAG'] },
+      children: [
+        { key: 'chillers', label: 'Chillers', order: 1, rules: { deviceProfiles: ['CHILLER'], identifierPrefixes: ['CHILLER-'] } },
+        { key: 'fancoils', label: 'Fancoils', order: 2, rules: { deviceProfiles: ['FANCOIL'], identifierPrefixes: ['FANCOIL-'] } },
+        { key: 'bombas_hidraulicas', label: 'Bombas Hidráulicas', order: 3, rules: { deviceProfiles: ['BOMBA_HIDRAULICA'], identifierContains: ['CAG'] } },
+        { key: 'outros_hvac', label: 'Outros HVAC', role: 'fallback', order: 4 },
+      ],
+    },
+    // "Outros" com filhos — prova que NÃO há caso especial de climatização
+    {
+      key: 'outros',
+      label: 'Outros Equipamentos',
+      role: 'fallback',
+      order: 3,
+      children: [
+        { key: 'iluminacao', label: 'Iluminação', order: 1, rules: { profileContains: ['ILUMINACAO'] } },
+        { key: 'incendio', label: 'Incêndio', order: 2, rules: { profileContains: ['INCENDIO'] } },
+        { key: 'outros_resto', label: 'Outros', role: 'fallback', order: 3 },
+      ],
+    },
+  ];
+
+  it('device-testemunha do §J: BOMBA_HIDRAULICA + "CAG 01" → climatizacao/bombas_hidraulicas', () => {
+    const r = resolveClassification({ deviceProfile: 'BOMBA_HIDRAULICA', identifier: 'CAG 01' }, treeWithChildren);
+    expect(r?.nodePath).toEqual(['climatizacao', 'bombas_hidraulicas']);
+    expect(r?.key).toBe('bombas_hidraulicas');
+  });
+
+  it('conta UMA vez, na folha mais profunda (§I.1 D-b)', () => {
+    const r = resolveClassification({ deviceProfile: 'CHILLER', identifier: 'CH-1' }, treeWithChildren);
+    expect(r?.nodePath).toEqual(['climatizacao', 'chillers']);
+  });
+
+  it('sem filho que case, cai no fallback DAQUELE nível', () => {
+    const r = resolveClassification({ deviceProfile: 'FANCOIL_X', identifier: 'Z' }, treeWithChildren);
+    // FANCOIL_X casa climatizacao por profileContains; nenhum filho casa exato/solto
+    expect(r?.nodePath).toEqual(['climatizacao', 'outros_hvac']);
+  });
+
+  it('"Outros" é apenas outro grupo com filhos — zero caso especial', () => {
+    expect(
+      resolveClassification({ deviceProfile: 'ILUMINACAO_G1', identifier: 'X' }, treeWithChildren)?.nodePath,
+    ).toEqual(['outros', 'iluminacao']);
+    expect(
+      // NB: um profile contendo "BOMBA" cairia em climatizacao (order 2 < 3), como
+      // manda a árvore deste fixture — por isso a sonda de incêndio usa um profile
+      // que não carrega o token BOMBA.
+      resolveClassification({ deviceProfile: 'INCENDIO_PAINEL', identifier: 'X' }, treeWithChildren)?.nodePath,
+    ).toEqual(['outros', 'incendio']);
+    expect(
+      resolveClassification({ deviceProfile: 'QUALQUER', identifier: 'X' }, treeWithChildren)?.nodePath,
+    ).toEqual(['outros', 'outros_resto']);
+  });
+
+  it('nova subcategoria = INSERIR UM NÓ (dado), sem tocar no motor', () => {
+    const withParking: ClassificationNode[] = [
+      ...treeWithChildren.filter((n) => n.key !== 'outros'),
+      { key: 'estacionamento', label: 'Estacionamento', role: 'consumer', order: 3, rules: { profileContains: ['ESTACIONAMENTO'] },
+        children: [
+          { key: 'coberto', label: 'Coberto', order: 1, rules: { identifierContains: ['COB'] } },
+          { key: 'externo', label: 'Externo', role: 'fallback', order: 2 },
+        ] },
+      { key: 'outros', label: 'Outros', role: 'fallback', order: 9 },
+    ];
+    expect(validateTree(withParking)).toEqual([]);
+    expect(
+      resolveClassification({ deviceProfile: 'ESTACIONAMENTO_A', identifier: 'COB-1' }, withParking)?.nodePath,
+    ).toEqual(['estacionamento', 'coberto']);
+    expect(
+      resolveClassification({ deviceProfile: 'ESTACIONAMENTO_A', identifier: 'X' }, withParking)?.nodePath,
+    ).toEqual(['estacionamento', 'externo']);
+  });
+
+  it('resolveSubcategory é group-generic e devolve null quando o grupo não é subdividido', () => {
+    expect(
+      resolveSubcategory({ deviceProfile: 'CHILLER' }, 'climatizacao', treeWithChildren)?.nodePath,
+    ).toEqual(['climatizacao', 'chillers']);
+    expect(resolveSubcategory({ deviceProfile: '3F_MEDIDOR' }, 'lojas', treeWithChildren)).toBeNull();
+    expect(resolveSubcategory({ deviceProfile: 'X' }, 'inexistente', treeWithChildren)).toBeNull();
+  });
+
+  it('ocultos curto-circuita a árvore inteira', () => {
+    const r = resolveClassification({ deviceProfile: 'CHILLER_ARQUIVADO', identifier: 'CH-1' }, treeWithChildren);
+    expect(r?.key).toBe('ocultos');
+    expect(r?.matchedBy).toBe('ocultos');
+  });
+});


### PR DESCRIPTION
Implementa o RFC-0207 seguindo o backlog da seção **Estado verificado (auditoria 2026-07-23)**, que nasceu de um bug real: bomba hidráulica classificada como climatização no Moxuara, sem nenhum caminho pela UI para diagnosticar.

## Status do backlog

| # | Item | Status |
|---|---|---|
| 1 | Fechar Phase B (persistência) | **DONE** |
| 2 | Contrato de regras + laço do `labelWidget` | **DONE** |
| 3 | Seam v3 (`ProfileSource`, baked, sources concretos) | **DONE**, com uma lacuna declarada |
| 4 | Árvore v2 + walker genérico | **PARCIAL** — motor completo e golden-testado; caminho de produção **não** trocado |
| 5 | Goldens da §F (key-parity, order-sensitivity) | **DONE** |
| — | Separar RFC-0207 / abrir RFC-0208 | **NÃO** — decisão de governança |

## As duas decisões que precisam de aval

**Store da Phase B = TB SERVER_SCOPE (não GCDR).** A §E atribui à v3.1 o store `TB attr + baked`; só a v3.2 move para GCDR. Escolher GCDR agora recriaria o par assimétrico que a auditoria condena, ou exigiria o adaptador `entities ↔ ClassificationNode` que a própria §v3.2-G lista como trabalho de backend pendente. Load e save agora usam a mesma chave, escopo e entidade. `GcdrResolveProfileSource` está implementado **atrás de flag desligada**; o adaptador lança erro rotulado em vez de adivinhar topologia — adivinhar produziria classificação silenciosamente errada.

**`combinedContains` → expor, não remover.** Removê-lo mandaria `COMPRESSOR`/`VENTILADOR`/`CLIMATIZA` para `outros` sem substituto. Foi renomeado para **`profileContains`** e passa a ser renderizado no editor como "deviceProfile contém"; o handler órfão `cc` morreu.

**No mesmo passe, o texto combinado foi eliminado.** `combinedOf` era `labelWidget + deviceProfile + label`; agora casa contra `deviceProfile` apenas. Isso mata dois defeitos de uma vez: o laço circular do `labelWidget` (o classificador lia a própria saída anterior, então o padrão `CLIMATIZA` casava com o carimbo "Climatização" e se auto-sustentava) e o casamento por `label`, que as regras do projeto proíbem.

Compatibilidade: `normalizeProfile` migra `combinedContains` → `profileContains`, e `validateProfile` tolera a chave legada porque `resolveActiveProfile` valida **antes** de normalizar — então um cliente com perfil salvo (ex.: Mestre Álvaro) não é resetado para o DEFAULT.

## ⚠️ Mudanças de comportamento que exigem verificação manual

1. **Devices classificados apenas por `label`/`labelWidget` passam a cair em `outros`.** É a correção deliberada, mas o impacto é por cliente — vale conferir Moxuara e Mestre Álvaro antes do deploy.
2. **O botão "Salvar perfil" agora escreve de verdade** no atributo SERVER_SCOPE do customer. Antes lançava erro. **Este caminho nunca executou em produção** — testar com superadmin contra um customer de teste antes de liberar para operadores.
3. Novo hook `prebuild` (`gen-baked-profile --check`) quebra o build se o artefato gerado divergir do seed. Intencional, mas é um modo de falha novo.
4. `resolveCategory().matchedBy` emite `'profileContains'` onde emitia `'combined'`. Nenhum consumidor de produção lê `matchedBy`, mas confirmar telemetria.
5. Novo estado em `window.MyIOUtils`: `deviceClassificationProfileSource` e `deviceClassificationProfileDegraded`. Nada renderiza ainda — a §v3.2-F.4 diz que o piso baked nunca pode ser apresentado como verdade, então um badge de UI é follow-up natural.
6. O load do perfil no `onInit` virou `resolveWithFallback` (timeout 8s, piso baked). Não lança, e mantém branch legado para dashboards com bundle antigo. Observar os logs no primeiro deploy.
7. **Gate operacional:** o `dist` precisa ser publicado antes que os widgets enxerguem `resolveWithFallback`. Até lá roda o branch legado, com comportamento atual.

## Verificação

- **Suíte RFC-0207: 74/74** em 9 arquivos (baseline: 27 em 5). Novos: `profileContains` (9), `profileSource` (12), `treeWalker` (21), `keyParity` (5). Reconferido pelo revisor, não só pelo autor.
- Golden de equivalência do walker v2: **zero diff** nos 3 domínios (43 devices).
- `npm run build` OK, `verify-dts` OK. `node --check` OK nos 2 controllers.
- Suíte completa: 746 passed / 105 failed — **todas as 105 pré-existentes**, em 7 arquivos não tocados por esta branch (3 NODE-RED com `jest is not defined`, `deviceStatus`, `deviceStatusMyTest`, `format`, `deviceClassification` do RFC-0209).
- `npm run lint`: idêntico byte a byte ao baseline (o ESLint não cobre `.ts` neste projeto).

## Achado separado, pré-existente: o gate de bundle está estourado 222×

Não é causado por este PR, mas foi encontrado ao medi-lo:

| Arquivo | Atual | Limite | Excesso |
|---|---|---|---|
| `umd.min.js` | 5,29 MB | 25 KB | **222×** |
| `index.js` | 5,05 MB | 50 KB | **106×** |

A causa de passar despercebido: **`size-check` não faz parte do `npm run build`**. Delta deste PR: +10 KB raw / +2,9 KB gzip (0,19%). Merece issue própria.

## Por que o item 4 ficou parcial

O walker genérico, a árvore recursiva com `order` explícito, `liftProfileToTree` e `validateTree` estão prontos e golden-testados. Mas `resolveGroup`/`resolveCategory` **não** viraram aliases sobre o walker: o modelo v2 funde colunas e breakdown numa árvore só, e essa fusão não é neutra — um device cujo grupo é `entrada` mas cuja categoria v1 seria `climatizacao` (ex.: `RELOGIO` com identifier `CAG-1`) muda de resultado. O golden prova que o walker é fiel ao modelo v2, não que a troca é invisível. A troca precisa do seu próprio migration snapshot revisado por humano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
