### PR TITLE
feat(rfc-0227): guia Metas × Consumo — botão "?" + wizard mock (componente na lib)

### DIFF
--- a/src/components/metas-guide/index.ts
+++ b/src/components/metas-guide/index.ts
@@ -1,0 +1,31 @@
+/**
+ * RFC-0227: Metas × Consumo — "?" Help Button + Mock-Data Guided Tour (Wizard).
+ *
+ * Self-contained, reusable library component. The widget calls
+ * `MyIOLibrary.openMetasGuide(...)` and passes only theme / persistKey /
+ * callbacks — never fixture or adapter internals.
+ *
+ * @module metas-guide
+ */
+
+export { openMetasGuide } from './openMetasGuide';
+
+export {
+  DEFAULT_FIXTURES,
+  ENERGY_FIXTURES,
+  WATER_FIXTURES,
+  SERIES_COLORS,
+  FIXTURE_YEAR_PREV,
+  FIXTURE_YEAR_CUR,
+  deriveTotal,
+  computeChips,
+} from './metasGuideFixtures';
+
+export type {
+  MetasGuideOptions,
+  MetasGuideHandle,
+  MetasGuideTheme,
+  MetasGuideFixtures,
+  MetasGuideShoppingFixture,
+  MetasGuideSeries,
+} from './types';

--- a/src/components/metas-guide/metasGuideFixtures.ts
+++ b/src/components/metas-guide/metasGuideFixtures.ts
@@ -1,0 +1,158 @@
+/**
+ * RFC-0227: co-located MOCK fixtures for the Metas × Consumo guided tour.
+ *
+ * Two static, deterministic datasets — one energy (MWh) + one water (m³) — plus
+ * pure derivation helpers. NOTHING here touches the network, Chart.js, GCDR
+ * fetchers, `openGoalsCompare`, or `createCustomerGoalsCard`. Fase 1 = static
+ * snapshots only (RFC §P0/§4).
+ *
+ * KPIs and the consolidated Total are DERIVED from the per-bucket series so the
+ * illustrative numbers can never diverge (RFC §P1). Tests re-derive them.
+ */
+
+import type {
+  MetasGuideFixtures,
+  MetasGuideSeries,
+  MetasGuideShoppingFixture,
+} from './types';
+
+/**
+ * Series color map — MUST match the RFC-0217 card so the snapshot reads true
+ * against the real panel (RFC §2/§5).
+ */
+export const SERIES_COLORS = {
+  realizado: '#2563eb',
+  aMinus1: '#94a3b8',
+  orcado: '#f59e0b',
+  meta: '#7c3aed',
+} as const;
+
+/** Fixture illustration years (NOT the live control labels — see RFC §P1). */
+export const FIXTURE_YEAR_PREV = 2025;
+export const FIXTURE_YEAR_CUR = 2026;
+
+const MONTHS = ['Jan', 'Fev', 'Mar', 'Abr', 'Mai', 'Jun', 'Jul', 'Ago', 'Set', 'Out', 'Nov', 'Dez'];
+
+const sum = (arr: Array<number | null>): number =>
+  arr.reduce<number>((acc, v) => acc + (typeof v === 'number' ? v : 0), 0);
+
+/** Build a shopping fixture, deriving the period KPIs from the per-bucket series. */
+function makeShopping(
+  id: string,
+  name: string,
+  inaugurationDate: string,
+  series: MetasGuideSeries,
+): MetasGuideShoppingFixture {
+  return {
+    id,
+    name,
+    inaugurationDate,
+    aMinus1: Math.round(sum(series.aMinus1)),
+    realizado: Math.round(sum(series.realizado)),
+    orcado: Math.round(sum(series.orcado)),
+    meta: Math.round(sum(series.meta)),
+    labels: MONTHS.slice(),
+    series,
+  };
+}
+
+/** Sum every shopping into the consolidated Total row (pure). */
+export function deriveTotal(fx: Pick<MetasGuideFixtures, 'shoppings'>): {
+  aMinus1: number;
+  realizado: number;
+  orcado: number;
+  meta: number;
+} {
+  return fx.shoppings.reduce(
+    (acc, s) => ({
+      aMinus1: acc.aMinus1 + s.aMinus1,
+      realizado: acc.realizado + s.realizado,
+      orcado: acc.orcado + s.orcado,
+      meta: acc.meta + s.meta,
+    }),
+    { aMinus1: 0, realizado: 0, orcado: 0, meta: 0 },
+  );
+}
+
+/**
+ * Deviation chips for section 6 (pure). Signed ratios, e.g. +0.08 = 8% above.
+ * `vsRealizado` compares Orçado to Realizado (illustrative cross-series read).
+ */
+export function computeChips(s: MetasGuideShoppingFixture): {
+  vsAMinus1: number;
+  vsMeta: number;
+  vsOrcado: number;
+  vsRealizado: number;
+} {
+  return {
+    vsAMinus1: s.aMinus1 ? s.realizado / s.aMinus1 - 1 : 0,
+    vsMeta: s.meta ? s.realizado / s.meta - 1 : 0,
+    vsOrcado: s.orcado ? s.realizado / s.orcado - 1 : 0,
+    vsRealizado: s.realizado ? s.orcado / s.realizado - 1 : 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Energy dataset (MWh) — 3 shoppings. 8 realized months + 4 pending (null).
+// ---------------------------------------------------------------------------
+
+const ENERGY_SHOPPINGS: MetasGuideShoppingFixture[] = [
+  makeShopping('mock-sh-1', 'Shopping Aurora', '2015-03-12', {
+    aMinus1: [820, 780, 860, 900, 880, 950, 1010, 990, 940, 910, 870, 900],
+    realizado: [860, 815, 905, 940, 930, 995, 1055, 1030, null, null, null, null],
+    orcado: [840, 800, 880, 920, 900, 970, 1030, 1010, 960, 930, 890, 920],
+    meta: [800, 760, 840, 880, 860, 930, 990, 970, 920, 890, 850, 880],
+  }),
+  makeShopping('mock-sh-2', 'Shopping Bosque', '2019-08-01', {
+    aMinus1: [520, 500, 545, 570, 560, 600, 640, 630, 595, 580, 555, 575],
+    realizado: [505, 485, 528, 552, 545, 585, 620, 612, null, null, null, null],
+    orcado: [530, 510, 555, 580, 570, 610, 650, 640, 605, 590, 565, 585],
+    meta: [510, 490, 535, 560, 550, 590, 630, 620, 585, 570, 545, 565],
+  }),
+  makeShopping('mock-sh-3', 'Shopping Cristal', '2022-11-20', {
+    aMinus1: [310, 300, 325, 340, 335, 360, 385, 380, 355, 345, 330, 345],
+    realizado: [335, 322, 350, 366, 360, 388, 414, 408, null, null, null, null],
+    orcado: [315, 305, 330, 345, 340, 365, 390, 385, 360, 350, 335, 350],
+    meta: [305, 295, 320, 335, 330, 355, 380, 375, 350, 340, 325, 340],
+  }),
+];
+
+export const ENERGY_FIXTURES: MetasGuideFixtures = {
+  domain: 'energy',
+  unit: 'MWh',
+  fixtureYearPrev: FIXTURE_YEAR_PREV,
+  fixtureYearCur: FIXTURE_YEAR_CUR,
+  shoppings: ENERGY_SHOPPINGS,
+  total: deriveTotal({ shoppings: ENERGY_SHOPPINGS }),
+};
+
+// ---------------------------------------------------------------------------
+// Water dataset (m³) — 2 shoppings.
+// ---------------------------------------------------------------------------
+
+const WATER_SHOPPINGS: MetasGuideShoppingFixture[] = [
+  makeShopping('mock-wsh-1', 'Shopping Aurora', '2015-03-12', {
+    aMinus1: [4200, 3980, 4350, 4510, 4460, 4720, 4980, 4900, 4650, 4530, 4380, 4470],
+    realizado: [4020, 3820, 4180, 4330, 4290, 4540, 4790, 4710, null, null, null, null],
+    orcado: [4300, 4080, 4450, 4610, 4560, 4820, 5080, 5000, 4750, 4630, 4480, 4570],
+    meta: [4150, 3940, 4300, 4450, 4400, 4650, 4900, 4820, 4580, 4470, 4320, 4410],
+  }),
+  makeShopping('mock-wsh-2', 'Shopping Bosque', '2019-08-01', {
+    aMinus1: [2600, 2480, 2700, 2790, 2760, 2920, 3080, 3030, 2870, 2800, 2710, 2760],
+    realizado: [2520, 2410, 2620, 2705, 2680, 2830, 2985, 2940, null, null, null, null],
+    orcado: [2650, 2530, 2750, 2840, 2810, 2970, 3130, 3080, 2920, 2850, 2760, 2810],
+    meta: [2560, 2450, 2660, 2745, 2720, 2870, 3020, 2975, 2820, 2750, 2660, 2710],
+  }),
+];
+
+export const WATER_FIXTURES: MetasGuideFixtures = {
+  domain: 'water',
+  unit: 'm³',
+  fixtureYearPrev: FIXTURE_YEAR_PREV,
+  fixtureYearCur: FIXTURE_YEAR_CUR,
+  shoppings: WATER_SHOPPINGS,
+  total: deriveTotal({ shoppings: WATER_SHOPPINGS }),
+};
+
+/** Default dataset shown by the guide (energy). */
+export const DEFAULT_FIXTURES = ENERGY_FIXTURES;

--- a/src/components/metas-guide/openMetasGuide.ts
+++ b/src/components/metas-guide/openMetasGuide.ts
@@ -1,0 +1,753 @@
+/**
+ * RFC-0227: Metas × Consumo — "?" Help Button + Mock-Data Guided Tour (Wizard).
+ *
+ * `openMetasGuide` is a SELF-CONTAINED premium wizard. It owns its overlay,
+ * navigation, focus-trap/restore, HTML escaping and persistence — it does NOT
+ * depend on the `openOnboardModal` shell lifecycle (which has known defects:
+ * Esc-listener leak, HTMLElement-not-attached-on-first-render, no focus trap,
+ * no escaping — RFC §P0). The Academy premium look (purple header + footer) is
+ * replicated here so the shell stays untouched and its consumers unaffected.
+ *
+ * HARD CONSTRAINT: the guide NEVER performs a network request. Every section
+ * renders static, deterministic snapshots built from co-located fixtures. This
+ * is enforced by a no-network test (RFC §P0).
+ */
+
+import type { MetasGuideHandle, MetasGuideOptions, MetasGuideShoppingFixture, MetasGuideTheme } from './types';
+import {
+  DEFAULT_FIXTURES,
+  WATER_FIXTURES,
+  SERIES_COLORS,
+  computeChips,
+  deriveTotal,
+} from './metasGuideFixtures';
+
+const STYLE_ID = 'myio-metas-guide-styles';
+const ROOT_ID = 'myio-metas-guide-root';
+
+/** Academy purple fallback (matches the onboard shell header). */
+const FALLBACK_THEME: MetasGuideTheme = {
+  accent: '#6c5ce7',
+  accentDark: '#a29bfe',
+  accentText: '#ffffff',
+  mode: 'light',
+};
+
+// --------------------------------------------------------------------------
+// small pure helpers
+// --------------------------------------------------------------------------
+
+/** Escape untrusted text before it is interpolated into innerHTML (RFC §P0). */
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+const nfInt = new Intl.NumberFormat('pt-BR', { maximumFractionDigits: 0 });
+
+function fmtInt(n: number): string {
+  return nfInt.format(Math.round(n));
+}
+
+/** Signed pt-BR percentage, e.g. `+8,2%` / `-3,0%`. */
+function fmtPct(ratio: number): string {
+  const pct = ratio * 100;
+  const sign = pct > 0 ? '+' : pct < 0 ? '' : '';
+  return `${sign}${pct.toLocaleString('pt-BR', { maximumFractionDigits: 1 })}%`;
+}
+
+function resolveTheme(theme?: Partial<MetasGuideTheme>): MetasGuideTheme {
+  return {
+    accent: theme?.accent || FALLBACK_THEME.accent,
+    accentDark: theme?.accentDark || FALLBACK_THEME.accentDark,
+    accentText: theme?.accentText || FALLBACK_THEME.accentText,
+    mode: theme?.mode === 'dark' ? 'dark' : 'light',
+  };
+}
+
+// --------------------------------------------------------------------------
+// mock visual builders — pure HTML/SVG, zero Chart.js, zero network
+// --------------------------------------------------------------------------
+
+/** Small legend row shared across the card sections. */
+function legendHtml(): string {
+  const items: Array<[string, string]> = [
+    [SERIES_COLORS.aMinus1, 'A-1'],
+    [SERIES_COLORS.realizado, 'Realizado'],
+    [SERIES_COLORS.meta, 'Meta'],
+    [SERIES_COLORS.orcado, 'Orçado'],
+  ];
+  return `<div class="myio-mg-legend">${items
+    .map(
+      ([c, l]) =>
+        `<span class="myio-mg-legend__item"><span class="myio-mg-legend__dot" style="background:${c}" aria-hidden="true"></span>${escapeHtml(
+          l,
+        )}</span>`,
+    )
+    .join('')}</div>`;
+}
+
+/**
+ * Deterministic inline-SVG mini-chart: A-1 + Realizado as bars, Meta + Orçado
+ * as lines. No Chart.js, no ResizeObserver, no images — pure markup.
+ */
+function miniChartSvg(s: MetasGuideShoppingFixture): string {
+  const W = 320;
+  const H = 130;
+  const padB = 16;
+  const padT = 8;
+  const n = s.labels.length;
+  const all = [
+    ...s.series.aMinus1,
+    ...s.series.realizado.map((v) => (v == null ? 0 : v)),
+    ...s.series.meta,
+    ...s.series.orcado,
+  ];
+  const max = Math.max(1, ...all);
+  const plotH = H - padB - padT;
+  const bandW = W / n;
+  const barW = Math.max(3, bandW * 0.28);
+  const y = (v: number) => padT + plotH - (v / max) * plotH;
+
+  const bars = s.labels
+    .map((_, i) => {
+      const cx = i * bandW + bandW / 2;
+      const a1 = s.series.aMinus1[i] ?? 0;
+      const rz = s.series.realizado[i];
+      const x1 = cx - barW - 1;
+      const x2 = cx + 1;
+      const b1 = `<rect x="${x1.toFixed(1)}" y="${y(a1).toFixed(1)}" width="${barW.toFixed(
+        1,
+      )}" height="${(padT + plotH - y(a1)).toFixed(1)}" rx="1.5" fill="${SERIES_COLORS.aMinus1}"></rect>`;
+      const b2 =
+        rz == null
+          ? ''
+          : `<rect x="${x2.toFixed(1)}" y="${y(rz).toFixed(1)}" width="${barW.toFixed(
+              1,
+            )}" height="${(padT + plotH - y(rz)).toFixed(1)}" rx="1.5" fill="${SERIES_COLORS.realizado}"></rect>`;
+      return b1 + b2;
+    })
+    .join('');
+
+  const line = (data: number[], color: string) => {
+    const pts = data
+      .map((v, i) => `${(i * bandW + bandW / 2).toFixed(1)},${y(v).toFixed(1)}`)
+      .join(' ');
+    return `<polyline points="${pts}" fill="none" stroke="${color}" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"></polyline>`;
+  };
+
+  return `<svg class="myio-mg-chart" viewBox="0 0 ${W} ${H}" role="img" aria-label="Gráfico ilustrativo de ${escapeHtml(
+    s.name,
+  )}" preserveAspectRatio="none">
+    ${bars}
+    ${line(s.series.meta, SERIES_COLORS.meta)}
+    ${line(s.series.orcado, SERIES_COLORS.orcado)}
+  </svg>`;
+}
+
+function kpiRowHtml(s: MetasGuideShoppingFixture, unit: string): string {
+  const kpis: Array<[string, number, string]> = [
+    ['A-1', s.aMinus1, SERIES_COLORS.aMinus1],
+    ['Realizado', s.realizado, SERIES_COLORS.realizado],
+    ['Orçado', s.orcado, SERIES_COLORS.orcado],
+    ['Meta', s.meta, SERIES_COLORS.meta],
+  ];
+  return `<div class="myio-mg-kpis">${kpis
+    .map(
+      ([label, val, color]) => `<div class="myio-mg-kpi">
+        <span class="myio-mg-kpi__label" style="color:${color}">${escapeHtml(label)}</span>
+        <span class="myio-mg-kpi__value">${fmtInt(val)} <small>${escapeHtml(unit)}</small></span>
+      </div>`,
+    )
+    .join('')}</div>`;
+}
+
+function chipsHtml(s: MetasGuideShoppingFixture): string {
+  const c = computeChips(s);
+  const chip = (label: string, ratio: number) => {
+    const cls = ratio > 0 ? 'is-up' : ratio < 0 ? 'is-down' : 'is-flat';
+    return `<span class="myio-mg-chip ${cls}">${escapeHtml(label)} <strong>${escapeHtml(
+      fmtPct(ratio),
+    )}</strong></span>`;
+  };
+  return `<div class="myio-mg-chips">
+    ${chip('vs A-1', c.vsAMinus1)}
+    ${chip('vs Realizado', c.vsRealizado)}
+    ${chip('vs Meta', c.vsMeta)}
+  </div>`;
+}
+
+/** A compact illustrative card (chart + KPIs + chips). */
+function miniCardHtml(s: MetasGuideShoppingFixture, unit: string, opts?: { chart?: boolean; kpis?: boolean; chips?: boolean }): string {
+  const showChart = opts?.chart !== false;
+  const showKpis = opts?.kpis !== false;
+  const showChips = opts?.chips !== false;
+  return `<div class="myio-mg-card">
+    <h5 class="myio-mg-card__title">${escapeHtml(s.name)}</h5>
+    ${showChart ? legendHtml() + miniChartSvg(s) : ''}
+    ${showKpis ? kpiRowHtml(s, unit) : ''}
+    ${showChips ? chipsHtml(s) : ''}
+  </div>`;
+}
+
+/** Illustrative sidebar "Resumo por shopping" with a Total row. */
+function miniSidebarHtml(shoppings: MetasGuideShoppingFixture[], unit: string, prevY: number, curY: number): string {
+  const total = deriveTotal({ shoppings });
+  const row = (name: string, a: number, r: number, o: number, m: number, isTotal: boolean) => `
+    <div class="myio-mg-side__row${isTotal ? ' is-total' : ''}">
+      <span class="myio-mg-side__name">${escapeHtml(name)}</span>
+      <span class="myio-mg-side__vals">
+        <b style="color:${SERIES_COLORS.aMinus1}">${fmtInt(a)}</b>
+        <b style="color:${SERIES_COLORS.realizado}">${fmtInt(r)}</b>
+        <b style="color:${SERIES_COLORS.orcado}">${fmtInt(o)}</b>
+        <b style="color:${SERIES_COLORS.meta}">${fmtInt(m)}</b>
+      </span>
+    </div>`;
+  return `<div class="myio-mg-side">
+    <div class="myio-mg-side__head">
+      <span>Resumo por shopping</span>
+      <span class="myio-mg-side__unit">${escapeHtml(unit)}</span>
+    </div>
+    <div class="myio-mg-side__cols">
+      <span>Shopping</span>
+      <span class="myio-mg-side__vals">
+        <b style="color:${SERIES_COLORS.aMinus1}">${prevY}</b>
+        <b style="color:${SERIES_COLORS.realizado}">${curY}</b>
+        <b style="color:${SERIES_COLORS.orcado}">Orç.</b>
+        <b style="color:${SERIES_COLORS.meta}">Meta</b>
+      </span>
+    </div>
+    ${shoppings.map((s) => row(s.name, s.aMinus1, s.realizado, s.orcado, s.meta, false)).join('')}
+    ${row('Total', total.aMinus1, total.realizado, total.orcado, total.meta, true)}
+  </div>`;
+}
+
+/** Illustrative toolbar with the domain tabs, período, presets, view + ⚙️/? . */
+function miniToolbarHtml(prevY: number, curY: number, highlight?: string): string {
+  const hl = (key: string) => (highlight === key ? ' is-highlight' : '');
+  return `<div class="myio-mg-toolbar" aria-hidden="true">
+    <span class="myio-mg-tb__group${hl('domain')}"><span class="myio-mg-tb__pill is-on">⚡ Energia</span><span class="myio-mg-tb__pill">💧 Água</span></span>
+    <span class="myio-mg-tb__input${hl('period')}">📅 Período</span>
+    <span class="myio-mg-tb__group${hl('presets')}"><span class="myio-mg-tb__pill">Ano ${prevY}</span><span class="myio-mg-tb__pill">Ano ${curY}</span></span>
+    <span class="myio-mg-tb__group${hl('view')}"><span class="myio-mg-tb__pill is-on">📊 Dashboards</span><span class="myio-mg-tb__pill">📋 Analítico</span></span>
+    <span class="myio-mg-tb__icon${hl('engine')}">⚙️</span>
+    <span class="myio-mg-tb__icon${hl('help')}">?</span>
+  </div>`;
+}
+
+function bannerHtml(text: string): string {
+  return `<p class="myio-mg-banner">${escapeHtml(text)}</p>`;
+}
+
+function paras(sentences: string[]): string {
+  return `<div class="myio-mg-copy">${sentences.map((s) => `<p>${escapeHtml(s)}</p>`).join('')}</div>`;
+}
+
+// --------------------------------------------------------------------------
+// section model
+// --------------------------------------------------------------------------
+
+interface GuideSection {
+  id: string;
+  title: string;
+  render: () => string;
+}
+
+/**
+ * Build the 11 sections (RFC §Guide-level). Copy uses DYNAMIC live-control
+ * years (`curY`/`prevY` from getFullYear), while the fixtures illustrate their
+ * own years — the two are kept distinct (RFC §P1).
+ */
+function buildSections(ctx: {
+  energy: typeof DEFAULT_FIXTURES;
+  water: typeof WATER_FIXTURES;
+  curY: number;
+  prevY: number;
+}): GuideSection[] {
+  const { energy, water, curY, prevY } = ctx;
+  const e0 = energy.shoppings[0];
+  const w0 = water.shoppings[0];
+  const fxPrev = energy.fixtureYearPrev;
+  const fxCur = energy.fixtureYearCur;
+
+  return [
+    {
+      id: 'welcome',
+      title: 'Bem-vindo ao Metas × Consumo',
+      render: () =>
+        bannerHtml('Este é um guia com dados de exemplo — nada aqui é do seu cliente e nenhuma informação é enviada ou alterada.') +
+        paras([
+          'O painel Metas × Consumo compara, para cada shopping, o que foi realizado no ano atual contra a meta, o orçado e o ano anterior (A-1).',
+          'Ele serve a operadores e ao time comercial para acompanhar desempenho e desvios de energia e água.',
+          'Vamos percorrer cada parte do painel, do topo até a gestão de metas. Use Anterior / Próximo ou as setas do teclado.',
+        ]) +
+        miniToolbarHtml(prevY, curY),
+    },
+    {
+      id: 'domain',
+      title: 'Domínio: Energia e Água',
+      render: () =>
+        bannerHtml('As abas de domínio trocam toda a leitura do painel entre Energia (MWh) e Água (m³).') +
+        paras([
+          'A régua da meta muda por domínio: em Energia a referência é a ENTRADA; em Água, os hidrômetros.',
+          'Os números e a unidade de cada card acompanham o domínio selecionado.',
+        ]) +
+        miniToolbarHtml(prevY, curY, 'domain') +
+        `<div class="myio-mg-two">
+          <div><div class="myio-mg-two__tag">⚡ Energia · ${escapeHtml(energy.unit)}</div>${miniCardHtml(e0, energy.unit, { chips: false })}</div>
+          <div><div class="myio-mg-two__tag">💧 Água · ${escapeHtml(water.unit)}</div>${miniCardHtml(w0, water.unit, { chips: false })}</div>
+        </div>`,
+    },
+    {
+      id: 'period',
+      title: 'Período e presets de Ano',
+      render: () =>
+        bannerHtml('O input Período aceita qualquer intervalo; os presets de Ano são atalhos rápidos.') +
+        paras([
+          `Os presets aparecem com rótulos dinâmicos: "Ano ${prevY}" (ano anterior) e "Ano ${curY}" (ano atual) — eles seguem a data de hoje, não são fixos.`,
+          'O intervalo escolhido afeta a granularidade: até 15 dias o painel detalha por Dia/Hora.',
+          `Neste guia os exemplos ilustram ${fxPrev} vs ${fxCur}, apenas para você ver o formato.`,
+        ]) +
+        miniToolbarHtml(prevY, curY, 'period') +
+        miniToolbarHtml(prevY, curY, 'presets'),
+    },
+    {
+      id: 'views',
+      title: 'Dashboards × Analítico',
+      render: () =>
+        bannerHtml('Duas sub-abas mostram a mesma seleção de formas diferentes.') +
+        paras([
+          'Dashboards traz os gráficos e cards por shopping, dirigidos pela configuração do Engine.',
+          'Analítico traz a tabela do portfólio (Resumo Analítico) com os mesmos dados, ideal para leitura linha a linha.',
+        ]) +
+        miniToolbarHtml(prevY, curY, 'view'),
+    },
+    {
+      id: 'card-chart',
+      title: 'O card do shopping — gráfico',
+      render: () =>
+        bannerHtml('Cada card mostra quatro séries com cores fixas.') +
+        paras([
+          `As barras são consumo: A-1 (ano anterior) em cinza e Realizado (ano atual) em azul.`,
+          'As linhas são referências: Meta em roxo e Orçado em laranja.',
+          'Comparar a altura das barras azuis com as linhas mostra, mês a mês, se o realizado ficou acima ou abaixo da meta.',
+        ]) +
+        miniCardHtml(e0, energy.unit, { kpis: false, chips: false }),
+    },
+    {
+      id: 'card-kpis',
+      title: 'O card do shopping — KPIs e chips',
+      render: () => {
+        const c = computeChips(e0);
+        return (
+          bannerHtml('Abaixo do gráfico ficam os KPIs do período e os chips de desvio.') +
+          paras([
+            'Os KPIs consolidam o período: A-1, Realizado, Orçado e Meta.',
+            `Os chips leem o sinal do desvio: vs A-1 ${fmtPct(c.vsAMinus1)}, vs Realizado ${fmtPct(
+              c.vsRealizado,
+            )}, vs Meta ${fmtPct(c.vsMeta)}.`,
+            'Verde indica acima da referência e vermelho abaixo — a interpretação (bom/ruim) depende do domínio.',
+          ]) +
+          miniCardHtml(e0, energy.unit, { chart: false })
+        );
+      },
+    },
+    {
+      id: 'year-toggles',
+      title: 'Toggles de ano (👁)',
+      render: () =>
+        bannerHtml('Os ícones 👁 na legenda ligam e desligam séries no gráfico.') +
+        paras([
+          'Desligue A-1 para focar só no ano atual, ou desligue Realizado para inspecionar apenas as referências.',
+          'O painel nunca deixa as duas ocultas ao mesmo tempo — sempre resta uma série visível.',
+        ]) +
+        `<div class="myio-mg-toggles">
+          <span class="myio-mg-toggle is-on"><span aria-hidden="true">👁</span> A-1 <i style="background:${SERIES_COLORS.aMinus1}"></i></span>
+          <span class="myio-mg-toggle is-on"><span aria-hidden="true">👁</span> Realizado <i style="background:${SERIES_COLORS.realizado}"></i></span>
+        </div>` +
+        miniCardHtml(e0, energy.unit, { kpis: false, chips: false }),
+    },
+    {
+      id: 'sidebar',
+      title: 'Resumo por shopping (sidebar)',
+      render: () =>
+        bannerHtml('A lista lateral resume o portfólio inteiro em uma olhada.') +
+        paras([
+          `Por shopping ela mostra ${prevY}, ${curY}, Orçado e Meta com os respectivos deltas.`,
+          'A linha Total consolida todos os shoppings da seleção atual.',
+        ]) +
+        miniSidebarHtml(energy.shoppings, energy.unit, prevY, curY),
+    },
+    {
+      id: 'ordering',
+      title: 'Ordenar o resumo',
+      render: () =>
+        bannerHtml('Você controla a ordem e o filtro da sidebar.') +
+        paras([
+          'O botão de ordenação (ex.: "Data de Inauguração ↑") inverte a direção a cada clique.',
+          'O botão de filtros abre um modal para buscar, excluir shoppings e aplicar filtros rápidos.',
+        ]) +
+        `<div class="myio-mg-order">
+          <span class="myio-mg-order__btn">Data de Inauguração ↑ · ⚙️</span>
+          <span class="myio-mg-order__btn">▽ Filtros</span>
+        </div>` +
+        `<ul class="myio-mg-order__list">${energy.shoppings
+          .slice()
+          .sort((a, b) => a.inaugurationDate.localeCompare(b.inaugurationDate))
+          .map((s) => `<li><b>${escapeHtml(s.name)}</b> <span>inaugurado em ${escapeHtml(s.inaugurationDate)}</span></li>`)
+          .join('')}</ul>`,
+    },
+    {
+      id: 'engine',
+      title: 'Engine — gestão de metas',
+      render: () =>
+        bannerHtml('O botão ⚙️ Engine controla como os dados são agregados e exibidos.') +
+        paras([
+          'Nele você define granularidade, visão (consolidado × por shopping), tipo (cards, empilhado ou separado) e ordenação.',
+          'As escolhas podem ser salvas no seu usuário, para o painel reabrir já configurado.',
+        ]) +
+        `<div class="myio-mg-engine">
+          <div class="myio-mg-engine__row"><span>Granularidade</span><b>Mês</b></div>
+          <div class="myio-mg-engine__row"><span>Visão</span><b>Por shopping</b></div>
+          <div class="myio-mg-engine__row"><span>Tipo</span><b>Cards</b></div>
+          <div class="myio-mg-engine__row"><span>Ordenação</span><b>Inauguração ↑</b></div>
+          <div class="myio-mg-engine__save">💾 Salvar preferência</div>
+        </div>`,
+    },
+    {
+      id: 'export',
+      title: 'Exportar e finalizar',
+      render: () =>
+        bannerHtml('No topo da janela ficam as ações de exportação e aparência.') +
+        paras([
+          '⬇️ PDF exporta o painel atual; 🌙 alterna tema claro/escuro; ⛶ maximiza a janela.',
+          'É isso! Você pode reabrir este guia a qualquer momento pelo botão "?" ao lado do Engine.',
+        ]) +
+        `<div class="myio-mg-window-actions">
+          <span>🌙 Tema</span><span>⛶ Maximizar</span><span>⬇️ PDF</span><span>✕ Fechar</span>
+        </div>`,
+    },
+  ];
+}
+
+// --------------------------------------------------------------------------
+// styles
+// --------------------------------------------------------------------------
+
+function injectStyles(): void {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+  #${ROOT_ID}{position:fixed;inset:0;z-index:100001;display:flex;align-items:center;justify-content:center;padding:20px;background:rgba(15,23,42,.6);backdrop-filter:blur(4px);font-family:'Nunito',system-ui,sans-serif;}
+  #${ROOT_ID} *{box-sizing:border-box;}
+  .myio-mg-modal{--mg-surface:#fff;--mg-text:#1f2937;--mg-text2:#475569;--mg-muted:#64748b;--mg-border:#e2e8f0;--mg-chip:#f1f5f9;
+    width:760px;max-width:96vw;max-height:92vh;background:var(--mg-surface);color:var(--mg-text);border-radius:16px;overflow:hidden;display:flex;flex-direction:column;box-shadow:0 20px 60px rgba(0,0,0,.35);}
+  .myio-mg-modal.is-dark{--mg-surface:#0f172a;--mg-text:#e2e8f0;--mg-text2:#cbd5e1;--mg-muted:#94a3b8;--mg-border:#334155;--mg-chip:#1e293b;}
+  .myio-mg-header{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:18px 22px;background:linear-gradient(135deg,var(--mg-accent),var(--mg-accent-dark));color:var(--mg-accent-text);}
+  .myio-mg-header__l{display:flex;align-items:center;gap:12px;min-width:0;}
+  .myio-mg-header__logo{font-size:26px;}
+  .myio-mg-header__t{margin:0;font-size:18px;font-weight:800;}
+  .myio-mg-header__s{margin:0;font-size:12px;opacity:.85;font-weight:600;}
+  .myio-mg-close{background:rgba(255,255,255,.2);border:0;color:inherit;font-size:22px;width:34px;height:34px;border-radius:50%;cursor:pointer;line-height:1;flex-shrink:0;}
+  .myio-mg-close:hover{background:rgba(255,255,255,.32);}
+  .myio-mg-body{flex:1;overflow:auto;padding:20px 22px;min-height:220px;}
+  .myio-mg-banner{margin:0 0 14px;padding:10px 14px;border-radius:10px;font-size:13px;font-weight:700;color:var(--mg-accent);background:color-mix(in srgb, var(--mg-accent) 12%, transparent);border:1px solid color-mix(in srgb, var(--mg-accent) 30%, transparent);}
+  .myio-mg-copy p{margin:0 0 8px;font-size:14px;line-height:1.55;color:var(--mg-text2);}
+  .myio-mg-legend{display:flex;flex-wrap:wrap;gap:12px;margin:6px 0 8px;}
+  .myio-mg-legend__item{display:inline-flex;align-items:center;gap:6px;font-size:12px;font-weight:700;color:var(--mg-muted);}
+  .myio-mg-legend__dot{width:10px;height:10px;border-radius:50%;display:inline-block;}
+  .myio-mg-chart{width:100%;height:130px;display:block;margin-bottom:10px;}
+  .myio-mg-card{border:1px solid var(--mg-border);border-radius:12px;padding:14px;background:var(--mg-surface);}
+  .myio-mg-card__title{margin:0 0 8px;font-size:15px;font-weight:800;color:var(--mg-text);}
+  .myio-mg-kpis{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin-top:8px;}
+  .myio-mg-kpi{display:flex;flex-direction:column;gap:2px;padding:8px;border-radius:8px;background:var(--mg-chip);}
+  .myio-mg-kpi__label{font-size:11px;font-weight:800;text-transform:uppercase;letter-spacing:.4px;}
+  .myio-mg-kpi__value{font-size:14px;font-weight:800;color:var(--mg-text);}
+  .myio-mg-kpi__value small{font-size:10px;font-weight:700;color:var(--mg-muted);}
+  .myio-mg-chips{display:flex;flex-wrap:wrap;gap:8px;margin-top:10px;}
+  .myio-mg-chip{font-size:12px;font-weight:700;padding:4px 10px;border-radius:999px;background:var(--mg-chip);color:var(--mg-muted);border:1px solid var(--mg-border);}
+  .myio-mg-chip.is-up{color:#15803d;border-color:#86efac;background:rgba(34,197,94,.12);}
+  .myio-mg-chip.is-down{color:#b91c1c;border-color:#fca5a5;background:rgba(239,68,68,.12);}
+  .myio-mg-two{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-top:12px;}
+  .myio-mg-two__tag{font-size:12px;font-weight:800;margin-bottom:6px;color:var(--mg-text2);}
+  .myio-mg-toolbar{display:flex;flex-wrap:wrap;align-items:center;gap:8px;padding:10px;border:1px dashed var(--mg-border);border-radius:10px;margin-top:12px;background:var(--mg-chip);}
+  .myio-mg-tb__group{display:inline-flex;gap:3px;background:var(--mg-surface);border-radius:8px;padding:3px;}
+  .myio-mg-tb__pill{font-size:12px;font-weight:700;padding:4px 10px;border-radius:6px;color:var(--mg-muted);}
+  .myio-mg-tb__pill.is-on{background:var(--mg-accent);color:var(--mg-accent-text);}
+  .myio-mg-tb__input{font-size:12px;font-weight:700;padding:5px 10px;border:1px solid var(--mg-border);border-radius:8px;color:var(--mg-text2);background:var(--mg-surface);}
+  .myio-mg-tb__icon{width:30px;height:30px;display:inline-flex;align-items:center;justify-content:center;border:1px solid var(--mg-accent);border-radius:8px;color:var(--mg-accent);font-weight:800;}
+  .myio-mg-toolbar .is-highlight{outline:3px solid color-mix(in srgb, var(--mg-accent) 55%, transparent);outline-offset:2px;border-radius:10px;}
+  .myio-mg-side{border:1px solid var(--mg-border);border-radius:12px;overflow:hidden;margin-top:12px;}
+  .myio-mg-side__head{display:flex;justify-content:space-between;padding:10px 14px;font-weight:800;font-size:13px;background:var(--mg-chip);color:var(--mg-text);}
+  .myio-mg-side__unit{color:var(--mg-muted);font-weight:700;}
+  .myio-mg-side__cols{display:flex;justify-content:space-between;padding:6px 14px;font-size:11px;font-weight:800;color:var(--mg-muted);border-bottom:1px solid var(--mg-border);}
+  .myio-mg-side__row{display:flex;justify-content:space-between;align-items:center;padding:9px 14px;font-size:13px;border-bottom:1px solid var(--mg-border);}
+  .myio-mg-side__row.is-total{font-weight:900;background:var(--mg-chip);border-bottom:0;}
+  .myio-mg-side__name{font-weight:700;color:var(--mg-text);}
+  .myio-mg-side__vals{display:inline-flex;gap:12px;}
+  .myio-mg-side__vals b{font-size:12px;min-width:44px;text-align:right;}
+  .myio-mg-toggles{display:flex;gap:10px;margin:6px 0 10px;}
+  .myio-mg-toggle{display:inline-flex;align-items:center;gap:6px;font-size:12px;font-weight:700;padding:5px 10px;border-radius:999px;border:1px solid var(--mg-border);color:var(--mg-text2);}
+  .myio-mg-toggle i{width:10px;height:10px;border-radius:2px;display:inline-block;}
+  .myio-mg-order{display:flex;gap:8px;margin-top:12px;}
+  .myio-mg-order__btn{font-size:12px;font-weight:700;padding:6px 12px;border-radius:8px;border:1px solid var(--mg-accent);color:var(--mg-accent);}
+  .myio-mg-order__list{list-style:none;margin:10px 0 0;padding:0;}
+  .myio-mg-order__list li{display:flex;justify-content:space-between;padding:8px 12px;border:1px solid var(--mg-border);border-radius:8px;margin-bottom:6px;font-size:13px;}
+  .myio-mg-order__list span{color:var(--mg-muted);font-size:12px;}
+  .myio-mg-engine{border:1px solid var(--mg-border);border-radius:12px;padding:12px;margin-top:12px;}
+  .myio-mg-engine__row{display:flex;justify-content:space-between;padding:7px 4px;border-bottom:1px solid var(--mg-border);font-size:13px;color:var(--mg-text2);}
+  .myio-mg-engine__row b{color:var(--mg-text);}
+  .myio-mg-engine__save{margin-top:10px;text-align:center;font-weight:800;font-size:13px;padding:8px;border-radius:8px;background:var(--mg-accent);color:var(--mg-accent-text);}
+  .myio-mg-window-actions{display:flex;flex-wrap:wrap;gap:10px;margin-top:12px;}
+  .myio-mg-window-actions span{font-size:13px;font-weight:700;padding:8px 14px;border-radius:8px;border:1px solid var(--mg-border);color:var(--mg-text2);}
+  .myio-mg-footer{border-top:1px solid var(--mg-border);padding:14px 22px;display:flex;flex-direction:column;gap:12px;background:var(--mg-chip);}
+  .myio-mg-nav{display:flex;align-items:center;justify-content:space-between;gap:12px;}
+  .myio-mg-progress{font-size:12px;font-weight:800;color:var(--mg-muted);}
+  .myio-mg-dots{display:inline-flex;gap:5px;margin-left:8px;}
+  .myio-mg-dot{width:7px;height:7px;border-radius:50%;background:var(--mg-border);}
+  .myio-mg-dot.is-on{background:var(--mg-accent);}
+  .myio-mg-nav__r{display:flex;gap:8px;}
+  .myio-mg-btn{font-family:inherit;font-size:13px;font-weight:800;padding:8px 16px;border-radius:8px;cursor:pointer;border:1px solid var(--mg-accent);background:transparent;color:var(--mg-accent);}
+  .myio-mg-btn:hover{background:color-mix(in srgb, var(--mg-accent) 12%, transparent);}
+  .myio-mg-btn.is-primary{background:var(--mg-accent);color:var(--mg-accent-text);border-color:var(--mg-accent);}
+  .myio-mg-btn.is-ghost{border-color:transparent;color:var(--mg-muted);}
+  .myio-mg-btn:disabled{opacity:.4;cursor:not-allowed;}
+  .myio-mg-persist{display:flex;align-items:center;gap:8px;font-size:12px;font-weight:700;color:var(--mg-muted);}
+  .myio-mg-persist input{width:15px;height:15px;accent-color:var(--mg-accent);}
+  .myio-mg-academy{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:10px;padding-top:10px;border-top:1px solid var(--mg-border);}
+  .myio-mg-academy__brand{display:inline-flex;align-items:center;gap:8px;font-size:13px;font-weight:800;color:var(--mg-text2);}
+  .myio-mg-academy__links{display:inline-flex;gap:10px;flex-wrap:wrap;}
+  .myio-mg-academy__links a{font-size:12px;font-weight:700;color:var(--mg-muted);text-decoration:none;padding:4px 10px;border-radius:6px;border:1px solid var(--mg-border);}
+  .myio-mg-academy__links a:hover{color:var(--mg-accent);border-color:var(--mg-accent);}
+  @media (max-width:640px){
+    .myio-mg-kpis{grid-template-columns:repeat(2,1fr);}
+    .myio-mg-two{grid-template-columns:1fr;}
+  }`;
+  document.head.appendChild(style);
+}
+
+// --------------------------------------------------------------------------
+// public API
+// --------------------------------------------------------------------------
+
+/**
+ * Open the Metas × Consumo guided tour (self-contained, mock-data, no network).
+ *
+ * @returns a handle compatible with `OnboardModalHandle` (+ `goToStep`).
+ */
+export function openMetasGuide(options: MetasGuideOptions = {}): MetasGuideHandle {
+  const theme = resolveTheme(options.theme);
+  const energy = options.mockData || DEFAULT_FIXTURES;
+  const water = options.mockDataWater || WATER_FIXTURES;
+  const now = new Date();
+  const curY = now.getFullYear();
+  const prevY = curY - 1;
+  const sections = buildSections({ energy, water, curY, prevY });
+  const total = sections.length;
+
+  // Remove any stray previous instance (idempotent open).
+  document.getElementById(ROOT_ID)?.remove();
+
+  injectStyles();
+
+  const previouslyFocused = document.activeElement as HTMLElement | null;
+  let index = 0;
+  let closed = false;
+
+  const root = document.createElement('div');
+  root.id = ROOT_ID;
+  root.innerHTML = `
+    <div class="myio-mg-modal${theme.mode === 'dark' ? ' is-dark' : ''}" role="dialog" aria-modal="true"
+         aria-labelledby="myio-mg-title"
+         style="--mg-accent:${escapeHtml(theme.accent)};--mg-accent-dark:${escapeHtml(
+           theme.accentDark,
+         )};--mg-accent-text:${escapeHtml(theme.accentText)};">
+      <div class="myio-mg-header">
+        <div class="myio-mg-header__l">
+          <span class="myio-mg-header__logo" aria-hidden="true">🎓</span>
+          <div>
+            <h2 class="myio-mg-header__t" id="myio-mg-title"></h2>
+            <p class="myio-mg-header__s">Guia do painel Metas × Consumo</p>
+          </div>
+        </div>
+        <button type="button" class="myio-mg-close" data-mg-close aria-label="Fechar guia">&times;</button>
+      </div>
+      <div class="myio-mg-body" data-mg-body></div>
+      <div class="myio-mg-footer">
+        <div class="myio-mg-nav">
+          <div class="myio-mg-progress" data-mg-progress aria-live="polite"></div>
+          <div class="myio-mg-nav__r">
+            <button type="button" class="myio-mg-btn is-ghost" data-mg-skip aria-label="Pular guia">Pular</button>
+            <button type="button" class="myio-mg-btn" data-mg-prev aria-label="Seção anterior">◀ Anterior</button>
+            <button type="button" class="myio-mg-btn is-primary" data-mg-next aria-label="Próxima seção">Próximo ▶</button>
+          </div>
+        </div>
+        <label class="myio-mg-persist" data-mg-persist-wrap hidden>
+          <input type="checkbox" data-mg-persist> Não mostrar novamente
+        </label>
+        <div class="myio-mg-academy">
+          <span class="myio-mg-academy__brand"><span aria-hidden="true">🎓</span> MYIO Academy</span>
+          <span class="myio-mg-academy__links">
+            <a href="https://academy.myio.com.br/tutoriais" target="_blank" rel="noopener noreferrer">📚 Tutoriais</a>
+            <a href="https://academy.myio.com.br/docs" target="_blank" rel="noopener noreferrer">📖 Documentação</a>
+            <a href="https://academy.myio.com.br/suporte" target="_blank" rel="noopener noreferrer">💬 Suporte</a>
+          </span>
+        </div>
+      </div>
+    </div>`;
+
+  const modal = root.querySelector('.myio-mg-modal') as HTMLElement;
+  const titleEl = root.querySelector('#myio-mg-title') as HTMLElement;
+  const bodyEl = root.querySelector('[data-mg-body]') as HTMLElement;
+  const progressEl = root.querySelector('[data-mg-progress]') as HTMLElement;
+  const prevBtn = root.querySelector('[data-mg-prev]') as HTMLButtonElement;
+  const nextBtn = root.querySelector('[data-mg-next]') as HTMLButtonElement;
+  const skipBtn = root.querySelector('[data-mg-skip]') as HTMLButtonElement;
+  const closeBtn = root.querySelector('[data-mg-close]') as HTMLButtonElement;
+  const persistWrap = root.querySelector('[data-mg-persist-wrap]') as HTMLElement;
+  const persistBox = root.querySelector('[data-mg-persist]') as HTMLInputElement;
+
+  function maybePersist(): void {
+    // Never writes without BOTH an explicit persistKey and the ticked box.
+    if (!options.persistKey || !persistBox.checked) return;
+    try {
+      window.localStorage.setItem(options.persistKey, JSON.stringify({ seen: true, at: Date.now() }));
+    } catch {
+      /* storage unavailable — silently ignore */
+    }
+  }
+
+  function close(): void {
+    if (closed) return;
+    closed = true;
+    maybePersist();
+    document.removeEventListener('keydown', onKeyDown, true);
+    root.remove();
+    // Restore focus to the opener (the "?" button) per RFC §7.
+    if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+      previouslyFocused.focus();
+    }
+    options.onClose?.();
+  }
+
+  function render(): void {
+    const section = sections[index];
+    titleEl.textContent = section.title;
+    bodyEl.innerHTML = section.render();
+    bodyEl.scrollTop = 0;
+
+    const isLast = index === total - 1;
+    const isFirst = index === 0;
+    prevBtn.disabled = isFirst;
+    nextBtn.textContent = isLast ? 'Concluir' : 'Próximo ▶';
+    nextBtn.setAttribute('aria-label', isLast ? 'Concluir guia' : 'Próxima seção');
+
+    const dots = sections
+      .map((_, i) => `<span class="myio-mg-dot${i === index ? ' is-on' : ''}"></span>`)
+      .join('');
+    progressEl.innerHTML = `${index + 1} / ${total}<span class="myio-mg-dots" aria-hidden="true">${dots}</span>`;
+    progressEl.setAttribute('aria-label', `Passo ${index + 1} de ${total}: ${section.title}`);
+
+    // "Não mostrar novamente" only on the last section, only when opt-in enabled.
+    persistWrap.hidden = !(isLast && !!options.persistKey);
+  }
+
+  function goToStep(target: number): void {
+    if (closed) return;
+    const clamped = Math.max(0, Math.min(total - 1, target));
+    if (clamped === index) return;
+    index = clamped;
+    render();
+  }
+
+  function next(): void {
+    if (index === total - 1) {
+      options.onFinish?.();
+      close();
+      return;
+    }
+    goToStep(index + 1);
+  }
+
+  function prev(): void {
+    goToStep(index - 1);
+  }
+
+  function focusables(): HTMLElement[] {
+    return Array.from(
+      modal.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), a[href], input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    ).filter((el) => el.offsetParent !== null || el === document.activeElement);
+  }
+
+  function onKeyDown(e: KeyboardEvent): void {
+    if (closed) return;
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+      return;
+    }
+    if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      next();
+      return;
+    }
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      prev();
+      return;
+    }
+    if (e.key === 'Tab') {
+      // Focus trap.
+      const els = focusables();
+      if (els.length === 0) return;
+      const first = els[0];
+      const last = els[els.length - 1];
+      const active = document.activeElement as HTMLElement;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+
+  // Wire events.
+  nextBtn.addEventListener('click', next);
+  prevBtn.addEventListener('click', prev);
+  skipBtn.addEventListener('click', close);
+  closeBtn.addEventListener('click', close);
+  root.addEventListener('click', (e) => {
+    if (e.target === root) close(); // backdrop
+  });
+  document.addEventListener('keydown', onKeyDown, true);
+
+  document.body.appendChild(root);
+  render();
+
+  // Initial focus inside the dialog (RFC §7).
+  nextBtn.focus();
+
+  return {
+    close,
+    getElement: () => (closed ? null : modal),
+    setContent: (content: string | HTMLElement) => {
+      if (closed) return;
+      if (typeof content === 'string') {
+        bodyEl.innerHTML = content;
+      } else {
+        bodyEl.innerHTML = '';
+        bodyEl.appendChild(content);
+      }
+    },
+    goToStep,
+  };
+}

--- a/src/components/metas-guide/types.ts
+++ b/src/components/metas-guide/types.ts
@@ -1,0 +1,109 @@
+/**
+ * RFC-0227: Metas × Consumo — "?" Help Button + Mock-Data Guided Tour (Wizard)
+ *
+ * Public types for the self-contained `openMetasGuide` wizard.
+ *
+ * The guide runs 100% on self-contained MOCK fixtures — it NEVER performs a
+ * network request. See `metasGuideFixtures.ts` for the illustrative data.
+ */
+
+/** Theme inherited from the host panel (Metas × Consumo `--gc-*` vars / `GP`). */
+export interface MetasGuideTheme {
+  /** Primary accent (e.g. `GP.accent`). */
+  accent: string;
+  /** Darker accent used on the header gradient (e.g. `GP.accentDark`). */
+  accentDark: string;
+  /** Foreground color used over the accent (e.g. `GP.accentText`). */
+  accentText: string;
+  /** Light / dark surface mode. */
+  mode: 'light' | 'dark';
+}
+
+/** Time-series (per bucket) for one mock shopping, for the mini-chart. */
+export interface MetasGuideSeries {
+  /** A-1 (previous year) consumption, per bucket. */
+  aMinus1: number[];
+  /** Realizado (current year) consumption, per bucket; `null` = not yet realized. */
+  realizado: (number | null)[];
+  /** Orçado (budget) line, per bucket. */
+  orcado: number[];
+  /** Meta (adjusted budget) line, per bucket. */
+  meta: number[];
+}
+
+/** One fictitious shopping used to illustrate the panel. */
+export interface MetasGuideShoppingFixture {
+  /** Stable mock id (e.g. `mock-sh-1`). */
+  id: string;
+  /** Fictitious display name (e.g. `Shopping Aurora`). */
+  name: string;
+  /** `YYYY-MM-DD` — illustrates the "Data de Inauguração" ordering control. */
+  inaugurationDate: string;
+  /** Period KPI: A-1 (previous year) — energy in MWh, water in m³. */
+  aMinus1: number;
+  /** Period KPI: Realizado (current year). */
+  realizado: number;
+  /** Period KPI: Orçado (raw budget value). */
+  orcado: number;
+  /** Period KPI: Meta (adjusted value = Orçado × margin). */
+  meta: number;
+  /** Bucket labels shared by the 4 series (e.g. `['Jan','Fev',...]`). */
+  labels: string[];
+  /** Per-bucket series for the mini-chart. */
+  series: MetasGuideSeries;
+}
+
+/** A complete mock dataset for one domain (energy or water). */
+export interface MetasGuideFixtures {
+  domain: 'energy' | 'water';
+  unit: 'MWh' | 'm³';
+  /**
+   * Fixture years used ONLY to illustrate the snapshots. Live control labels
+   * are derived dynamically from `new Date().getFullYear()` in the tour copy
+   * (RFC §P1 — "Ano anterior / Ano atual", never hardcoded).
+   */
+  fixtureYearPrev: number;
+  fixtureYearCur: number;
+  shoppings: MetasGuideShoppingFixture[];
+  /**
+   * Consolidated "Total" row. MUST equal the sum of `shoppings` (see
+   * `deriveTotal`). Tests derive from `shoppings` so numbers never diverge.
+   */
+  total: { aMinus1: number; realizado: number; orcado: number; meta: number };
+}
+
+/** Options accepted by `openMetasGuide`. The widget passes only these. */
+export interface MetasGuideOptions {
+  /** Inherit the host panel theme; fallback = Academy purple. */
+  theme?: Partial<MetasGuideTheme>;
+  /** Override the mock dataset (default = embedded energy + water fixtures). */
+  mockData?: MetasGuideFixtures;
+  /**
+   * Water dataset override (used by the domain section). Defaults to the
+   * embedded water fixtures.
+   */
+  mockDataWater?: MetasGuideFixtures;
+  /**
+   * Enables the opt-in "não mostrar novamente" checkbox. When present AND the
+   * user ticks the box, the guide writes this key to `localStorage`. Without a
+   * `persistKey`, or without the tick, the guide NEVER writes.
+   * e.g. `myio:metas-guide:seen:v1`
+   */
+  persistKey?: string;
+  /** Called after the guide fully closes. */
+  onClose?: () => void;
+  /** Called when the user reaches "Concluir" on the last section. */
+  onFinish?: () => void;
+}
+
+/** Handle returned by `openMetasGuide` — compatible with `OnboardModalHandle`. */
+export interface MetasGuideHandle {
+  /** Close and dispose the guide (restores focus to the opener). */
+  close: () => void;
+  /** Replace the body of the current section (compat shim). */
+  setContent: (content: string | HTMLElement) => void;
+  /** Root modal element, or `null` once closed. */
+  getElement: () => HTMLElement | null;
+  /** Jump to a section by 0-based index. */
+  goToStep: (index: number) => void;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1259,6 +1259,25 @@ export { openOnboardModal, openTutorialModal, openHelpModal, OnboardModalView } 
 
 export type { OnboardModalConfig, OnboardModalHandle, OnboardFooterLink } from './components/onboard';
 
+// RFC-0227: Metas × Consumo — "?" Help Button + Mock-Data Guided Tour (Wizard)
+export {
+  openMetasGuide,
+  DEFAULT_FIXTURES as MetasGuideDefaultFixtures,
+  WATER_FIXTURES as MetasGuideWaterFixtures,
+  SERIES_COLORS as MetasGuideSeriesColors,
+  deriveTotal as metasGuideDeriveTotal,
+  computeChips as metasGuideComputeChips,
+} from './components/metas-guide';
+
+export type {
+  MetasGuideOptions,
+  MetasGuideHandle,
+  MetasGuideTheme,
+  MetasGuideFixtures,
+  MetasGuideShoppingFixture,
+  MetasGuideSeries,
+} from './components/metas-guide';
+
 // RFC-0139: HeaderShopping Component (Shopping Dashboard toolbar)
 export { createHeaderShoppingComponent } from './components/header-shopping';
 export { HeaderShoppingView, injectHeaderShoppingStyles } from './components/header-shopping';

--- a/src/thingsboard/MYIO-SIM/v5.2.0_UNIQUE/controller.js
+++ b/src/thingsboard/MYIO-SIM/v5.2.0_UNIQUE/controller.js
@@ -4058,6 +4058,7 @@ body.filter-modal-open { overflow: hidden !important; }
                 <button type="button" data-view="analitico" title="Tabela do portfólio (Resumo Analítico) da mesma seleção do Engine" style="border:0;border-radius:6px;padding:6px 16px;cursor:pointer;font:700 13px Nunito,sans-serif;">📋 Analítico</button>
               </div>
               <button type="button" data-engine title="Engine — granularidade, visão, tipo e ordenação" aria-label="Engine" style="border:1px solid ${GP.tint(45)};border-radius:8px;background:transparent;color:${GP.accent};padding:6px 12px;cursor:pointer;font:700 15px Nunito,sans-serif;line-height:1;">⚙️</button>
+              <button type="button" data-help title="Como usar este painel — guia passo a passo" aria-label="Como usar este painel — guia passo a passo" style="border:1px solid ${GP.tint(45)};border-radius:8px;background:transparent;color:${GP.accent};padding:6px 12px;cursor:pointer;font:700 15px Nunito,sans-serif;line-height:1;">?</button>
               <span data-evo-status style="margin-left:auto;font:600 12px Nunito,sans-serif;color:var(--gc-muted);"></span>
               <span data-status hidden style="display:none;"></span>
             </div>
@@ -7164,6 +7165,20 @@ body.myio-gbt-dark .myio-gbt__empty{color:#64748b;}
       }
       // ⚙️ Engine: abre o modal de configuração (granularidade/visão/tipo/ordenação/salvar).
       if (e.target.closest('[data-engine]')) return void openEngineModal();
+      // ❓ Ajuda (RFC-0227): tour guiado em dados MOCK. Toda a lógica vive na lib
+      // (MyIOLibrary.openMetasGuide); aqui só disparamos com tema/persistKey.
+      if (e.target.closest('[data-help]')) {
+        const helpTheme = { accent: GP.accent, accentDark: GP.accentDark, accentText: GP.accentText, mode: modalTheme };
+        if (MyIOLibrary?.openMetasGuide) {
+          return void MyIOLibrary.openMetasGuide({ theme: helpTheme, persistKey: 'myio:metas-guide:seen:v1' });
+        }
+        // Fallback mínimo caso o símbolo não exista na lib carregada.
+        return void MyIOLibrary?.openOnboardModal?.({
+          title: 'Guia — Metas × Consumo',
+          content: '<p style="font:600 14px Nunito,sans-serif;">O guia interativo não está disponível nesta versão da biblioteca. Atualize o MyIOLibrary para ver o passo a passo do painel.</p>',
+          width: 520,
+        });
+      }
       // Abas superiores Dashboards | Analítico — ambas dirigidas pela config do Engine.
       const viewBtn = e.target.closest('[data-view]');
       if (viewBtn && viewBtn.dataset.view !== engView) {

--- a/tests/metasGuide.nonetwork.test.ts
+++ b/tests/metasGuide.nonetwork.test.ts
@@ -1,0 +1,131 @@
+/**
+ * RFC-0227 §P0 — "sem rede" é CONTRATO DE TESTE.
+ *
+ * This suite stubs every network primitive (fetch, XMLHttpRequest, Image,
+ * sendBeacon, WebSocket, EventSource) and FAILS if opening or navigating the
+ * guide fires ANY request. Footer "MYIO Academy" links must stay inert until an
+ * explicit user click.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { openMetasGuide } from '../src/components/metas-guide';
+
+const ROOT = '#myio-metas-guide-root';
+
+let violations: string[];
+
+function guardNetwork(): void {
+  violations = [];
+
+  // fetch
+  (global as any).fetch = vi.fn((...args: any[]) => {
+    violations.push(`fetch(${String(args[0])})`);
+    return Promise.reject(new Error('network blocked'));
+  });
+  (window as any).fetch = (global as any).fetch;
+
+  // XMLHttpRequest
+  class BlockedXHR {
+    open(_method: string, url: string) {
+      violations.push(`XHR.open(${url})`);
+    }
+    send() {
+      violations.push('XHR.send()');
+    }
+    setRequestHeader() {}
+    addEventListener() {}
+    abort() {}
+  }
+  (global as any).XMLHttpRequest = BlockedXHR as any;
+  (window as any).XMLHttpRequest = BlockedXHR as any;
+
+  // Image loading (data-uri / remote)
+  const RealImage = (global as any).Image;
+  class BlockedImage {
+    private _src = '';
+    set src(v: string) {
+      violations.push(`Image.src(${v})`);
+      this._src = v;
+    }
+    get src() {
+      return this._src;
+    }
+  }
+  (global as any).Image = BlockedImage as any;
+  (window as any).Image = BlockedImage as any;
+  void RealImage;
+
+  // beacon / websocket / SSE
+  if (navigator) {
+    (navigator as any).sendBeacon = vi.fn((url: string) => {
+      violations.push(`sendBeacon(${url})`);
+      return false;
+    });
+  }
+  (global as any).WebSocket = class {
+    constructor(url: string) {
+      violations.push(`WebSocket(${url})`);
+    }
+  } as any;
+  (global as any).EventSource = class {
+    constructor(url: string) {
+      violations.push(`EventSource(${url})`);
+    }
+  } as any;
+}
+
+beforeEach(() => {
+  guardNetwork();
+});
+
+afterEach(() => {
+  document.querySelectorAll(ROOT).forEach((el) => el.remove());
+  vi.restoreAllMocks();
+});
+
+describe('RFC-0227 no-network contract', () => {
+  it('fires ZERO requests when opening the guide', () => {
+    const handle = openMetasGuide();
+    expect(document.querySelector(ROOT)).not.toBeNull();
+    expect(violations, `unexpected requests: ${violations.join(', ')}`).toEqual([]);
+    handle.close();
+  });
+
+  it('fires ZERO requests while navigating all 11 sections (forward + back)', () => {
+    const handle = openMetasGuide();
+    const nextBtn = document.querySelector<HTMLButtonElement>('[data-mg-next]')!;
+    const prevBtn = document.querySelector<HTMLButtonElement>('[data-mg-prev]')!;
+
+    // walk forward to the last section
+    for (let i = 0; i < 10; i++) nextBtn.click();
+    // and back to the first
+    for (let i = 0; i < 10; i++) prevBtn.click();
+
+    expect(violations, `unexpected requests: ${violations.join(', ')}`).toEqual([]);
+    handle.close();
+  });
+
+  it('fires ZERO requests on keyboard navigation', () => {
+    const handle = openMetasGuide();
+    for (let i = 0; i < 12; i++) {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+    }
+    for (let i = 0; i < 12; i++) {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
+    }
+    expect(violations, `unexpected requests: ${violations.join(', ')}`).toEqual([]);
+    handle.close();
+  });
+
+  it('footer MYIO Academy links are inert (no auto-navigation) until clicked', () => {
+    const handle = openMetasGuide();
+    const links = document.querySelectorAll<HTMLAnchorElement>('.myio-mg-academy__links a');
+    expect(links.length).toBeGreaterThan(0);
+    // links exist but nothing was requested by merely rendering them
+    links.forEach((a) => {
+      expect(a.target).toBe('_blank');
+      expect(a.rel).toContain('noopener');
+    });
+    expect(violations).toEqual([]);
+    handle.close();
+  });
+});

--- a/tests/metasGuide.test.ts
+++ b/tests/metasGuide.test.ts
@@ -1,0 +1,240 @@
+/**
+ * RFC-0227 — Metas × Consumo guided tour: behavior, fixtures, persistence, a11y.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  openMetasGuide,
+  ENERGY_FIXTURES,
+  WATER_FIXTURES,
+  deriveTotal,
+  computeChips,
+  SERIES_COLORS,
+} from '../src/components/metas-guide';
+
+const ROOT = '#myio-metas-guide-root';
+const TOTAL_SECTIONS = 11;
+
+function q<T extends Element = HTMLElement>(sel: string): T {
+  const el = document.querySelector<T>(sel);
+  if (!el) throw new Error(`missing element: ${sel}`);
+  return el;
+}
+
+afterEach(() => {
+  document.querySelectorAll(ROOT).forEach((el) => el.remove());
+  try {
+    window.localStorage.clear();
+  } catch {
+    /* ignore */
+  }
+});
+
+describe('fixtures — derivation (no divergent pre-computed numbers)', () => {
+  it('energy KPIs equal the sum of their per-bucket series', () => {
+    for (const s of ENERGY_FIXTURES.shoppings) {
+      const sum = (arr: Array<number | null>) =>
+        arr.reduce<number>((a, v) => a + (typeof v === 'number' ? v : 0), 0);
+      expect(s.aMinus1).toBe(Math.round(sum(s.series.aMinus1)));
+      expect(s.realizado).toBe(Math.round(sum(s.series.realizado)));
+      expect(s.orcado).toBe(Math.round(sum(s.series.orcado)));
+      expect(s.meta).toBe(Math.round(sum(s.series.meta)));
+    }
+  });
+
+  it('the declared Total equals deriveTotal(shoppings) for both datasets', () => {
+    expect(ENERGY_FIXTURES.total).toEqual(deriveTotal(ENERGY_FIXTURES));
+    expect(WATER_FIXTURES.total).toEqual(deriveTotal(WATER_FIXTURES));
+  });
+
+  it('chips are derived signed ratios from the fixture KPIs', () => {
+    const s = ENERGY_FIXTURES.shoppings[0];
+    const c = computeChips(s);
+    expect(c.vsAMinus1).toBeCloseTo(s.realizado / s.aMinus1 - 1, 10);
+    expect(c.vsMeta).toBeCloseTo(s.realizado / s.meta - 1, 10);
+    expect(c.vsOrcado).toBeCloseTo(s.realizado / s.orcado - 1, 10);
+  });
+
+  it('ships one energy dataset (MWh) and one water dataset (m³)', () => {
+    expect(ENERGY_FIXTURES.domain).toBe('energy');
+    expect(ENERGY_FIXTURES.unit).toBe('MWh');
+    expect(WATER_FIXTURES.domain).toBe('water');
+    expect(WATER_FIXTURES.unit).toBe('m³');
+    expect(SERIES_COLORS.realizado).toBe('#2563eb');
+    expect(SERIES_COLORS.aMinus1).toBe('#94a3b8');
+    expect(SERIES_COLORS.orcado).toBe('#f59e0b');
+    expect(SERIES_COLORS.meta).toBe('#7c3aed');
+  });
+});
+
+describe('wizard — sections, order, navigation', () => {
+  it('renders exactly 11 sections in the documented order', () => {
+    const handle = openMetasGuide();
+    expect(q('[data-mg-progress]').textContent).toContain(`1 / ${TOTAL_SECTIONS}`);
+
+    const titles: string[] = [];
+    for (let i = 0; i < TOTAL_SECTIONS; i++) {
+      titles.push(q('#myio-mg-title').textContent || '');
+      if (i < TOTAL_SECTIONS - 1) q<HTMLButtonElement>('[data-mg-next]').click();
+    }
+
+    expect(titles).toEqual([
+      'Bem-vindo ao Metas × Consumo',
+      'Domínio: Energia e Água',
+      'Período e presets de Ano',
+      'Dashboards × Analítico',
+      'O card do shopping — gráfico',
+      'O card do shopping — KPIs e chips',
+      'Toggles de ano (👁)',
+      'Resumo por shopping (sidebar)',
+      'Ordenar o resumo',
+      'Engine — gestão de metas',
+      'Exportar e finalizar',
+    ]);
+    handle.close();
+  });
+
+  it('Prev is disabled on the first section; Next becomes "Concluir" on the last', () => {
+    const handle = openMetasGuide();
+    expect(q<HTMLButtonElement>('[data-mg-prev]').disabled).toBe(true);
+    for (let i = 0; i < TOTAL_SECTIONS - 1; i++) q<HTMLButtonElement>('[data-mg-next]').click();
+    expect(q<HTMLButtonElement>('[data-mg-next]').textContent).toBe('Concluir');
+    handle.close();
+  });
+
+  it('goToStep clamps out-of-range indices', () => {
+    const handle = openMetasGuide();
+    handle.goToStep(999);
+    expect(q('[data-mg-progress]').textContent).toContain(`${TOTAL_SECTIONS} / ${TOTAL_SECTIONS}`);
+    handle.goToStep(-5);
+    expect(q('[data-mg-progress]').textContent).toContain(`1 / ${TOTAL_SECTIONS}`);
+    handle.close();
+  });
+
+  it('ArrowRight / ArrowLeft navigate; Escape closes', () => {
+    const handle = openMetasGuide();
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+    expect(q('[data-mg-progress]').textContent).toContain(`2 / ${TOTAL_SECTIONS}`);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
+    expect(q('[data-mg-progress]').textContent).toContain(`1 / ${TOTAL_SECTIONS}`);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(document.querySelector(ROOT)).toBeNull();
+    void handle;
+  });
+
+  it('Concluir on the last section calls onFinish then closes', () => {
+    let finished = 0;
+    let closed = 0;
+    const handle = openMetasGuide({ onFinish: () => (finished += 1), onClose: () => (closed += 1) });
+    for (let i = 0; i < TOTAL_SECTIONS - 1; i++) q<HTMLButtonElement>('[data-mg-next]').click();
+    q<HTMLButtonElement>('[data-mg-next]').click(); // Concluir
+    expect(finished).toBe(1);
+    expect(closed).toBe(1);
+    expect(document.querySelector(ROOT)).toBeNull();
+    void handle;
+  });
+
+  it('Skip closes without calling onFinish', () => {
+    let finished = 0;
+    const handle = openMetasGuide({ onFinish: () => (finished += 1) });
+    q<HTMLButtonElement>('[data-mg-skip]').click();
+    expect(finished).toBe(0);
+    expect(document.querySelector(ROOT)).toBeNull();
+    void handle;
+  });
+});
+
+describe('wizard — snapshot content derives from fixtures', () => {
+  it('renders the Total row with deriveTotal values on the sidebar section', () => {
+    const handle = openMetasGuide();
+    handle.goToStep(7); // "Resumo por shopping (sidebar)"
+    const totalRow = q('.myio-mg-side__row.is-total');
+    const total = deriveTotal(ENERGY_FIXTURES);
+    const text = totalRow.textContent || '';
+    // pt-BR thousands separators — assert each derived value appears
+    for (const v of [total.aMinus1, total.realizado, total.orcado, total.meta]) {
+      expect(text).toContain(v.toLocaleString('pt-BR'));
+    }
+    handle.close();
+  });
+});
+
+describe('persistence — opt-in only (RFC §6)', () => {
+  it('never writes localStorage without a persistKey', () => {
+    const handle = openMetasGuide(); // no persistKey
+    // no checkbox is even shown on the last section
+    for (let i = 0; i < TOTAL_SECTIONS - 1; i++) q<HTMLButtonElement>('[data-mg-next]').click();
+    expect((q('[data-mg-persist-wrap]') as HTMLElement).hidden).toBe(true);
+    q<HTMLButtonElement>('[data-mg-next]').click(); // Concluir
+    expect(window.localStorage.length).toBe(0);
+    void handle;
+  });
+
+  it('never writes when persistKey is set but the box is left unchecked', () => {
+    const key = 'myio:metas-guide:seen:v1';
+    const handle = openMetasGuide({ persistKey: key });
+    for (let i = 0; i < TOTAL_SECTIONS - 1; i++) q<HTMLButtonElement>('[data-mg-next]').click();
+    expect((q('[data-mg-persist-wrap]') as HTMLElement).hidden).toBe(false); // checkbox visible
+    q<HTMLButtonElement>('[data-mg-next]').click(); // Concluir, box unchecked
+    expect(window.localStorage.getItem(key)).toBeNull();
+    void handle;
+  });
+
+  it('writes the versioned key only when persistKey is set AND the box is ticked', () => {
+    const key = 'myio:metas-guide:seen:v1';
+    const handle = openMetasGuide({ persistKey: key });
+    for (let i = 0; i < TOTAL_SECTIONS - 1; i++) q<HTMLButtonElement>('[data-mg-next]').click();
+    q<HTMLInputElement>('[data-mg-persist]').checked = true;
+    q<HTMLButtonElement>('[data-mg-next]').click(); // Concluir
+    expect(window.localStorage.getItem(key)).not.toBeNull();
+    expect(JSON.parse(window.localStorage.getItem(key)!).seen).toBe(true);
+    void handle;
+  });
+});
+
+describe('accessibility (RFC §7)', () => {
+  it('returns focus to the opener ("?" button) on close', () => {
+    const opener = document.createElement('button');
+    opener.setAttribute('data-help', '');
+    document.body.appendChild(opener);
+    opener.focus();
+    expect(document.activeElement).toBe(opener);
+
+    const handle = openMetasGuide();
+    // focus moved into the dialog
+    expect(document.activeElement).not.toBe(opener);
+    handle.close();
+    expect(document.activeElement).toBe(opener);
+    opener.remove();
+  });
+
+  it('exposes a dialog role, aria-modal and an aria-live progress', () => {
+    const handle = openMetasGuide();
+    const dialog = q('.myio-mg-modal');
+    expect(dialog.getAttribute('role')).toBe('dialog');
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+    expect(q('[data-mg-progress]').getAttribute('aria-live')).toBe('polite');
+    handle.close();
+  });
+
+  it('applies the inherited theme accent and dark mode', () => {
+    const handle = openMetasGuide({
+      theme: { accent: '#123456', accentDark: '#654321', accentText: '#fff', mode: 'dark' },
+    });
+    const dialog = q<HTMLElement>('.myio-mg-modal');
+    expect(dialog.classList.contains('is-dark')).toBe(true);
+    expect(dialog.style.getPropertyValue('--mg-accent')).toBe('#123456');
+    handle.close();
+  });
+});
+
+describe('copy — dynamic years, not hardcoded (RFC §P1)', () => {
+  it('uses live getFullYear() labels in the presets section', () => {
+    const handle = openMetasGuide();
+    handle.goToStep(2); // "Período e presets de Ano"
+    const body = q('[data-mg-body]').textContent || '';
+    const cur = new Date().getFullYear();
+    expect(body).toContain(`Ano ${cur}`);
+    expect(body).toContain(`Ano ${cur - 1}`);
+    handle.close();
+  });
+});


### PR DESCRIPTION
Implementa o RFC-0227: botão **"?"** ao lado do Engine na modal **Metas × Consumo** (HO UNIQUE) que abre um **wizard de tour guiado** (11 seções) rodando 100% em dados MOCK — sem rede.

## Restrição do usuário (atendida)
Toda a lógica do tour é um **componente novo na lib** (`src/components/metas-guide/`), **não** inline no controller. O controller ganhou só **+15 linhas**: o botão `data-help` após `data-engine` e um branch que chama `MyIOLibrary.openMetasGuide(...)` com fallback. Nada de lógica de tour no widget.

## Decisão de arquitetura: shell autocontido (não estendeu o onboard)
O `openOnboardModal`/`OnboardModalView` tem os 4 defeitos P0 que o RFC aponta (Esc vaza no backdrop/close, `content` HTMLElement não anexa no 1º render, sem focus-trap, HTML sem escaping). Corrigi-los + testes de regressão é o caminho mais arriscado. O caminho seguro que o RFC permite — `openMetasGuide` dono do próprio overlay/navegação/foco/escaping/persistência — garante **zero** mudança no shell e nos consumidores atuais (`openTutorialModal`, `openHelpModal`, etc.). O look Academy (header roxo + footer) é replicado localmente; o handle retornado é compatível com `OnboardModalHandle` + `goToStep`.

## Arquivos
Criados: `metas-guide/{types,metasGuideFixtures,openMetasGuide,index}.ts` (~1051 linhas) + `tests/metasGuide.{nonetwork,}.test.ts`. Modificados: `src/index.ts` (export) e o controller (2 hooks).

## MOCK = contrato de teste (RFC §P0)
`metasGuide.nonetwork.test.ts` stuba `fetch`/`XMLHttpRequest`/`Image`/`sendBeacon`/`WebSocket`/`EventSource` e **falha** se qualquer request disparar ao abrir/navegar as 11 seções (ida+volta) e na navegação por teclado. Links do footer inertes (`target=_blank`/`rel=noopener`). Snapshots são estáticos e determinísticos (SVG inline, **sem** Chart.js, **sem** `openGoalsCompare`, **sem** `createCustomerGoalsCard` — Fase 2 fica adiada).

## Verificação (reconferida pelo revisor, não só pelo autor)
- **Testes metas-guide: 22/22** (4 no-network + 18 unit: contagem/ordem das 11 seções, derivação de KPI/Total/chips das fixtures, nav + clamp do goToStep, persistência opt-in — nunca grava sem `persistKey` + checkbox, retorno de foco, aria, tema, ano dinâmico). Rodei na worktree.
- `node --check` no controller OK. `npm run build` OK (verify-dts OK).
- Suíte completa: 768 pass / 105 fail — todas **pré-existentes e não relacionadas** (NODE-RED `jest is not defined`, `format`, `deviceStatus`, `deviceClassification`); nenhuma toca metas-guide.
- ESLint do repo cobre só `.js/.mjs/.cjs`; os `.ts` novos não são lintados por esse config (type-safety vem do build DTS). Controller: 0 erros novos.

## Delta de bundle
Componente isolado ~28 KB raw / **~8,7 KB gzip** (bloco CSS único + copy pt-BR das seções, sem assets externos). O gate de 25 KB UMD-min não está ligado no `npm run build` e já está estourado no projeto — issue à parte.

## Cores das séries (batem com RFC-0217)
Realizado `#2563eb` · A-1 `#94a3b8` · Orçado `#f59e0b` · Meta `#7c3aed`. Anos **dinâmicos** na copy ("Ano anterior/atual"), fixtures ilustram 2025/2026.

## Adiado (conforme RFC)
Fase 2 (snapshot vivo via `createCustomerGoalsCard`, gated na checagem de compat §P1); auto-open first-run (§P2, default OFF — `data-help` é o caminho primário); extensão `steps` do shell (desnecessária dado o autocontido); Fase 3 (reuso no Shopping v5.2.0 via `LIB_SYMBOLS`).

## Revisor deve conferir à mão
1. Fidelidade visual dos mini snapshots (card/sidebar/toolbar) vs painel real, em claro e escuro.
2. Se `GP.accentDark`/`GP.accentText` são os valores certos a passar como tema.
3. O CSS usa `color-mix()` — ok em navegadores modernos, degrada em muito antigos.
4. A copy do fallback quando `MyIOLibrary.openMetasGuide` não existe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
