### PR TITLE
feat(rfc-0207): Dispositivos Específicos no card de Climatização (+ corrige residual da Área Comum)

### DIFF
--- a/docs/rfcs/RFC-0207-CustomerScopedDeviceClassificationProfile.md
+++ b/docs/rfcs/RFC-0207-CustomerScopedDeviceClassificationProfile.md
@@ -1301,7 +1301,7 @@ Cada regra de categoria (`domains.<domain>.categories.rules[]`) ganha um campo *
 deviceOverrides?: Array<{
   id: string;              // TB entity id — mesma chave de `excludeDevicesAtCountSubtotalCAG`
   label?: string;          // guardado só para exibição/resiliência na UI
-  mode: 'include' | 'exclude';
+  mode: 'include' | 'exclude' | 'parent';  // `parent` adicionado em 2026-07-24 — ver §DE-G
 }>;
 ```
 
@@ -1318,8 +1318,9 @@ apaga a chave quando a lista esvazia).
 
 | modo | efeito |
 | --- | --- |
-| `include` | O device **agrega nesta categoria mantendo o seu grupo**. `resolveGroup` não muda: o total da coluna Entrada fica **idêntico**. Ele é apenas somado a mais nos itens/total da categoria do breakdown. |
+| `include` | O device **agrega nesta categoria mantendo o seu grupo** (feed **paralelo**). `resolveGroup` não muda: o total da coluna Entrada fica **idêntico**. Ele é apenas somado a mais nos itens/total da categoria do breakdown. |
 | `exclude` | O device sai do breakdown **inteiro**. **Não** cai em `outros` nem em bucket nenhum. |
+| `parent` | O device **contém** a composição da categoria (ver **§DE-G**): o valor DELE vira o total da categoria e a composição auto-classificada é o **breakdown aninhado**, **não somado por cima** (evita a dupla contagem). Grupo inalterado (Entrada intacta), como no `include`. |
 
 Por que `exclude` não cai em `outros`: o `exclude` existe para **dupla medição** — a bomba já
 está dentro da leitura do trafo. Roteá-la para `outros` seria recontá-la, que é exatamente o
@@ -1434,6 +1435,93 @@ anterior.
 O clamp em 0 **fica** — mas um `residualRaw` negativo agora significa problema real de
 dado/configuração (soma dos subtotais maior que o total do grupo), não artefato deste recurso.
 Por isso ele é logado uma vez por sessão (`LogHelper.warn`) com os números, em vez de sumir.
+
+### DE-G. Modo `parent` — o device CONTÉM a composição (2026-07-24)
+
+`include` resolve o caso da **Ilha** (feed **paralelo**: o trafo da CAG é energia *adicional*, some
+com os submedidores). Mas há o caso oposto, medido ao vivo no **Moxuara**:
+
+```
+CAG-Entrada  (deviceProfile ENTRADA, identifier CAG, grupo entrada)  = 336.600   ← PAI
+  ├─ Chillers 3                                                        = 184.661
+  ├─ Fancoils 14                                                       =  96.046   } composição
+  └─ Bombas  13                                                        =  46.266   } (grupo areacomum)
+                                                                        ---------
+                                                         Σ filhos      = 326.973
+```
+
+`CAG-Entrada` é o medidor de **entrada** da Central de Água Gelada: mede TODA a alimentação da
+CAG. Os submedidores internos (Chillers/Fancoils/Bombas) estão **a jusante** dele — 336.600 ≳
+326.973 (~3% de perda de linha). Não são feeds paralelos: o pai **contém** os filhos.
+
+Com `include` o card mostraria `336.600 + 326.973 = 663.573` — **dupla contagem**. Com a
+composição pura (sem override) mostraria 326.973 e o pai ficaria invisível. O correto é
+**336.600** (o pai), com a composição como **detalhamento aninhado**.
+
+**Schema.** `mode` passa a ser `'include' | 'exclude' | 'parent'` (valor puro, §A respeitada;
+ausente/bundles antigos ⇒ comportamento de antes — a lib antiga coage `parent` → `include`).
+
+**Semântica de `parent` para a Climatização:**
+
+| | `include` (Ilha) | `parent` (Moxuara) |
+|---|---|---|
+| Relação com a composição | **paralelo** | **contém** |
+| Total do card | composição **+** device | **valor do device** (a composição não soma por cima) |
+| Composição | some no total | vira **breakdown aninhado** sob o pai |
+| Grupo do device | inalterado (Entrada intacta) | inalterado (Entrada intacta) |
+
+Mesmo gesto de UI, matemática de total **oposta** — só o operador sabe qual é o caso, por isso é
+escolha **explícita** ("como pai" no picker), nunca inferida.
+
+**Fórmula do total** (MAIN_VIEW `buildSummary`):
+`climatizacaoTotal = hasParent ? Σ(pais) : Σ(filhos)`. Os pais vão para um balde à parte
+(`climatizacaoParentItems`) e **não** entram nem em `climatizacaoItems` nem nas subcategorias;
+`climatizacaoItems` continua sendo só a composição (os filhos). Moxuara: `climatizacaoTotal =
+336.600` (≠ 663.573, ≠ 326.973). Entrada continua `783.750 + 336.600 = 1.120.350` — o pai não
+muda de grupo.
+
+**Fórmula do residual** e a **prevenção da dupla subtração** (o ponto delicado). O modo `parent`
+quebra a premissa `base = total − cross` do §DE-E: quando o card mostra o valor do pai
+(cross-group), `total` **não** é mais a soma dos filhos. Se descontássemos `total − cross` do
+residual daria `336.600 − 336.600 = 0` — e os filhos (326.973), que ESTÃO em `areacomumTotal`,
+ficariam sem desconto. Se descontássemos os dois, o residual cairia por `−336.600`.
+
+A solução: `computeBaseGroupResidual` ganhou `baseGroupContribution` (opcional). Para a
+climatização com pai o `buildSummary` passa:
+
+```
+{ category:'climatizacao',
+  total: 336.600,                         // = card (o pai, cross-group)
+  crossGroupTotal: 336.600,               // o pai — informativo, NUNCA descontado
+  baseGroupContribution: 326.973 }        // os FILHOS de origem-base — o único desconto
+```
+
+`computeBaseGroupResidual` então faz `subtotalFromBaseGroup += baseGroupContribution` em vez de
+`total − cross`. Resultado: **só os filhos (326.973) são descontados, uma vez**; o pai (336.600),
+por ser cross-group, entra apenas em `subtotalCrossGroup` (informativo) e **nunca** toca o
+residual. É exatamente isso que impede o pai E os filhos de baterem no residual cada um:
+`residual = areacomumTotal − 326.973`. No Moxuara `areacomumTotal = 326.973` (só a composição)
+⇒ `residual = 0`, **de verdade** (pré-clamp 0, não negativo mascarado). `baseGroupContribution`
+ausente ⇒ cai em `total − cross` (byte-idêntico ao §DE-E; `include`/sem-override intocados).
+
+Na reconstrução da Área Comum efetiva (quando `excludeGroupsTotals` está ligado), a parcela de
+climatização usada é a dos **filhos** (`Math.max(0, Σfilhos − crossFilhos)`), não a do pai — o pai
+mora em Entrada e somá-lo ali dobraria com `_entradaEff`.
+
+**Tooltip** (TELEMETRY_INFO `buildClimatizacaoContent`). `STATE.consumidores.climatizacao` ganhou
+`parents: [{id,label,total}]` (threaded pelo MAIN_VIEW). Com pai, a **Composição** renderiza uma
+linha `🔌 <label> … <total>` no topo (classe `myio-info-tooltip__category--parent`, "Medidor pai
+da composição") e as subcategorias existentes vão num wrapper `myio-info-tooltip__nested`
+indentado abaixo. Campo ausente/vazio ⇒ composição plana, **byte-idêntica** à de antes.
+
+**Limitação assumida — N pais.** O modelo trata **todos** os pais de uma categoria como cobrindo
+**coletivamente** a composição inteira dela (a composição não é atribuída pai-a-pai). Para o caso
+de **um** pai que cobre toda a Climatização — que é o Moxuara — isso é exato. Com dois ou mais
+pais na mesma categoria, a partição "qual filho está sob qual pai" não é derivável dos dados
+disponíveis; o comportamento resultante (todos os pais somam no total da categoria; toda a
+composição vira o breakdown coletivo) é uma simplificação **documentada**, não um palpite. Se
+esse caso surgir de verdade, é sinal de que falta modelar a topologia com mais estrutura (ex.:
+um pai por sub-árvore), não de forçar heurística.
 
 ### DE-F. Ressalva — isto é um escape hatch, não um método
 

--- a/docs/rfcs/RFC-0207-CustomerScopedDeviceClassificationProfile.md
+++ b/docs/rfcs/RFC-0207-CustomerScopedDeviceClassificationProfile.md
@@ -1327,17 +1327,22 @@ bug que o mecanismo existe para evitar.
 
 - `exclude` **vence** `include` se um device aparecer nos dois (o `exclude` é global ao
   breakdown; o `include` é por categoria).
-- A **fórmula do residual não muda**:
-  `Área Comum = Entrada − (Lojas + Climatização + Elevadores + Escadas + Outros)`.
-  Com o trafo dentro de Climatização, Área Comum encolhe corretamente naquele valor.
+- Sobre o residual de Área Comum, ver **§DE-E** — um `include` cross-group exige separar a
+  origem de cada subtotal, senão o residual vai negativo pelo valor exato do device puxado.
 
-**Aceitação (números reais da Ilha)** — `include` no trafo + `exclude` nas 9 bombas:
+**Aceitação A — o rollout real da Ilha é INCLUDE-ONLY**: um único `include` no trafo
+"Medição Geral CAG", sem nenhum `exclude`. Números medidos em produção:
 
 | | valor |
 | --- | --- |
-| Climatização | **637.560** (e **não** 793.231 — esse seria o bug de dupla contagem) |
+| Card Climatização | **1.790.163** (1.152.603 internos + 637.560 do trafo) |
 | Entrada | **1.390.237**, inalterada |
-| As 9 bombas | em **nenhum** bucket do breakdown (nem em `outros`) |
+| Residual Área Comum | **0**, e **antes** do clamp (ver §DE-E) |
+
+**Aceitação B — semântica do `exclude`** (não usada na Ilha; trava o contrato do modo):
+`include` no trafo + `exclude` nas 9 bombas ⇒ Climatização **637.560** (e não 793.231, que
+seria a dupla contagem), Entrada **1.390.237** inalterada, e as 9 bombas em **nenhum** bucket
+do breakdown — nem em `outros`.
 
 ### DE-D. Implementação
 
@@ -1385,7 +1390,52 @@ em Climatização** (`DEVICE_OVERRIDE_CATEGORIES`) — ampliar = acrescentar nom
 Persistência: nada novo. O modal continua delegando ao `onSave` →
 `window.MyIOOrchestrator.saveDeviceClassificationProfile`; o campo apenas faz round-trip.
 
-### DE-E. Ressalva — isto é um escape hatch, não um método
+### DE-E. O residual de Área Comum × includes cross-group (correção)
+
+A primeira versão desta implementação tinha um defeito aritmético, medido sobre dados reais
+da Ilha antes de ir a produção.
+
+`buildSummary` calculava
+`_areacomumResidual = Math.max(0, areacomumTotal − Σ subtotais)`. A fórmula assume que **todo
+subtotal é composto de devices que estão dentro de `areacomumTotal`**. Um `include`
+cross-group viola a premissa: os 637.560 do trafo entram no subtotal de climatização mas o
+device vive no grupo `entrada` e **nunca fez parte** do `areacomumTotal`.
+
+Medição em produção (Ilha, hoje, sem override):
+
+```
+areacomumTotal                    = 1.240.503
+climatizacao (origem areacomum)   = 1.152.603
+elevadores / escadas / outros     =    25.559 / 51.942 / 10.399
+                                    ------------------------------
+Σ subtotais                       = 1.240.503   ->  residual = 0
+```
+
+Com o `include` aplicado, `Σ subtotais` viraria 1.878.063 e
+`residual = max(0, 1.240.503 − 1.878.063) = max(0, −637.560) = 0`. Na Ilha o residual já é 0,
+então **nada pareceria errado** — mas a conta está quebrada por construção, e qualquer cliente
+com Área Comum positiva veria o número encolher pelo valor do device incluído, sem motivo
+legítimo. O `Math.max(0, …)` mascarava exatamente isso.
+
+**A correção.** Cada subtotal é decomposto em parcela de **origem-base** e parcela
+**cross-group**:
+
+- O **card mantém o total cheio** (1.790.163 em Climatização) — é o objetivo do recurso.
+- O **residual desconta apenas a parcela de origem-base**:
+  `1.240.503 − (1.152.603 + 25.559 + 51.942 + 10.399) = 0` — correto, e sem depender do clamp.
+
+Mecânica: `selectBreakdownItems` passou a devolver `sourceGroup` e `fromBaseGroup` em cada
+entrada; o `buildSummary` acumula, em paralelo aos totais cheios, a parcela cross-group de cada
+categoria; e `computeBaseGroupResidual(baseGroupTotal, subtotals[])` (pura, na lib) faz a
+conta e devolve `{ subtotalFromBaseGroup, subtotalCrossGroup, residualRaw, residual, negative }`.
+Sem overrides a parcela cross-group é 0 em todas as categorias e a aritmética é idêntica à
+anterior.
+
+O clamp em 0 **fica** — mas um `residualRaw` negativo agora significa problema real de
+dado/configuração (soma dos subtotais maior que o total do grupo), não artefato deste recurso.
+Por isso ele é logado uma vez por sessão (`LogHelper.warn`) com os números, em vez de sumir.
+
+### DE-F. Ressalva — isto é um escape hatch, não um método
 
 **Overrides por device-id escalam mal e quebram em re-provisionamento**: o `id` é o TB entity
 id, e um device recriado ganha id novo — o override vira órfão silencioso (o modal sinaliza

--- a/docs/rfcs/RFC-0207-CustomerScopedDeviceClassificationProfile.md
+++ b/docs/rfcs/RFC-0207-CustomerScopedDeviceClassificationProfile.md
@@ -451,6 +451,9 @@ A new MENU entry opens a premium modal that:
   - `identifierContains` → `identifier.includes(s)` (**this is the unified rule** that fixes
     the CAG `Set.has` bug — substring everywhere).
   - `conditional[]` → `{ deviceTypes, whenIdentifierContains }` for BOMBA/MOTOR-style devices.
+  - `deviceOverrides?[]` → `{ id, label?, mode }` — **Dispositivos Específicos**, escape hatch
+    topológico por dispositivo. Opcional; ausência = comportamento anterior. Ver o addendum
+    homônimo no fim deste RFC (semântica `include`/`exclude` e a ressalva de escala).
   - exactly one category per domain has `fallback: true` ("outros").
 
 ### Resolution order (deterministic)
@@ -1263,6 +1266,136 @@ Verde nesse teste = contrato `bulk-replace` honrado → o golden-lib e o adaptad
 [ ] boot: N parallel domain loads resolve distinct trees; 304 isolated per domain
 [ ] integração §v3.2-D: 422 atômico + 409 com currentVersion + pg_typeof=jsonb
 ```
+
+---
+
+## Addendum — "Dispositivos Específicos": overrides por dispositivo no breakdown (2026-07-24)
+
+### DE-A. O problema, com o caso que o produziu
+
+No **Shopping da Ilha**, o device **"Medição Geral CAG"** (`deviceProfile: ENTRADA`,
+`identifier: CAG`) é um **trafo de entrada** que mede toda a alimentação da CAG (central de
+água gelada): **637.560**. Ele cai no grupo `entrada` e conta no total de entrada — isso está
+**certo**. Só que aquela energia *é* climatização, e o operador quer vê-la no card
+**Climatização** do TELEMETRY_INFO.
+
+Hoje isso é impossível, por duas razões estruturais — nenhuma das quais deve ser abolida:
+
+1. **Alocação única.** `resolveGroup(item)` devolve **um** grupo. É o que mantém os totais
+   coerentes (nenhum device conta duas vezes numa coluna). Fica.
+2. **O breakdown só lê `areacomum`.** `buildSummary` (MAIN_VIEW) percorre o grupo residual.
+   Devices de entrada são, portanto, **estruturalmente invisíveis** ao card de climatização.
+
+A complicação que decidiu o desenho: na Ilha o **mesmo `identifier` "CAG"** é usado pelo trafo
+de entrada **e** por 9 submedidores `BOMBA_CAG` (155.671 no total) que **já** caem em
+climatização pela regra de identifier. As 9 bombas estão **fisicamente dentro** dos 637.560 que
+o trafo mede. Uma regra por identifier pegaria os dois e dobraria a conta (793.231). Daí:
+**override explícito por dispositivo, não regra.**
+
+### DE-B. Schema (aditivo, retrocompatível)
+
+Cada regra de categoria (`domains.<domain>.categories.rules[]`) ganha um campo **opcional**:
+
+```ts
+/** Overrides explícitos por dispositivo (escape hatch topológico). */
+deviceOverrides?: Array<{
+  id: string;              // TB entity id — mesma chave de `excludeDevicesAtCountSubtotalCAG`
+  label?: string;          // guardado só para exibição/resiliência na UI
+  mode: 'include' | 'exclude';
+}>;
+```
+
+É uma **lista de valores**, nunca um predicado (§A segue valendo). `label` é guardado junto do
+`id` para que o modal consiga renderizar um nome humano mesmo quando o device sumiu do
+dashboard — nesse caso a chip aparece marcada como "não encontrado" (⚠). O motor **nunca**
+classifica por `label`; ele é texto de exibição.
+
+Ausência do campo ⇒ **comportamento idêntico ao de antes** (`selectBreakdownItems` tem
+fast-path para "zero overrides"; `normalizeProfile` preserva ausência como ausência e o modal
+apaga a chave quando a lista esvazia).
+
+### DE-C. Semântica (decidida)
+
+| modo | efeito |
+| --- | --- |
+| `include` | O device **agrega nesta categoria mantendo o seu grupo**. `resolveGroup` não muda: o total da coluna Entrada fica **idêntico**. Ele é apenas somado a mais nos itens/total da categoria do breakdown. |
+| `exclude` | O device sai do breakdown **inteiro**. **Não** cai em `outros` nem em bucket nenhum. |
+
+Por que `exclude` não cai em `outros`: o `exclude` existe para **dupla medição** — a bomba já
+está dentro da leitura do trafo. Roteá-la para `outros` seria recontá-la, que é exatamente o
+bug que o mecanismo existe para evitar.
+
+- `exclude` **vence** `include` se um device aparecer nos dois (o `exclude` é global ao
+  breakdown; o `include` é por categoria).
+- A **fórmula do residual não muda**:
+  `Área Comum = Entrada − (Lojas + Climatização + Elevadores + Escadas + Outros)`.
+  Com o trafo dentro de Climatização, Área Comum encolhe corretamente naquele valor.
+
+**Aceitação (números reais da Ilha)** — `include` no trafo + `exclude` nas 9 bombas:
+
+| | valor |
+| --- | --- |
+| Climatização | **637.560** (e **não** 793.231 — esse seria o bug de dupla contagem) |
+| Entrada | **1.390.237**, inalterada |
+| As 9 bombas | em **nenhum** bucket do breakdown (nem em `outros`) |
+
+### DE-D. Implementação
+
+**LIB** (`src/utils/devices/deviceClassificationProfile.ts`, pura — sem DOM, sem fetch):
+
+- `collectDeviceOverrides(profile, domain)` → achata os `deviceOverrides` de todas as
+  categorias em `{ includes: Map<id, categoria>, excludes: Set<id>, labels: Map<id, label> }`,
+  já aplicando a precedência do §DE-C.
+- `selectBreakdownItems(groups, profile, domain, { baseGroup })` → monta a lista que o
+  breakdown deve percorrer: base = `groups[baseGroup]` (hoje `areacomum`), menos os `exclude`,
+  mais os `include` **puxados de qualquer grupo**, cada um carimbado com `forcedCategory`.
+- `normalizeDeviceOverrideId(id)` → `String(id).trim().toLowerCase()`, a **mesma** chave que
+  `excludeDevicesAtCountSubtotalCAG` usa. IDs e labels **nunca** são upper-cased (ao contrário
+  dos demais comparandos): `id` é UUID do TB e `label` é texto humano.
+- `validateProfile` acusa `deviceOverrides` não-array, entrada não-objeto, `id` vazio, `mode`
+  fora de `include|exclude` e `label` não-string. Campo ausente **não** gera erro.
+
+**MAIN_VIEW** (`buildSummary`): o laço `for (const item of areacomum)` virou
+`for (const { item, forcedCategory } of _breakdownEntries)`, alimentado por
+`window.MyIOLibrary.selectBreakdownItems({ areacomum, entrada, lojas }, …)`. `forcedCategory`
+tem precedência sobre `resolveCategory`; a **sub-subcategorização** (chiller/fancoil/CAG/…)
+segue pelas regras de texto locais de sempre — o trafo da Ilha cai em `cag` porque o texto
+combinado contém "CAG" e não contém CHILLER/FANCOIL/BOMBA.
+
+**Relação com `excludeDevicesAtCountSubtotalCAG`** (setting de widget, preservado intacto):
+são mecanismos **distintos** e ambos continuam valendo.
+
+| | `excludeDevicesAtCountSubtotalCAG` | `deviceOverrides` |
+| --- | --- | --- |
+| onde vive | setting do **widget** | perfil do **cliente** (JSON persistido) |
+| quando age | tarde | cedo |
+| escopo | só o **subtotal** da sub-subcategoria CAG; o device segue em `climatizacaoTotal` e no breakdown | o breakdown **inteiro** (entra/sai) |
+
+Um device pode estar nos dois; o `exclude` do perfil vence por chegar primeiro.
+
+**Modal** (`openDeviceProfileModal.ts`): seção **"Dispositivos Específicos"** com botão **+**,
+picker com busca (🔍) sobre `device.label`, devices já adicionados **removidos da lista** (não
+dá para adicionar o mesmo duas vezes), marcação incluir/excluir na seleção e chips removíveis.
+Os devices vêm do callback `getDevices(domain)` que o modal **já recebia** para o preview
+(sem novo I/O); lista vazia ou callback que lança degradam para uma dica, sem quebrar. O
+**"Preview ao vivo"** reflete os overrides antes de salvar. Respeita `canEdit` (read-only não
+renderiza "+" nem "×"). O schema é genérico por categoria, mas a seção é **renderizada apenas
+em Climatização** (`DEVICE_OVERRIDE_CATEGORIES`) — ampliar = acrescentar nomes ali.
+
+Persistência: nada novo. O modal continua delegando ao `onSave` →
+`window.MyIOOrchestrator.saveDeviceClassificationProfile`; o campo apenas faz round-trip.
+
+### DE-E. Ressalva — isto é um escape hatch, não um método
+
+**Overrides por device-id escalam mal e quebram em re-provisionamento**: o `id` é o TB entity
+id, e um device recriado ganha id novo — o override vira órfão silencioso (o modal sinaliza
+com ⚠, mas o número já mudou). Também não sobrevivem a export/import entre ambientes.
+
+Portanto: **regras por atributo continuam sendo o caminho padrão**
+(`deviceProfiles` / `profileContains` / `identifier*`). Os `deviceOverrides` são para o que
+regra nenhuma alcança — topologia física, como um trafo que mede um subsistema inteiro. Se a
+lista de um cliente começar a crescer, isso é sinal de que falta uma **regra** (ou um
+`deviceProfile` novo), não de que faltam mais overrides.
 
 ---
 

--- a/src/components/premium-modals/device-profile/openDeviceProfileModal.ts
+++ b/src/components/premium-modals/device-profile/openDeviceProfileModal.ts
@@ -33,10 +33,14 @@ import {
   validateProfile,
   normalizeProfile,
   setActiveProfile,
+  collectDeviceOverrides,
+  normalizeDeviceOverrideId,
   type DeviceClassificationProfile,
   type DomainProfile,
   type ClassificationDomain,
   type ClassifiableItem,
+  type DeviceOverride,
+  type DeviceOverrideMode,
 } from '../../../utils/devices/deviceClassificationProfile';
 
 const DOMAIN_TABS: { key: ClassificationDomain; label: string; icon: string }[] = [
@@ -47,6 +51,14 @@ const DOMAIN_TABS: { key: ClassificationDomain; label: string; icon: string }[] 
 
 const STYLE_ID = 'myio-device-profile-styles';
 const ACCENT = '#7C3AED';
+
+/**
+ * RFC-0207 "Dispositivos Específicos": o schema é genérico (qualquer regra de
+ * categoria aceita `deviceOverrides`), mas por ora a seção só é RENDERIZADA na
+ * categoria abaixo — o caso de uso que a motivou (trafo de entrada da CAG) é
+ * exclusivamente de climatização. Ampliar = acrescentar nomes aqui.
+ */
+const DEVICE_OVERRIDE_CATEGORIES = new Set<string>(['climatizacao']);
 
 export interface DeviceProfilePreviewDevice extends ClassifiableItem {
   label?: string;
@@ -139,6 +151,11 @@ export function openDeviceProfileModal(params: OpenDeviceProfileModalParams) {
   let cardHandles: DivCardHandle[] = [];
   // Card ids parallel to cardHandles (for expand-all / collapse-all).
   let cardIds: string[] = [];
+  // "Dispositivos Específicos": índice da regra de categoria cujo picker está
+  // aberto (null = fechado) + termo de busca. Vive fora do render porque cada
+  // edição de chip reconstrói o body inteiro.
+  let pickerOpenForRule: number | null = null;
+  let pickerQuery = '';
 
   injectStyles();
 
@@ -352,7 +369,8 @@ export function openDeviceProfileModal(params: OpenDeviceProfileModalParams) {
             <div class="mdp-field"><label>deviceProfile</label>${chipList(`cat-${i}-dp`, r.deviceProfiles || [], ro)}</div>
             <div class="mdp-field"><label>deviceProfile contém</label>${chipList(`cat-${i}-pc`, r.profileContains || [], ro)}</div>
             <div class="mdp-field"><label>identifier contém</label>${chipList(`cat-${i}-idc`, r.identifierFallback?.identifierContains || [], ro)}</div>
-            <div class="mdp-field"><label>identifier prefixo</label>${chipList(`cat-${i}-idp`, r.identifierFallback?.identifierPrefixes || [], ro)}</div>`,
+            <div class="mdp-field"><label>identifier prefixo</label>${chipList(`cat-${i}-idp`, r.identifierFallback?.identifierPrefixes || [], ro)}</div>
+            ${overrideSection(i, r.name, r.deviceOverrides || [], ro)}`,
         ),
       );
       addCard(
@@ -403,6 +421,241 @@ export function openDeviceProfileModal(params: OpenDeviceProfileModalParams) {
       ? ''
       : `<input class="mdp-chip-input" data-key="${key}" type="text" placeholder="+ adicionar" />`;
     return `<div class="mdp-chips" data-key="${key}">${chips}${adder}</div>`;
+  }
+
+  // ------------------------------------------- Dispositivos Específicos (RFC-0207)
+
+  /** Devices do domínio ativo, com id normalizado — fonte do picker e dos labels. */
+  function overrideDevicePool(): { key: string; id: string; label: string }[] {
+    let raw: DeviceProfilePreviewDevice[] = [];
+    try {
+      raw = getDevices(activeDomain) || [];
+    } catch {
+      raw = [];
+    }
+    const seen = new Set<string>();
+    const pool: { key: string; id: string; label: string }[] = [];
+    for (const d of raw) {
+      if (!d) continue;
+      const id = String((d as { id?: unknown }).id ?? '').trim();
+      const key = normalizeDeviceOverrideId(id);
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      pool.push({ key, id, label: deviceLabel(d) });
+    }
+    return pool;
+  }
+
+  /**
+   * Seção "Dispositivos Específicos" — escape hatch topológico por device.
+   * Renderizada só nas categorias de `DEVICE_OVERRIDE_CATEGORIES`.
+   */
+  function overrideSection(
+    ruleIdx: number,
+    ruleName: string,
+    overrides: DeviceOverride[],
+    readOnly: boolean,
+  ): string {
+    if (!DEVICE_OVERRIDE_CATEGORIES.has(String(ruleName).toLowerCase())) return '';
+
+    const pool = overrideDevicePool();
+    const byKey = new Map(pool.map((d) => [d.key, d]));
+
+    const rows = overrides
+      .map((ov, i) => {
+        const key = normalizeDeviceOverrideId(ov.id);
+        const found = byKey.get(key);
+        // Resiliência: se o device sumiu (re-provisionado/removido), usamos o
+        // label guardado no perfil e sinalizamos.
+        const name = found?.label || ov.label || ov.id;
+        const missing = !found;
+        const isExc = ov.mode === 'exclude';
+        return `<span class="mdp-ovr-chip ${isExc ? 'is-exclude' : 'is-include'} ${
+          missing ? 'is-missing' : ''
+        }" title="${escHtml(ov.id)}">
+          <span class="mdp-ovr-mode">${isExc ? 'excluir' : 'incluir'}</span>
+          <span class="mdp-ovr-name">${escHtml(name)}</span>
+          ${missing ? '<span class="mdp-ovr-warn" title="Dispositivo não encontrado na lista atual">⚠</span>' : ''}
+          ${
+            readOnly
+              ? ''
+              : `<button class="mdp-ovr-x" data-cat="${ruleIdx}" data-idx="${i}" aria-label="remover">×</button>`
+          }
+        </span>`;
+      })
+      .join('');
+
+    const empty = overrides.length
+      ? ''
+      : '<span class="mdp-ovr-empty">Nenhum dispositivo específico.</span>';
+
+    const addBtn = readOnly
+      ? ''
+      : `<button type="button" class="mdp-ovr-add" data-cat="${ruleIdx}" title="Adicionar dispositivo específico">+</button>`;
+
+    const picker = pickerOpenForRule === ruleIdx && !readOnly ? overridePicker(ruleIdx, pool, overrides) : '';
+
+    return `<div class="mdp-field mdp-ovr">
+      <label>Dispositivos Específicos</label>
+      <div class="mdp-ovr-hint">
+        <b>incluir</b>: soma o device nesta categoria <i>sem</i> mudar o grupo dele (o total da coluna
+        de origem continua igual). <b>excluir</b>: tira o device do breakdown por completo (não cai em
+        “outros”) — use para dupla-medição.
+      </div>
+      <div class="mdp-ovr-row">
+        <div class="mdp-ovr-list">${rows}${empty}</div>
+        ${addBtn}
+      </div>
+      ${picker}
+    </div>`;
+  }
+
+  /** Picker de dispositivos: busca por label + já-adicionados removidos da lista. */
+  function overridePicker(
+    ruleIdx: number,
+    pool: { key: string; id: string; label: string }[],
+    overrides: DeviceOverride[],
+  ): string {
+    // Regra do spec: o operador não pode adicionar o mesmo device duas vezes —
+    // tudo que já está na lista sai do picker.
+    const taken = new Set(overrides.map((o) => normalizeDeviceOverrideId(o.id)));
+    const available = pool.filter((d) => !taken.has(d.key));
+
+    return `<div class="mdp-picker" data-cat="${ruleIdx}">
+      <div class="mdp-picker-search">
+        <span class="mdp-picker-mag" aria-hidden="true">🔍</span>
+        <input class="mdp-picker-input" type="text" placeholder="Buscar dispositivo…"
+               value="${escHtml(pickerQuery)}" data-cat="${ruleIdx}" />
+        <button type="button" class="mdp-picker-close" data-cat="${ruleIdx}" aria-label="fechar">×</button>
+      </div>
+      <div class="mdp-picker-list">${overridePickerRows(available)}</div>
+    </div>`;
+  }
+
+  function overridePickerRows(available: { key: string; id: string; label: string }[]): string {
+    if (!available.length) {
+      return `<div class="mdp-picker-empty">Nenhum dispositivo disponível. ${
+        pickerQuery ? 'Ajuste a busca.' : 'A lista de devices do dashboard está vazia.'
+      }</div>`;
+    }
+    const q = pickerQuery.trim().toLowerCase();
+    const filtered = q ? available.filter((d) => d.label.toLowerCase().includes(q)) : available;
+    if (!filtered.length) {
+      return '<div class="mdp-picker-empty">Nenhum dispositivo casa com a busca.</div>';
+    }
+    const MAX = 200;
+    const rows = filtered
+      .slice(0, MAX)
+      .map(
+        (d) => `<div class="mdp-picker-row">
+          <span class="mdp-picker-name" title="${escHtml(d.id)}">${escHtml(d.label)}</span>
+          <span class="mdp-picker-actions">
+            <button type="button" class="mdp-picker-pick is-include" data-id="${escHtml(d.id)}"
+                    data-label="${escHtml(d.label)}" data-mode="include">incluir</button>
+            <button type="button" class="mdp-picker-pick is-exclude" data-id="${escHtml(d.id)}"
+                    data-label="${escHtml(d.label)}" data-mode="exclude">excluir</button>
+          </span>
+        </div>`,
+      )
+      .join('');
+    const more =
+      filtered.length > MAX
+        ? `<div class="mdp-picker-empty">+${filtered.length - MAX} dispositivos — refine a busca.</div>`
+        : '';
+    return rows + more;
+  }
+
+  function overrideListFor(ruleIdx: number): DeviceOverride[] | null {
+    const cats = dom()?.categories;
+    const rule = cats?.rules?.[ruleIdx];
+    if (!rule) return null;
+    return (rule.deviceOverrides = rule.deviceOverrides || []);
+  }
+
+  function addOverride(ruleIdx: number, id: string, label: string, mode: DeviceOverrideMode) {
+    const list = overrideListFor(ruleIdx);
+    if (!list) return;
+    const key = normalizeDeviceOverrideId(id);
+    if (!key) return;
+    if (list.some((o) => normalizeDeviceOverrideId(o.id) === key)) return; // sem duplicatas
+    list.push(label ? { id: String(id).trim(), label, mode } : { id: String(id).trim(), mode });
+    pickerOpenForRule = null;
+    pickerQuery = '';
+    rerenderBody();
+  }
+
+  function removeOverride(ruleIdx: number, idx: number) {
+    const list = overrideListFor(ruleIdx);
+    if (!list || idx < 0 || idx >= list.length) return;
+    list.splice(idx, 1);
+    // Campo opcional: some do JSON quando esvazia (retrocompat — perfil sem
+    // overrides volta a ser byte-idêntico ao de antes).
+    if (!list.length) {
+      const rule = dom()?.categories?.rules?.[ruleIdx];
+      if (rule) delete rule.deviceOverrides;
+    }
+    rerenderBody();
+  }
+
+  function bindOverrides() {
+    if (!canEdit) return;
+
+    body.querySelectorAll<HTMLButtonElement>('.mdp-ovr-add').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const idx = Number(btn.dataset.cat);
+        pickerOpenForRule = pickerOpenForRule === idx ? null : idx;
+        pickerQuery = '';
+        rerenderBody();
+      });
+    });
+
+    body.querySelectorAll<HTMLButtonElement>('.mdp-ovr-x').forEach((btn) => {
+      btn.addEventListener('click', () => removeOverride(Number(btn.dataset.cat), Number(btn.dataset.idx)));
+    });
+
+    body.querySelectorAll<HTMLButtonElement>('.mdp-picker-close').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        pickerOpenForRule = null;
+        pickerQuery = '';
+        rerenderBody();
+      });
+    });
+
+    body.querySelectorAll<HTMLButtonElement>('.mdp-picker-pick').forEach((btn) => {
+      btn.addEventListener('click', () =>
+        addOverride(
+          Number((btn.closest('.mdp-picker') as HTMLElement | null)?.dataset.cat),
+          btn.dataset.id || '',
+          btn.dataset.label || '',
+          (btn.dataset.mode as DeviceOverrideMode) || 'include',
+        ),
+      );
+    });
+
+    // A busca re-renderiza SÓ a lista, para não perder o foco do input.
+    const input = body.querySelector<HTMLInputElement>('.mdp-picker-input');
+    if (input) {
+      input.addEventListener('input', () => {
+        pickerQuery = input.value;
+        const ruleIdx = Number(input.dataset.cat);
+        const list = body.querySelector('.mdp-picker-list');
+        if (!list) return;
+        const taken = new Set((overrideListFor(ruleIdx) || []).map((o) => normalizeDeviceOverrideId(o.id)));
+        list.innerHTML = overridePickerRows(overrideDevicePool().filter((d) => !taken.has(d.key)));
+        list.querySelectorAll<HTMLButtonElement>('.mdp-picker-pick').forEach((btn) => {
+          btn.addEventListener('click', () =>
+            addOverride(
+              ruleIdx,
+              btn.dataset.id || '',
+              btn.dataset.label || '',
+              (btn.dataset.mode as DeviceOverrideMode) || 'include',
+            ),
+          );
+        });
+      });
+      // O picker acabou de abrir → foco na busca.
+      input.focus();
+    }
   }
 
   // ---------------------------------------------------------------- editing
@@ -485,6 +738,7 @@ export function openDeviceProfileModal(params: OpenDeviceProfileModalParams) {
     mountCards(); // build the DivCard sections into .mdp-editor (before chip binding)
     bindTabs();
     bindChipEditors();
+    bindOverrides();
     refreshPreview();
   }
 
@@ -494,6 +748,8 @@ export function openDeviceProfileModal(params: OpenDeviceProfileModalParams) {
         const next = tab.dataset.domain as ClassificationDomain;
         if (!next || next === activeDomain) return;
         activeDomain = next;
+        pickerOpenForRule = null;
+        pickerQuery = '';
         rerenderBody();
       });
     });
@@ -528,17 +784,34 @@ export function openDeviceProfileModal(params: OpenDeviceProfileModalParams) {
 
   function refreshPreview() {
     const hasCats = !!dom()?.categories;
-    const devices = (getDevices(activeDomain) || []).filter(Boolean);
+    // `getDevices` é um callback do chamador (o dashboard). Um throw dele não
+    // pode derrubar o editor — degrada para preview vazio.
+    let devices: DeviceProfilePreviewDevice[] = [];
+    try {
+      devices = (getDevices(activeDomain) || []).filter(Boolean);
+    } catch (err) {
+      console.warn('[openDeviceProfileModal] getDevices falhou — preview vazio', err);
+    }
     const groups: Record<string, number> = {};
     const cats: Record<string, number> = {};
     const groupDevices: Record<string, string[]> = {};
     const catDevices: Record<string, string[]> = {};
+    // RFC-0207 "Dispositivos Específicos" — o preview reflete os overrides para
+    // que o operador veja o efeito ANTES de salvar. Os overrides atuam só no
+    // breakdown; as COLUNAS (grupos) não mudam, por construção.
+    const ov = hasCats
+      ? collectDeviceOverrides(working, activeDomain)
+      : { includes: new Map<string, string>(), excludes: new Set<string>() };
+
     for (const d of devices) {
       const g = resolveGroup(d, working, activeDomain).group;
       groups[g] = (groups[g] || 0) + 1;
       (groupDevices[g] ||= []).push(deviceLabel(d));
       if (hasCats) {
-        const c = resolveCategory(d, working, activeDomain).category;
+        const key = normalizeDeviceOverrideId((d as { id?: unknown }).id);
+        if (key && ov.excludes.has(key)) continue; // fora do breakdown inteiro
+        const c =
+          (key && ov.includes.get(key)) || resolveCategory(d, working, activeDomain).category;
         cats[c] = (cats[c] || 0) + 1;
         (catDevices[c] ||= []).push(deviceLabel(d));
       }
@@ -720,6 +993,52 @@ function injectStyles() {
   .mdp-chip-x:hover { color: #dc2626; }
   .mdp-chip-input { border: 1px dashed #cbd5e1; border-radius: 12px; padding: 2px 8px; font-size: 11px; width: 110px; outline: none; }
   .mdp-chip-input:focus { border-color: ${ACCENT}; }
+  /* Dispositivos Específicos (RFC-0207) — escape hatch por dispositivo */
+  .mdp-ovr { margin-top: 10px; padding-top: 8px; border-top: 1px dashed #e2e8f0; }
+  .mdp-ovr-hint { font-size: 10.5px; line-height: 1.45; color: #64748b; margin: 0 0 6px; }
+  .mdp-ovr-hint b { color: #475569; }
+  .mdp-ovr-row { display: flex; align-items: flex-start; gap: 6px; }
+  .mdp-ovr-list { display: flex; flex-wrap: wrap; gap: 5px; align-items: center; flex: 1; min-width: 0; }
+  .mdp-ovr-empty { font-size: 11px; color: #94a3b8; font-style: italic; }
+  .mdp-ovr-chip { display: inline-flex; align-items: center; gap: 5px; border-radius: 12px;
+    padding: 2px 8px; font-size: 11px; font-weight: 600; border: 1px solid; max-width: 100%; }
+  .mdp-ovr-chip.is-include { background: #ede9fe; border-color: #c4b5fd; color: #5b21b6; }
+  .mdp-ovr-chip.is-exclude { background: #fee2e2; border-color: #fca5a5; color: #991b1b; }
+  .mdp-ovr-chip.is-missing { opacity: .75; border-style: dashed; }
+  .mdp-ovr-mode { font-size: 9px; font-weight: 800; text-transform: uppercase; letter-spacing: .04em; opacity: .8; }
+  .mdp-ovr-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 200px; }
+  .mdp-ovr-warn { font-size: 11px; }
+  .mdp-ovr-x { background: none; border: none; cursor: pointer; color: inherit; opacity: .55;
+    font-size: 13px; line-height: 1; padding: 0; }
+  .mdp-ovr-x:hover { opacity: 1; }
+  .mdp-ovr-add { flex-shrink: 0; width: 22px; height: 22px; border-radius: 50%; border: 1px solid ${ACCENT};
+    background: #fff; color: ${ACCENT}; font-size: 15px; font-weight: 700; line-height: 1; cursor: pointer;
+    display: inline-flex; align-items: center; justify-content: center; font-family: inherit; }
+  .mdp-ovr-add:hover { background: ${ACCENT}; color: #fff; }
+  /* picker */
+  .mdp-picker { margin-top: 8px; border: 1px solid #ddd6fe; border-radius: 9px; background: #fff; overflow: hidden; }
+  .mdp-picker-search { display: flex; align-items: center; gap: 6px; padding: 6px 8px;
+    background: #faf9ff; border-bottom: 1px solid #ede9fe; }
+  .mdp-picker-mag { font-size: 12px; }
+  .mdp-picker-input { flex: 1; min-width: 0; border: 1px solid #e2e8f0; border-radius: 7px;
+    padding: 4px 8px; font-size: 11px; font-family: inherit; outline: none; }
+  .mdp-picker-input:focus { border-color: ${ACCENT}; }
+  .mdp-picker-close { background: none; border: none; cursor: pointer; color: #94a3b8; font-size: 15px; line-height: 1; padding: 0 2px; }
+  .mdp-picker-close:hover { color: #dc2626; }
+  .mdp-picker-list { max-height: 200px; overflow-y: auto; }
+  .mdp-picker-row { display: flex; align-items: center; justify-content: space-between; gap: 8px;
+    padding: 5px 8px; border-bottom: 1px solid #f1f5f9; }
+  .mdp-picker-row:last-child { border-bottom: none; }
+  .mdp-picker-row:hover { background: #faf9ff; }
+  .mdp-picker-name { font-size: 11.5px; color: #334155; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .mdp-picker-actions { display: inline-flex; gap: 4px; flex-shrink: 0; }
+  .mdp-picker-pick { font-family: inherit; font-size: 10px; font-weight: 700; border-radius: 6px;
+    padding: 3px 8px; cursor: pointer; border: 1px solid; }
+  .mdp-picker-pick.is-include { background: #ede9fe; border-color: #c4b5fd; color: #5b21b6; }
+  .mdp-picker-pick.is-include:hover { background: #ddd6fe; }
+  .mdp-picker-pick.is-exclude { background: #fee2e2; border-color: #fca5a5; color: #991b1b; }
+  .mdp-picker-pick.is-exclude:hover { background: #fecaca; }
+  .mdp-picker-empty { font-size: 11px; color: #94a3b8; padding: 10px 8px; text-align: center; font-style: italic; }
   .mdp-preview { background: #faf9ff; border: 1px solid #ede9fe; border-radius: 10px; padding: 12px; height: fit-content; position: sticky; top: 0; }
   .mdp-pv { margin-bottom: 12px; }
   .mdp-pv-title { font-size: 12px; font-weight: 800; color: #1e293b; margin-bottom: 6px; }

--- a/src/components/premium-modals/device-profile/openDeviceProfileModal.ts
+++ b/src/components/premium-modals/device-profile/openDeviceProfileModal.ts
@@ -469,11 +469,14 @@ export function openDeviceProfileModal(params: OpenDeviceProfileModalParams) {
         // label guardado no perfil e sinalizamos.
         const name = found?.label || ov.label || ov.id;
         const missing = !found;
-        const isExc = ov.mode === 'exclude';
-        return `<span class="mdp-ovr-chip ${isExc ? 'is-exclude' : 'is-include'} ${
+        const modeClass =
+          ov.mode === 'exclude' ? 'is-exclude' : ov.mode === 'parent' ? 'is-parent' : 'is-include';
+        const modeLabel =
+          ov.mode === 'exclude' ? 'excluir' : ov.mode === 'parent' ? 'como pai' : 'incluir';
+        return `<span class="mdp-ovr-chip ${modeClass} ${
           missing ? 'is-missing' : ''
         }" title="${escHtml(ov.id)}">
-          <span class="mdp-ovr-mode">${isExc ? 'excluir' : 'incluir'}</span>
+          <span class="mdp-ovr-mode">${modeLabel}</span>
           <span class="mdp-ovr-name">${escHtml(name)}</span>
           ${missing ? '<span class="mdp-ovr-warn" title="Dispositivo não encontrado na lista atual">⚠</span>' : ''}
           ${
@@ -498,9 +501,11 @@ export function openDeviceProfileModal(params: OpenDeviceProfileModalParams) {
     return `<div class="mdp-field mdp-ovr">
       <label>Dispositivos Específicos</label>
       <div class="mdp-ovr-hint">
-        <b>incluir</b>: soma o device nesta categoria <i>sem</i> mudar o grupo dele (o total da coluna
-        de origem continua igual). <b>excluir</b>: tira o device do breakdown por completo (não cai em
-        “outros”) — use para dupla-medição.
+        <b>incluir</b>: <i>soma</i> o device nesta categoria sem mudar o grupo dele (feed paralelo — o
+        total da coluna de origem continua igual). <b>como pai</b>: o device <i>contém</i> a composição —
+        o valor DELE vira o total da categoria e as subcategorias viram o detalhamento aninhado (não
+        somam por cima). <b>excluir</b>: tira o device do breakdown por completo (não cai em “outros”)
+        — use para dupla-medição.
       </div>
       <div class="mdp-ovr-row">
         <div class="mdp-ovr-list">${rows}${empty}</div>
@@ -552,6 +557,8 @@ export function openDeviceProfileModal(params: OpenDeviceProfileModalParams) {
           <span class="mdp-picker-actions">
             <button type="button" class="mdp-picker-pick is-include" data-id="${escHtml(d.id)}"
                     data-label="${escHtml(d.label)}" data-mode="include">incluir</button>
+            <button type="button" class="mdp-picker-pick is-parent" data-id="${escHtml(d.id)}"
+                    data-label="${escHtml(d.label)}" data-mode="parent">como pai</button>
             <button type="button" class="mdp-picker-pick is-exclude" data-id="${escHtml(d.id)}"
                     data-label="${escHtml(d.label)}" data-mode="exclude">excluir</button>
           </span>
@@ -1003,6 +1010,7 @@ function injectStyles() {
   .mdp-ovr-chip { display: inline-flex; align-items: center; gap: 5px; border-radius: 12px;
     padding: 2px 8px; font-size: 11px; font-weight: 600; border: 1px solid; max-width: 100%; }
   .mdp-ovr-chip.is-include { background: #ede9fe; border-color: #c4b5fd; color: #5b21b6; }
+  .mdp-ovr-chip.is-parent { background: #ccfbf1; border-color: #5eead4; color: #0f766e; }
   .mdp-ovr-chip.is-exclude { background: #fee2e2; border-color: #fca5a5; color: #991b1b; }
   .mdp-ovr-chip.is-missing { opacity: .75; border-style: dashed; }
   .mdp-ovr-mode { font-size: 9px; font-weight: 800; text-transform: uppercase; letter-spacing: .04em; opacity: .8; }
@@ -1036,6 +1044,8 @@ function injectStyles() {
     padding: 3px 8px; cursor: pointer; border: 1px solid; }
   .mdp-picker-pick.is-include { background: #ede9fe; border-color: #c4b5fd; color: #5b21b6; }
   .mdp-picker-pick.is-include:hover { background: #ddd6fe; }
+  .mdp-picker-pick.is-parent { background: #ccfbf1; border-color: #5eead4; color: #0f766e; }
+  .mdp-picker-pick.is-parent:hover { background: #99f6e4; }
   .mdp-picker-pick.is-exclude { background: #fee2e2; border-color: #fca5a5; color: #991b1b; }
   .mdp-picker-pick.is-exclude:hover { background: #fecaca; }
   .mdp-picker-empty { font-size: 11px; color: #94a3b8; padding: 10px 8px; text-align: center; font-style: italic; }

--- a/src/index.ts
+++ b/src/index.ts
@@ -215,6 +215,10 @@ export {
   setActiveProfile,
   listDomains,
   listGroups,
+  // RFC-0207 "Dispositivos Específicos" — overrides por dispositivo no breakdown.
+  collectDeviceOverrides,
+  selectBreakdownItems,
+  normalizeDeviceOverrideId,
 } from './utils/devices/deviceClassificationProfile.js';
 // RFC-0207 v2/v3.1: árvore recursiva de nós + walker genérico (group-generic).
 // ADITIVO: `resolveGroup`/`resolveCategory` (v1) continuam sendo o caminho que o
@@ -276,6 +280,11 @@ export type {
   GroupName,
   CategoryName,
   GroupDescriptor,
+  DeviceOverride,
+  DeviceOverrideMode,
+  CollectedDeviceOverrides,
+  BreakdownEntry,
+  SelectBreakdownItemsOptions,
 } from './utils/devices/deviceClassificationProfile.js';
 
 // RFC-0207 Phase B: device classification profile management modal (premium UI).

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,6 +219,7 @@ export {
   collectDeviceOverrides,
   selectBreakdownItems,
   normalizeDeviceOverrideId,
+  computeBaseGroupResidual,
 } from './utils/devices/deviceClassificationProfile.js';
 // RFC-0207 v2/v3.1: árvore recursiva de nós + walker genérico (group-generic).
 // ADITIVO: `resolveGroup`/`resolveCategory` (v1) continuam sendo o caminho que o
@@ -285,6 +286,8 @@ export type {
   CollectedDeviceOverrides,
   BreakdownEntry,
   SelectBreakdownItemsOptions,
+  BreakdownSubtotalInput,
+  BaseGroupResidual,
 } from './utils/devices/deviceClassificationProfile.js';
 
 // RFC-0207 Phase B: device classification profile management modal (premium UI).

--- a/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/MAIN_VIEW/controller.js
+++ b/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/MAIN_VIEW/controller.js
@@ -4061,6 +4061,10 @@ function buildGroupData(items) {
   };
 }
 
+// RFC-0207 — o aviso de residual negativo sai UMA vez por sessão (buildSummary
+// roda a cada troca de período; sem o flag, o log viraria ruído).
+let _warnedNegativeAreacomumResidual = false;
+
 /**
  * Build summary for TELEMETRY_INFO (pie chart, cards, tooltips)
  * RFC-0106: Pre-compute ALL tooltip data so TELEMETRY_INFO just reads it
@@ -4206,13 +4210,29 @@ function buildSummary(lojas, entrada, areacomum, periodKey) {
       window.MyIOLibrary &&
       window.MyIOLibrary.selectBreakdownItems) ||
     null;
+  const _computeBaseGroupResidual =
+    (typeof window !== 'undefined' &&
+      window.MyIOLibrary &&
+      window.MyIOLibrary.computeBaseGroupResidual) ||
+    null;
   const _breakdownEntries = _selectBreakdownItems
     ? _selectBreakdownItems({ areacomum, entrada, lojas }, undefined, 'energy', {
         baseGroup: 'areacomum',
       })
-    : areacomum.map((item) => ({ item, forcedCategory: null }));
+    : areacomum.map((item) => ({ item, forcedCategory: null, fromBaseGroup: true }));
 
-  for (const { item, forcedCategory } of _breakdownEntries) {
+  // Itens que entraram no breakdown vindos de OUTRO grupo (include cross-group).
+  // Guardados por identidade porque `areacomumTotal` NÃO os contém: sem separar a
+  // origem, o residual de Área Comum (mais abaixo) ficaria negativo pelo valor
+  // exato do device puxado — e o clamp em 0 esconderia o erro. Ver
+  // `computeBaseGroupResidual`. Fica vazio quando não há override nenhum.
+  const _crossOriginItems = new Set();
+
+  for (const { item, forcedCategory, fromBaseGroup } of _breakdownEntries) {
+    // `=== false` de propósito: bundles antigos da lib não emitem o campo, e
+    // `undefined` deve significar "veio do grupo base" (comportamento de antes).
+    if (fromBaseGroup === false) _crossOriginItems.add(item);
+
     const lw = toStr(item.labelWidget);
     const dp = toStr(item.deviceProfile);
     const label = toStr(item.label);
@@ -4293,6 +4313,21 @@ function buildSummary(lojas, entrada, areacomum, periodKey) {
   );
   const outrosTotal = outrosItems.reduce((sum, i) => sum + getValorEfetivo(i, 'outros'), 0);
 
+  // RFC-0207 — parcela CROSS-GROUP de cada subtotal (devices puxados por um
+  // `include` de fora do grupo `areacomum`). Os totais acima seguem CHEIOS: é o
+  // que os cards exibem, e é o objetivo do recurso. Estas parcelas servem só para
+  // o cálculo do residual logo abaixo, que não pode descontar de `areacomumTotal`
+  // um valor que nunca esteve nele. Sem overrides, o Set é vazio e tudo dá 0 —
+  // aritmética byte-idêntica à de antes.
+  const _crossTotalOf = (items, grupo) =>
+    _crossOriginItems.size === 0
+      ? 0
+      : items.reduce((sum, i) => sum + (_crossOriginItems.has(i) ? getValorEfetivo(i, grupo) : 0), 0);
+  const climatizacaoCrossTotal = _crossTotalOf(climatizacaoItems, 'climatizacao');
+  const elevadoresCrossTotal = _crossTotalOf(elevadoresItems, 'elevadores');
+  const escadasRolantesCrossTotal = _crossTotalOf(escadasRolantesItems, 'escadas_rolantes');
+  const outrosCrossTotal = _crossTotalOf(outrosItems, 'outros');
+
   // Climatizacao subcategories totals (O Helper usa 'climatizacao' para herdar a regra do pai)
   const chillerTotal = chillerItems.reduce((sum, i) => sum + getValorEfetivo(i, 'climatizacao'), 0);
   const fancoilTotal = fancoilItems.reduce((sum, i) => sum + getValorEfetivo(i, 'climatizacao'), 0);
@@ -4320,8 +4355,51 @@ function buildSummary(lojas, entrada, areacomum, periodKey) {
     const _elevadoresEff = _exclGroups.elevadores ? 0 : elevadoresTotal;
     const _escadasEff = _exclGroups.escadas_rolantes ? 0 : escadasRolantesTotal;
     const _outrosEff = _exclGroups.outros ? 0 : outrosTotal;
-    const _areacomumSubtot = climatizacaoTotal + elevadoresTotal + escadasRolantesTotal + outrosTotal;
-    const _areacomumResidual = Math.max(0, areacomumTotal - _areacomumSubtot);
+    // RFC-0207 — o residual desconta APENAS a parcela de cada subtotal que veio
+    // do próprio grupo `areacomum`. Descontar o subtotal cheio jogaria o residual
+    // negativo pelo valor exato de cada device puxado por um `include`
+    // cross-group (que vive em outro grupo e nunca esteve em `areacomumTotal`),
+    // e o clamp em 0 mascararia. Sem overrides, cross = 0 e a conta é a de antes.
+    const _residualCalc = _computeBaseGroupResidual
+      ? _computeBaseGroupResidual(areacomumTotal, [
+          { category: 'climatizacao', total: climatizacaoTotal, crossGroupTotal: climatizacaoCrossTotal },
+          { category: 'elevadores', total: elevadoresTotal, crossGroupTotal: elevadoresCrossTotal },
+          {
+            category: 'escadas_rolantes',
+            total: escadasRolantesTotal,
+            crossGroupTotal: escadasRolantesCrossTotal,
+          },
+          { category: 'outros', total: outrosTotal, crossGroupTotal: outrosCrossTotal },
+        ])
+      : (() => {
+          // Sem a lib no bundle não existe `selectBreakdownItems`, logo não existe
+          // include cross-group — as duas fórmulas coincidem.
+          const raw =
+            areacomumTotal -
+            (climatizacaoTotal + elevadoresTotal + escadasRolantesTotal + outrosTotal);
+          return { residualRaw: raw, residual: Math.max(0, raw), negative: raw < 0 };
+        })();
+    const _areacomumResidual = _residualCalc.residual;
+
+    // Um residual negativo AGORA significa problema real de dado/configuração
+    // (soma dos subtotais maior que o total do grupo), não artefato do recurso.
+    // Não pode ficar invisível atrás do clamp. Uma vez por sessão.
+    if (_residualCalc.negative && !_warnedNegativeAreacomumResidual) {
+      _warnedNegativeAreacomumResidual = true;
+      LogHelper.warn(
+        '[RFC-0207] Residual de Área Comum NEGATIVO (clampado em 0) — soma dos subtotais excede o total do grupo areacomum:',
+        {
+          areacomumTotal,
+          residualRaw: _residualCalc.residualRaw,
+          subtotalFromBaseGroup: _residualCalc.subtotalFromBaseGroup,
+          subtotalCrossGroup: _residualCalc.subtotalCrossGroup,
+          climatizacaoTotal,
+          elevadoresTotal,
+          escadasRolantesTotal,
+          outrosTotal,
+        }
+      );
+    }
     const _residualEff = _exclGroups.area_comum ? 0 : _areacomumResidual;
     const _areacomumEff = _climatizacaoEff + _elevadoresEff + _escadasEff + _outrosEff + _residualEff;
 

--- a/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/MAIN_VIEW/controller.js
+++ b/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/MAIN_VIEW/controller.js
@@ -4170,6 +4170,11 @@ function buildSummary(lojas, entrada, areacomum, periodKey) {
   const GERADOR_PATTERNS = ['GERADOR', 'NOBREAK', 'UPS'];
 
   const climatizacaoItems = [];
+  // RFC-0207 "parent" — devices marcados como PAI da composição de Climatização.
+  // O valor deles VIRA o total do card; a composição (chillers/fancoils/bombas)
+  // é o breakdown aninhado, NÃO somado por cima (evita a dupla contagem). Ficam
+  // FORA de `climatizacaoItems` e das subcategorias por isso.
+  const climatizacaoParentItems = [];
   const elevadoresItems = [];
   const escadasRolantesItems = [];
   const outrosItems = [];
@@ -4228,7 +4233,7 @@ function buildSummary(lojas, entrada, areacomum, periodKey) {
   // `computeBaseGroupResidual`. Fica vazio quando não há override nenhum.
   const _crossOriginItems = new Set();
 
-  for (const { item, forcedCategory, fromBaseGroup } of _breakdownEntries) {
+  for (const { item, forcedCategory, fromBaseGroup, isParent } of _breakdownEntries) {
     // `=== false` de propósito: bundles antigos da lib não emitem o campo, e
     // `undefined` deve significar "veio do grupo base" (comportamento de antes).
     if (fromBaseGroup === false) _crossOriginItems.add(item);
@@ -4253,6 +4258,13 @@ function buildSummary(lojas, entrada, areacomum, periodKey) {
     } else if (_topCat === 'escadas_rolantes') {
       escadasRolantesItems.push(item);
     } else if (_topCat === 'climatizacao') {
+      // RFC-0207 "parent": o PAI da composição CONTÉM os filhos — o valor dele
+      // é o total do card e os filhos são só o breakdown aninhado. Não entra em
+      // climatizacaoItems (não infla o total) nem nas subcategorias.
+      if (isParent === true) {
+        climatizacaoParentItems.push(item);
+        continue;
+      }
       climatizacaoItems.push(item);
       if (combined.includes('CHILLER') || id.startsWith('CHILLER-')) chillerItems.push(item);
       else if (combined.includes('FANCOIL') || id.startsWith('FANCOIL-')) fancoilItems.push(item);
@@ -4305,7 +4317,22 @@ function buildSummary(lojas, entrada, areacomum, periodKey) {
   }
 
   // ============ CALCULATE SUB-TOTAIS (Usando o Helper) ============
-  const climatizacaoTotal = climatizacaoItems.reduce((sum, i) => sum + getValorEfetivo(i, 'climatizacao'), 0);
+  // RFC-0207 "parent": `climatizacaoItems` é a COMPOSIÇÃO (filhos auto-classificados,
+  // sempre no grupo base). Quando há um PAI declarado, o total do card passa a ser
+  // o valor do pai (ele CONTÉM os filhos), e os filhos viram só o breakdown aninhado
+  // — nunca somados por cima (a dupla contagem que o modo existe para evitar).
+  const _climatizacaoChildrenTotal = climatizacaoItems.reduce(
+    (sum, i) => sum + getValorEfetivo(i, 'climatizacao'),
+    0
+  );
+  const _climatizacaoParentTotal = climatizacaoParentItems.reduce(
+    (sum, i) => sum + getValorEfetivo(i, 'climatizacao'),
+    0
+  );
+  const _hasClimatizacaoParent = climatizacaoParentItems.length > 0;
+  const climatizacaoTotal = _hasClimatizacaoParent
+    ? _climatizacaoParentTotal
+    : _climatizacaoChildrenTotal;
   const elevadoresTotal = elevadoresItems.reduce((sum, i) => sum + getValorEfetivo(i, 'elevadores'), 0);
   const escadasRolantesTotal = escadasRolantesItems.reduce(
     (sum, i) => sum + getValorEfetivo(i, 'escadas_rolantes'),
@@ -4351,7 +4378,15 @@ function buildSummary(lojas, entrada, areacomum, periodKey) {
     const _exclGroups = _excludeGroupsTotals.groups || {};
     const _lojasEff = _exclGroups.lojas ? 0 : lojasTotal;
     const _entradaEff = _exclGroups.entrada ? 0 : entradaTotal;
-    const _climatizacaoEff = _exclGroups.climatizacao ? 0 : climatizacaoTotal;
+    // RFC-0207 "parent": ao reconstruir a Área Comum efetiva, a parcela de
+    // climatização que REALMENTE mora em `areacomum` é a dos FILHOS (a composição),
+    // não a do pai — o pai é cross-group (mora em Entrada) e somá-lo aqui dobraria
+    // com `_entradaEff`. Sem pai, usa `climatizacaoTotal` cheio (include/normal
+    // seguem byte-idênticos: o quirk cross-group do include é pré-existente).
+    const _climatizacaoAreacomumPortion = _hasClimatizacaoParent
+      ? Math.max(0, _climatizacaoChildrenTotal - climatizacaoCrossTotal)
+      : climatizacaoTotal;
+    const _climatizacaoEff = _exclGroups.climatizacao ? 0 : _climatizacaoAreacomumPortion;
     const _elevadoresEff = _exclGroups.elevadores ? 0 : elevadoresTotal;
     const _escadasEff = _exclGroups.escadas_rolantes ? 0 : escadasRolantesTotal;
     const _outrosEff = _exclGroups.outros ? 0 : outrosTotal;
@@ -4362,7 +4397,21 @@ function buildSummary(lojas, entrada, areacomum, periodKey) {
     // e o clamp em 0 mascararia. Sem overrides, cross = 0 e a conta é a de antes.
     const _residualCalc = _computeBaseGroupResidual
       ? _computeBaseGroupResidual(areacomumTotal, [
-          { category: 'climatizacao', total: climatizacaoTotal, crossGroupTotal: climatizacaoCrossTotal },
+          // RFC-0207 "parent": o card mostra o valor do PAI (cross-group), mas o
+          // residual só pode descontar de `areacomumTotal` os FILHOS que de fato
+          // estão nele. `baseGroupContribution` = soma dos filhos de origem-base;
+          // o pai entra em crossGroupTotal (informativo, nunca descontado). Assim
+          // nem o pai (336.600) nem os filhos (326.973) são descontados duas vezes:
+          // só os filhos, uma vez. Sem pai, o campo fica ausente e a conta é a de
+          // antes (total − crossGroupTotal).
+          _hasClimatizacaoParent
+            ? {
+                category: 'climatizacao',
+                total: climatizacaoTotal,
+                crossGroupTotal: _climatizacaoParentTotal,
+                baseGroupContribution: Math.max(0, _climatizacaoChildrenTotal - climatizacaoCrossTotal),
+              }
+            : { category: 'climatizacao', total: climatizacaoTotal, crossGroupTotal: climatizacaoCrossTotal },
           { category: 'elevadores', total: elevadoresTotal, crossGroupTotal: elevadoresCrossTotal },
           {
             category: 'escadas_rolantes',
@@ -4462,6 +4511,14 @@ function buildSummary(lojas, entrada, areacomum, periodKey) {
     lojas: buildCategorySummary(lojas, lojasTotal, 'Lojas'),
     climatizacao: {
       ...buildCategorySummary(climatizacaoItems, climatizacaoTotal, 'Climatização'),
+      // RFC-0207 "parent": devices que HEADAM a composição (o total do card é o
+      // valor deles; a composição abaixo é o breakdown aninhado). Vazio quando não
+      // há pai — nesse caso o TELEMETRY_INFO renderiza a composição plana, como antes.
+      parents: climatizacaoParentItems.map((i) => ({
+        id: i.id,
+        label: i.label || i.name || i.identifier || i.id,
+        total: getValorEfetivo(i, 'climatizacao'),
+      })),
       subcategories: {
         chillers: buildCategorySummary(chillerItems, chillerTotal, 'Chillers'),
         fancoils: buildCategorySummary(fancoilItems, fancoilTotal, 'Fancoils'),

--- a/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/MAIN_VIEW/controller.js
+++ b/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/MAIN_VIEW/controller.js
@@ -4183,7 +4183,36 @@ function buildSummary(lojas, entrada, areacomum, periodKey) {
 
   const toStr = (val) => String(val || '').toUpperCase();
 
-  for (const item of areacomum) {
+  // ============ RFC-0207 "DISPOSITIVOS ESPECÍFICOS" ============
+  // O breakdown historicamente só percorria `areacomum`, o que torna um device de
+  // ENTRADA estruturalmente invisível ao card de Climatização — mesmo quando ele
+  // é, fisicamente, climatização (Shopping da Ilha: o trafo "Medição Geral CAG"
+  // mede TODA a alimentação da CAG). `selectBreakdownItems` resolve isso sem
+  // mexer em `resolveGroup` (alocação única preservada, total de Entrada intacto):
+  //   - `include` → puxa o device de QUALQUER grupo e força a categoria dele;
+  //   - `exclude` → tira o device do breakdown INTEIRO (nunca cai em `outros`,
+  //     porque o motivo do exclude é dupla-medição — recontá-lo em outros seria
+  //     exatamente o bug que ele existe para evitar).
+  //
+  // Relação com `widgetSettings.excludeDevicesAtCountSubtotalCAG` (abaixo, na
+  // seção "FILTER EXCLUDED DEVICES FROM CAG"): são mecanismos DISTINTOS e ambos
+  // continuam valendo. Aquele é setting de WIDGET e atua tarde, só no SUBTOTAL da
+  // sub-subcategoria CAG (o device continua contando em `climatizacaoTotal`).
+  // Este é perfil de CLIENTE (persistido no JSON) e atua cedo, decidindo quais
+  // devices sequer entram no breakdown. Um device pode estar nos dois; o
+  // `exclude` do perfil vence por chegar primeiro.
+  const _selectBreakdownItems =
+    (typeof window !== 'undefined' &&
+      window.MyIOLibrary &&
+      window.MyIOLibrary.selectBreakdownItems) ||
+    null;
+  const _breakdownEntries = _selectBreakdownItems
+    ? _selectBreakdownItems({ areacomum, entrada, lojas }, undefined, 'energy', {
+        baseGroup: 'areacomum',
+      })
+    : areacomum.map((item) => ({ item, forcedCategory: null }));
+
+  for (const { item, forcedCategory } of _breakdownEntries) {
     const lw = toStr(item.labelWidget);
     const dp = toStr(item.deviceProfile);
     const label = toStr(item.label);
@@ -4194,7 +4223,10 @@ function buildSummary(lojas, entrada, areacomum, periodKey) {
     // RFC-0207 (A1b → cleanup): top-level bucket is resolver-only (degrades to
     // 'outros' when the library is missing — logged once above). Identifier-prefix
     // and combined-text signals are now encoded in the resolver seed.
-    const _topCat = _resolveCategory ? _resolveCategory(item).category : 'outros';
+    // `forcedCategory` (Dispositivos Específicos) tem precedência: o operador
+    // declarou explicitamente onde o device agrega. A sub-subcategorização abaixo
+    // segue pelas regras de texto normais.
+    const _topCat = forcedCategory || (_resolveCategory ? _resolveCategory(item).category : 'outros');
 
     if (_topCat === 'elevadores') {
       elevadoresItems.push(item);
@@ -4228,6 +4260,13 @@ function buildSummary(lojas, entrada, areacomum, periodKey) {
   }
 
   // ============ FILTER EXCLUDED DEVICES FROM CAG ============
+  // NÃO confundir com os "Dispositivos Específicos" do perfil (RFC-0207, acima):
+  //   - AQUI: setting de WIDGET, escopo estreito — retira o device apenas do
+  //     SUBTOTAL da sub-subcategoria CAG. Ele continua dentro de
+  //     `climatizacaoItems`/`climatizacaoTotal` e dentro do breakdown.
+  //   - LÁ: perfil do CLIENTE (JSON persistido), escopo largo — `exclude` retira
+  //     o device do breakdown INTEIRO (não chega aqui) e `include` traz devices de
+  //     outros grupos. Os dois convivem; o do perfil age antes.
   const excludeIds = widgetSettings.excludeDevicesAtCountSubtotalCAG || [];
   const excludeIdsSet = new Set(excludeIds.map((id) => String(id).trim().toLowerCase()));
 

--- a/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/TELEMETRY_INFO/controller.js
+++ b/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/TELEMETRY_INFO/controller.js
@@ -1591,6 +1591,10 @@ function processStateFromSummaryEnergy(summary, _grandTotal) {
       perc: _pct(_climatTot),
       // Subcategories available for detailed tooltips
       subcategories: summary.climatizacao?.subcategories || null,
+      // RFC-0207 "parent": device(s) que headam a composição. Quando presente e
+      // não-vazio, o tooltip renderiza o pai no topo e a composição aninhada
+      // abaixo dele. Ausente/vazio ⇒ composição plana (comportamento de antes).
+      parents: summary.climatizacao?.parents || [],
     },
     elevadores: {
       devices: elevadoresDevices,
@@ -2824,6 +2828,41 @@ function buildClimatizacaoContent() {
     `;
   }
 
+  // RFC-0207 "parent": quando um device foi declarado PAI da composição, ele
+  // aparece como uma linha no TOPO da Composição (com o valor dele = total do
+  // card) e as subcategorias existentes ficam ANINHADAS (indentadas) abaixo. O
+  // pai NÃO é somado por cima da composição — o total já é o valor dele. Campo
+  // ausente/vazio ⇒ composição plana, exatamente como antes.
+  const _escClim = (s) =>
+    String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  const climParents = STATE.consumidores.climatizacao?.parents || [];
+  const _hasClimParents = Array.isArray(climParents) && climParents.length > 0;
+  let composicaoHtml = subcatHtml;
+  if (_hasClimParents) {
+    const parentLines = climParents
+      .map(
+        (p) => `
+          <div class="myio-info-tooltip__category myio-info-tooltip__category--climatizacao myio-info-tooltip__category--parent">
+            <span class="myio-info-tooltip__category-icon">🔌</span>
+            <div class="myio-info-tooltip__category-info">
+              <div class="myio-info-tooltip__category-name">${_escClim(p.label)}</div>
+              <div class="myio-info-tooltip__category-desc">Medidor pai da composição</div>
+            </div>
+            <span class="myio-info-tooltip__category-value">${formatEnergy(p.total || 0)}</span>
+          </div>
+        `
+      )
+      .join('');
+    composicaoHtml = `${parentLines}
+      <div class="myio-info-tooltip__nested" style="margin-left:16px; padding-left:10px; border-left:2px solid rgba(0,200,150,0.28);">
+        ${subcatHtml}
+      </div>`;
+  }
+
   return `
     <div class="myio-info-tooltip__section">
       <div class="myio-info-tooltip__section-title">
@@ -2849,13 +2888,17 @@ function buildClimatizacaoContent() {
       <div class="myio-info-tooltip__section-title">
         <span>📋</span> Composição
       </div>
-      ${subcatHtml}
+      ${composicaoHtml}
     </div>
 
     <div class="myio-info-tooltip__notice">
       <span class="myio-info-tooltip__notice-icon">💡</span>
       <div class="myio-info-tooltip__notice-text">
-        O valor de <strong>Climatização</strong> é calculado pela soma do consumo de todos os equipamentos classificados nestas categorias.
+        ${
+          _hasClimParents
+            ? 'O valor de <strong>Climatização</strong> é o do <strong>medidor pai</strong> da composição; as subcategorias abaixo dele são o detalhamento (não somam por cima).'
+            : 'O valor de <strong>Climatização</strong> é calculado pela soma do consumo de todos os equipamentos classificados nestas categorias.'
+        }
       </div>
     </div>
     ${buildExcludedFromCAGNotice()}

--- a/src/utils/devices/deviceClassificationProfile.ts
+++ b/src/utils/devices/deviceClassificationProfile.ts
@@ -109,6 +109,38 @@ export interface ConditionalRule extends IdentifierMatch {
   deviceTypes?: string[];
 }
 
+/**
+ * RFC-0207 "Dispositivos Específicos" — modo de um override por dispositivo.
+ *
+ * - `include` — o device AGREGA nesta categoria do breakdown **mantendo o seu
+ *   grupo**. `resolveGroup` não muda: o total da coluna (ex.: Entrada) fica
+ *   idêntico. O device é apenas somado a mais na categoria.
+ * - `exclude` — o device sai do breakdown **inteiro**. Não cai em `outros` nem em
+ *   nenhum outro bucket. Existe para dupla-medição (o submedidor já está dentro
+ *   da leitura do trafo); mandá-lo para `outros` seria recontá-lo.
+ */
+export type DeviceOverrideMode = 'include' | 'exclude';
+
+/**
+ * Override explícito por dispositivo (escape hatch topológico).
+ *
+ * É uma LISTA DE VALORES, nunca um predicado (RFC-0207 §A proíbe
+ * predicates-as-data). `id` é o TB entity id — a MESMA chave usada por
+ * `excludeDevicesAtCountSubtotalCAG` (`String(item.id)`, comparada
+ * trim+lowercase).
+ *
+ * ⚠️ Escala mal e quebra em re-provisionamento (o entity id do TB muda). Regras
+ * por atributo (`deviceProfiles`/`profileContains`/`identifier*`) continuam sendo
+ * o caminho padrão; overrides são exceção topológica.
+ */
+export interface DeviceOverride {
+  /** TB entity id do dispositivo. */
+  id: string;
+  /** Guardado só para exibição/resiliência na UI (o motor NUNCA classifica por nome). */
+  label?: string;
+  mode: DeviceOverrideMode;
+}
+
 /** A single (non-fallback) category rule. */
 export interface CategoryRule {
   name: Exclude<CategoryName, 'lojas'>; // lojas is handled by the store shortcut
@@ -136,6 +168,13 @@ export interface CategoryRule {
   conditional?: ConditionalRule;
   /** Identifier-fallback hit list, mirroring classifyDeviceByIdentifier. */
   identifierFallback?: IdentifierMatch;
+  /**
+   * RFC-0207 "Dispositivos Específicos" — overrides explícitos por dispositivo.
+   *
+   * OPCIONAL e retrocompatível: ausente ⇒ comportamento idêntico ao de antes
+   * (`selectBreakdownItems` tem fast-path para "zero overrides").
+   */
+  deviceOverrides?: DeviceOverride[];
   fallback?: boolean;
 }
 
@@ -519,6 +558,145 @@ export function resolveCategory(
 }
 
 // ---------------------------------------------------------------------------
+// Dispositivos Específicos — device-level overrides for the BREAKDOWN
+//
+// Por que existem, em uma frase: `resolveGroup` aloca cada device em UM grupo só
+// (invariante de coerência dos totais — não é para ser abolida) e o breakdown do
+// TELEMETRY_INFO só percorre o grupo residual (`areacomum`). Um trafo de entrada
+// que mede TODA a carga da CAG fica, portanto, estruturalmente invisível ao card
+// de Climatização — mesmo sendo, fisicamente, climatização.
+//
+// Os overrides são o escape hatch: por dispositivo, explícito, sem tocar em
+// `resolveGroup` e sem inventar predicados novos no JSON.
+// ---------------------------------------------------------------------------
+
+/** Chave de comparação de device id — mesma normalização de `excludeDevicesAtCountSubtotalCAG`. */
+export function normalizeDeviceOverrideId(id: unknown): string {
+  return String(id ?? '').trim().toLowerCase();
+}
+
+export interface CollectedDeviceOverrides {
+  /** device id normalizado → categoria na qual ele deve ser AGREGADO. */
+  includes: Map<string, CategoryName>;
+  /** device ids normalizados removidos do breakdown por inteiro. */
+  excludes: Set<string>;
+  /** device id normalizado → label capturado na edição (exibição/diagnóstico). */
+  labels: Map<string, string>;
+}
+
+/**
+ * Achata os `deviceOverrides` de TODAS as categorias de um domínio.
+ *
+ * Regras de precedência (decididas, não negociáveis aqui):
+ *  - `exclude` vence `include` — se o mesmo device aparecer nos dois, ele sai do
+ *    breakdown. `exclude` é global (vale para o breakdown inteiro), `include` é
+ *    por categoria.
+ *  - Primeiro `include` na ordem das regras vence, caso o device apareça como
+ *    `include` em mais de uma categoria (alocação única também no breakdown).
+ */
+export function collectDeviceOverrides(
+  profile: DeviceClassificationProfile = getActiveProfile(),
+  domain: ClassificationDomain = 'energy',
+): CollectedDeviceOverrides {
+  const includes = new Map<string, CategoryName>();
+  const excludes = new Set<string>();
+  const labels = new Map<string, string>();
+
+  const rules = getDomain(profile, domain).categories?.rules ?? [];
+  for (const rule of rules) {
+    for (const ov of rule.deviceOverrides ?? []) {
+      const key = normalizeDeviceOverrideId(ov?.id);
+      if (!key) continue;
+      if (ov.label) labels.set(key, String(ov.label));
+      if (ov.mode === 'exclude') excludes.add(key);
+      else if (!includes.has(key)) includes.set(key, rule.name);
+    }
+  }
+  // exclude vence include
+  for (const key of excludes) includes.delete(key);
+
+  return { includes, excludes, labels };
+}
+
+/** Um item elegível ao breakdown + a categoria forçada por override (ou `null`). */
+export interface BreakdownEntry<T> {
+  item: T;
+  /**
+   * Categoria imposta por um override `include`. `null` ⇒ classificar
+   * normalmente com `resolveCategory`.
+   */
+  forcedCategory: CategoryName | null;
+}
+
+export interface SelectBreakdownItemsOptions {
+  /** Grupo que alimenta o breakdown (default `areacomum`, o residual do energy). */
+  baseGroup?: string;
+}
+
+/**
+ * Monta a lista de itens que o breakdown (TELEMETRY_INFO) deve percorrer,
+ * aplicando os Dispositivos Específicos.
+ *
+ *  - base = `groups[baseGroup]` (hoje `areacomum`), na ordem original;
+ *  - itens `exclude` são REMOVIDOS (não caem em `outros`);
+ *  - itens `include` são PUXADOS de qualquer grupo (tipicamente `entrada`) e
+ *    marcados com `forcedCategory` — o grupo deles NÃO muda, então o total da
+ *    coluna Entrada continua idêntico.
+ *
+ * Função pura: sem DOM, sem fetch. Quando não há nenhum override, devolve
+ * exatamente `groups[baseGroup]` (zero mudança de comportamento).
+ */
+export function selectBreakdownItems<T extends ClassifiableItem>(
+  groups: Record<string, T[] | undefined | null>,
+  profile: DeviceClassificationProfile = getActiveProfile(),
+  domain: ClassificationDomain = 'energy',
+  options: SelectBreakdownItemsOptions = {},
+): BreakdownEntry<T>[] {
+  const baseGroup = options.baseGroup || 'areacomum';
+  const base = (groups?.[baseGroup] ?? []) as T[];
+
+  const { includes, excludes } = collectDeviceOverrides(profile, domain);
+
+  // Fast-path: perfil sem Dispositivos Específicos ⇒ o breakdown de sempre.
+  if (includes.size === 0 && excludes.size === 0) {
+    return base.map((item) => ({ item, forcedCategory: null }));
+  }
+
+  const out: BreakdownEntry<T>[] = [];
+  const seen = new Set<string>();
+
+  for (const item of base) {
+    const key = normalizeDeviceOverrideId((item as { id?: unknown })?.id);
+    if (key) {
+      if (excludes.has(key)) continue;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const forced = includes.get(key);
+      out.push({ item, forcedCategory: forced ?? null });
+      continue;
+    }
+    out.push({ item, forcedCategory: null });
+  }
+
+  if (includes.size === 0) return out;
+
+  // Puxa os `include` que vivem FORA do grupo base (tipicamente `entrada`).
+  for (const groupKey of Object.keys(groups || {})) {
+    if (groupKey === baseGroup) continue;
+    for (const item of (groups[groupKey] ?? []) as T[]) {
+      const key = normalizeDeviceOverrideId((item as { id?: unknown })?.id);
+      if (!key || excludes.has(key) || seen.has(key)) continue;
+      const forced = includes.get(key);
+      if (!forced) continue;
+      seen.add(key);
+      out.push({ item, forcedCategory: forced });
+    }
+  }
+
+  return out;
+}
+
+// ---------------------------------------------------------------------------
 // validateProfile — structural integrity (closes bug #3)
 // ---------------------------------------------------------------------------
 
@@ -606,6 +784,32 @@ export function validateProfile(profile: DeviceClassificationProfile): string[] 
         if (r.combinedContains !== undefined && !Array.isArray(r.combinedContains)) {
           errors.push(`${domain}.categories.rules["${r?.name}"].combinedContains: must be an array`);
         }
+        // RFC-0207 "Dispositivos Específicos" — lista de valores por dispositivo.
+        // Campo OPCIONAL: ausente não gera erro (retrocompat total).
+        if (r.deviceOverrides !== undefined) {
+          if (!Array.isArray(r.deviceOverrides)) {
+            errors.push(
+              `${domain}.categories.rules["${r?.name}"].deviceOverrides: must be an array`,
+            );
+          } else {
+            r.deviceOverrides.forEach((ov, i) => {
+              const where = `${domain}.categories.rules["${r?.name}"].deviceOverrides[${i}]`;
+              if (!ov || typeof ov !== 'object') {
+                errors.push(`${where}: must be an object`);
+                return;
+              }
+              if (!ov.id || typeof ov.id !== 'string' || !ov.id.trim()) {
+                errors.push(`${where}.id: missing device id`);
+              }
+              if (ov.mode !== 'include' && ov.mode !== 'exclude') {
+                errors.push(`${where}.mode: must be "include" or "exclude"`);
+              }
+              if (ov.label !== undefined && typeof ov.label !== 'string') {
+                errors.push(`${where}.label: must be a string`);
+              }
+            });
+          }
+        }
       }
       // exactly one fallback across the category family (the 'outros' bucket)
       const inlineFallbacks = catRules.filter((r) => r.fallback === true).length;
@@ -688,6 +892,25 @@ export function normalizeProfile(raw: DeviceClassificationProfile): DeviceClassi
           upIdMatch(r.conditional);
         }
         upIdMatch(r.identifierFallback);
+        // RFC-0207 "Dispositivos Específicos": IDs e labels NUNCA são
+        // upper-cased. `id` é um UUID do TB (comparado trim+lowercase, igual a
+        // `excludeDevicesAtCountSubtotalCAG`) e `label` é texto de exibição.
+        // Só entradas estruturalmente sãs sobrevivem; ausência do campo é
+        // preservada como ausência (retrocompat).
+        if (r.deviceOverrides !== undefined) {
+          r.deviceOverrides = (Array.isArray(r.deviceOverrides) ? r.deviceOverrides : [])
+            .filter((ov) => ov && typeof ov === 'object' && String(ov.id ?? '').trim())
+            .map((ov) => {
+              const out: DeviceOverride = {
+                id: String(ov.id).trim(),
+                mode: ov.mode === 'exclude' ? 'exclude' : 'include',
+              };
+              if (ov.label !== undefined && ov.label !== null) out.label = String(ov.label);
+              return out;
+            })
+            // dedupe por (id, mode) mantendo a primeira ocorrência
+            .filter((ov, i, arr) => arr.findIndex((o) => o.id === ov.id && o.mode === ov.mode) === i);
+        }
       }
     }
   }

--- a/src/utils/devices/deviceClassificationProfile.ts
+++ b/src/utils/devices/deviceClassificationProfile.ts
@@ -626,6 +626,18 @@ export interface BreakdownEntry<T> {
    * normalmente com `resolveCategory`.
    */
   forcedCategory: CategoryName | null;
+  /** Grupo de onde o item veio (chave de `groups`). */
+  sourceGroup: string;
+  /**
+   * `true` quando o item veio do grupo BASE (e portanto já está dentro do total
+   * daquele grupo); `false` quando foi PUXADO de outro grupo por um `include`.
+   *
+   * O consumidor **precisa** dessa distinção para o residual: o total do grupo
+   * base não contém os itens cross-group, então subtrair o subtotal cheio dele
+   * produz um residual negativo pelo valor exato do item puxado.
+   * Ver `computeBaseGroupResidual`.
+   */
+  fromBaseGroup: boolean;
 }
 
 export interface SelectBreakdownItemsOptions {
@@ -659,7 +671,12 @@ export function selectBreakdownItems<T extends ClassifiableItem>(
 
   // Fast-path: perfil sem Dispositivos Específicos ⇒ o breakdown de sempre.
   if (includes.size === 0 && excludes.size === 0) {
-    return base.map((item) => ({ item, forcedCategory: null }));
+    return base.map((item) => ({
+      item,
+      forcedCategory: null,
+      sourceGroup: baseGroup,
+      fromBaseGroup: true,
+    }));
   }
 
   const out: BreakdownEntry<T>[] = [];
@@ -672,15 +689,21 @@ export function selectBreakdownItems<T extends ClassifiableItem>(
       if (seen.has(key)) continue;
       seen.add(key);
       const forced = includes.get(key);
-      out.push({ item, forcedCategory: forced ?? null });
+      out.push({
+        item,
+        forcedCategory: forced ?? null,
+        sourceGroup: baseGroup,
+        fromBaseGroup: true,
+      });
       continue;
     }
-    out.push({ item, forcedCategory: null });
+    out.push({ item, forcedCategory: null, sourceGroup: baseGroup, fromBaseGroup: true });
   }
 
   if (includes.size === 0) return out;
 
   // Puxa os `include` que vivem FORA do grupo base (tipicamente `entrada`).
+  // Estes NÃO estão dentro do total do grupo base — daí `fromBaseGroup: false`.
   for (const groupKey of Object.keys(groups || {})) {
     if (groupKey === baseGroup) continue;
     for (const item of (groups[groupKey] ?? []) as T[]) {
@@ -689,11 +712,73 @@ export function selectBreakdownItems<T extends ClassifiableItem>(
       const forced = includes.get(key);
       if (!forced) continue;
       seen.add(key);
-      out.push({ item, forcedCategory: forced });
+      out.push({ item, forcedCategory: forced, sourceGroup: groupKey, fromBaseGroup: false });
     }
   }
 
   return out;
+}
+
+// ---------------------------------------------------------------------------
+// Residual do grupo base × includes cross-group
+// ---------------------------------------------------------------------------
+
+/** Um subtotal do breakdown, decomposto por origem. */
+export interface BreakdownSubtotalInput {
+  /** Nome da categoria — só diagnóstico. */
+  category: string;
+  /** Total EXIBIDO no card (inclui a parcela cross-group). */
+  total: number;
+  /** Parcela de `total` que veio de devices FORA do grupo base. */
+  crossGroupTotal: number;
+}
+
+export interface BaseGroupResidual {
+  /** Soma das parcelas que estão de fato dentro de `baseGroupTotal`. */
+  subtotalFromBaseGroup: number;
+  /** Soma das parcelas cross-group (informativo). */
+  subtotalCrossGroup: number;
+  /** Residual ANTES do clamp. Negativo aqui = problema real de dado/config. */
+  residualRaw: number;
+  /** Residual publicável (clamp em 0). */
+  residual: number;
+  /** `true` quando `residualRaw < 0`. */
+  negative: boolean;
+}
+
+/**
+ * Residual do grupo base (Área Comum) na presença de includes cross-group.
+ *
+ * O bug que esta função existe para impedir: `residual = baseGroupTotal −
+ * Σ subtotais` assume que TODO subtotal é composto de devices que estão dentro
+ * de `baseGroupTotal`. Um `include` cross-group quebra a premissa — o trafo da
+ * Ilha (637.560) entra no subtotal de climatização mas vive no grupo `entrada`
+ * e nunca fez parte do `areacomumTotal`. O residual ia negativo pelo valor
+ * exato do device puxado, e o `Math.max(0, …)` mascarava.
+ *
+ * A correção: o **card** continua mostrando o total cheio (é o objetivo do
+ * recurso), mas o **residual** desconta apenas a parcela de origem-base.
+ */
+export function computeBaseGroupResidual(
+  baseGroupTotal: number,
+  subtotals: BreakdownSubtotalInput[],
+): BaseGroupResidual {
+  let subtotalFromBaseGroup = 0;
+  let subtotalCrossGroup = 0;
+  for (const s of subtotals ?? []) {
+    const total = Number(s?.total) || 0;
+    const cross = Number(s?.crossGroupTotal) || 0;
+    subtotalFromBaseGroup += total - cross;
+    subtotalCrossGroup += cross;
+  }
+  const residualRaw = (Number(baseGroupTotal) || 0) - subtotalFromBaseGroup;
+  return {
+    subtotalFromBaseGroup,
+    subtotalCrossGroup,
+    residualRaw,
+    residual: Math.max(0, residualRaw),
+    negative: residualRaw < 0,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/utils/devices/deviceClassificationProfile.ts
+++ b/src/utils/devices/deviceClassificationProfile.ts
@@ -114,12 +114,26 @@ export interface ConditionalRule extends IdentifierMatch {
  *
  * - `include` — o device AGREGA nesta categoria do breakdown **mantendo o seu
  *   grupo**. `resolveGroup` não muda: o total da coluna (ex.: Entrada) fica
- *   idêntico. O device é apenas somado a mais na categoria.
+ *   idêntico. O device é apenas somado a mais na categoria (feed PARALELO — o
+ *   caso do Shopping da Ilha, onde o trafo da CAG é energia ADICIONAL).
  * - `exclude` — o device sai do breakdown **inteiro**. Não cai em `outros` nem em
  *   nenhum outro bucket. Existe para dupla-medição (o submedidor já está dentro
  *   da leitura do trafo); mandá-lo para `outros` seria recontá-lo.
+ * - `parent` — o device é o **PAI** da composição da categoria: o valor DELE vira
+ *   o total da categoria e a composição auto-classificada (Chillers/Fancoils/…)
+ *   é o BREAKDOWN dele — mostrada aninhada, mas **NÃO somada por cima** do pai
+ *   (evita a dupla contagem). É o caso do Moxuara: o medidor de ENTRADA da CAG
+ *   (`CAG-Entrada`, 336.600) CONTÉM os submedidores internos (326.973); os filhos
+ *   estão a jusante do pai. Contraste com `include`: `include` SOMA (feed
+ *   paralelo), `parent` CONTÉM (a composição). Mesmo gesto de UI, matemática de
+ *   total OPOSTA — só o operador sabe qual dos dois é, por isso é escolha
+ *   explícita, nunca inferida. Como `include`, o device é PUXADO do grupo dele
+ *   (o grupo NÃO muda; o total da coluna de origem continua igual).
+ *
+ * Retrocompat: ausência do campo = comportamento de sempre; bundles antigos da
+ * lib coagem `parent` → `include` (degradação documentada — vira feed paralelo).
  */
-export type DeviceOverrideMode = 'include' | 'exclude';
+export type DeviceOverrideMode = 'include' | 'exclude' | 'parent';
 
 /**
  * Override explícito por dispositivo (escape hatch topológico).
@@ -576,8 +590,20 @@ export function normalizeDeviceOverrideId(id: unknown): string {
 }
 
 export interface CollectedDeviceOverrides {
-  /** device id normalizado → categoria na qual ele deve ser AGREGADO. */
+  /**
+   * device id normalizado → categoria na qual ele deve ser PUXADO ao breakdown.
+   * Contém tanto os `include` quanto os `parent` (ambos são puxados do grupo de
+   * origem e recebem `forcedCategory`); o que distingue os dois é o mapa
+   * `parents` abaixo, que só a matemática do total lê.
+   */
   includes: Map<string, CategoryName>;
+  /**
+   * device id normalizado → categoria da qual ele é PAI. Subconjunto de
+   * `includes`. Um pai CONTÉM a composição da categoria (o total da categoria
+   * passa a ser o valor do pai; a composição vira breakdown aninhado, não somado
+   * por cima). Vazio quando não há nenhum `parent`.
+   */
+  parents: Map<string, CategoryName>;
   /** device ids normalizados removidos do breakdown por inteiro. */
   excludes: Set<string>;
   /** device id normalizado → label capturado na edição (exibição/diagnóstico). */
@@ -599,6 +625,7 @@ export function collectDeviceOverrides(
   domain: ClassificationDomain = 'energy',
 ): CollectedDeviceOverrides {
   const includes = new Map<string, CategoryName>();
+  const parents = new Map<string, CategoryName>();
   const excludes = new Set<string>();
   const labels = new Map<string, string>();
 
@@ -608,14 +635,24 @@ export function collectDeviceOverrides(
       const key = normalizeDeviceOverrideId(ov?.id);
       if (!key) continue;
       if (ov.label) labels.set(key, String(ov.label));
-      if (ov.mode === 'exclude') excludes.add(key);
-      else if (!includes.has(key)) includes.set(key, rule.name);
+      if (ov.mode === 'exclude') {
+        excludes.add(key);
+      } else if (!includes.has(key)) {
+        // `parent` e `include` ambos entram em `includes` (ambos são puxados +
+        // recebem forcedCategory); `parent` é adicionalmente marcado em `parents`
+        // para que só a matemática do total troque SOMAR por CONTER.
+        includes.set(key, rule.name);
+        if (ov.mode === 'parent') parents.set(key, rule.name);
+      }
     }
   }
-  // exclude vence include
-  for (const key of excludes) includes.delete(key);
+  // exclude vence include (e vence parent — parent é uma variante de include)
+  for (const key of excludes) {
+    includes.delete(key);
+    parents.delete(key);
+  }
 
-  return { includes, excludes, labels };
+  return { includes, parents, excludes, labels };
 }
 
 /** Um item elegível ao breakdown + a categoria forçada por override (ou `null`). */
@@ -638,6 +675,18 @@ export interface BreakdownEntry<T> {
    * Ver `computeBaseGroupResidual`.
    */
   fromBaseGroup: boolean;
+  /**
+   * `true` quando o item é PAI da composição da sua categoria (override `parent`).
+   * O consumidor usa isto para trocar a matemática do total: o valor do pai
+   * VIRA o total da categoria, e a composição auto-classificada é o breakdown
+   * aninhado (não somado por cima).
+   *
+   * OPCIONAL e emitido SÓ quando `true` (nunca `false`): mantém as entradas de
+   * `include`/base/fast-path byte-idênticas às de antes do modo `parent`
+   * (retrocompat — perfis sem pai não ganham chave nova). Leia como
+   * `entry.isParent === true`; ausência ⇒ não é pai.
+   */
+  isParent?: boolean;
 }
 
 export interface SelectBreakdownItemsOptions {
@@ -667,7 +716,7 @@ export function selectBreakdownItems<T extends ClassifiableItem>(
   const baseGroup = options.baseGroup || 'areacomum';
   const base = (groups?.[baseGroup] ?? []) as T[];
 
-  const { includes, excludes } = collectDeviceOverrides(profile, domain);
+  const { includes, parents, excludes } = collectDeviceOverrides(profile, domain);
 
   // Fast-path: perfil sem Dispositivos Específicos ⇒ o breakdown de sempre.
   if (includes.size === 0 && excludes.size === 0) {
@@ -681,6 +730,10 @@ export function selectBreakdownItems<T extends ClassifiableItem>(
 
   const out: BreakdownEntry<T>[] = [];
   const seen = new Set<string>();
+  // `isParent` só é emitido quando true (ver BreakdownEntry) — mantém entradas
+  // de include/base byte-idênticas.
+  const parentFlag = (key: string): { isParent: true } | Record<string, never> =>
+    parents.has(key) ? { isParent: true } : {};
 
   for (const item of base) {
     const key = normalizeDeviceOverrideId((item as { id?: unknown })?.id);
@@ -694,6 +747,7 @@ export function selectBreakdownItems<T extends ClassifiableItem>(
         forcedCategory: forced ?? null,
         sourceGroup: baseGroup,
         fromBaseGroup: true,
+        ...parentFlag(key),
       });
       continue;
     }
@@ -702,7 +756,7 @@ export function selectBreakdownItems<T extends ClassifiableItem>(
 
   if (includes.size === 0) return out;
 
-  // Puxa os `include` que vivem FORA do grupo base (tipicamente `entrada`).
+  // Puxa os `include`/`parent` que vivem FORA do grupo base (tipicamente `entrada`).
   // Estes NÃO estão dentro do total do grupo base — daí `fromBaseGroup: false`.
   for (const groupKey of Object.keys(groups || {})) {
     if (groupKey === baseGroup) continue;
@@ -712,7 +766,13 @@ export function selectBreakdownItems<T extends ClassifiableItem>(
       const forced = includes.get(key);
       if (!forced) continue;
       seen.add(key);
-      out.push({ item, forcedCategory: forced, sourceGroup: groupKey, fromBaseGroup: false });
+      out.push({
+        item,
+        forcedCategory: forced,
+        sourceGroup: groupKey,
+        fromBaseGroup: false,
+        ...parentFlag(key),
+      });
     }
   }
 
@@ -731,6 +791,21 @@ export interface BreakdownSubtotalInput {
   total: number;
   /** Parcela de `total` que veio de devices FORA do grupo base. */
   crossGroupTotal: number;
+  /**
+   * RFC-0207 "parent" — parcela EXPLÍCITA que está de fato dentro do
+   * `baseGroupTotal` e deve ser descontada no residual.
+   *
+   * Existe porque o modo `parent` QUEBRA a premissa `base = total − cross`: quando
+   * o pai (ex.: CAG-Entrada, 336.600, cross-group) SUBSTITUI a composição no card,
+   * `total` passa a ser o valor do pai — não mais a soma dos filhos. Os FILHOS
+   * (326.973), que continuam fisicamente no grupo base, é que precisam ser
+   * descontados do residual; o pai, nunca (é cross-group, jamais esteve em
+   * `baseGroupTotal`). Passe aqui a soma dos filhos de origem-base.
+   *
+   * Ausente/`undefined` ⇒ cai no cálculo de sempre `total − crossGroupTotal`
+   * (byte-idêntico ao de antes; `include`/sem-override não usam este campo).
+   */
+  baseGroupContribution?: number;
 }
 
 export interface BaseGroupResidual {
@@ -768,7 +843,14 @@ export function computeBaseGroupResidual(
   for (const s of subtotals ?? []) {
     const total = Number(s?.total) || 0;
     const cross = Number(s?.crossGroupTotal) || 0;
-    subtotalFromBaseGroup += total - cross;
+    // `parent`: quando o card mostra o valor do PAI (cross-group) no lugar da
+    // composição, a parcela de origem-base é a soma dos FILHOS, não `total−cross`
+    // (que daria ~0 porque total==cross). O caller passa essa parcela explícita.
+    const base =
+      s?.baseGroupContribution !== undefined && s?.baseGroupContribution !== null
+        ? Number(s.baseGroupContribution) || 0
+        : total - cross;
+    subtotalFromBaseGroup += base;
     subtotalCrossGroup += cross;
   }
   const residualRaw = (Number(baseGroupTotal) || 0) - subtotalFromBaseGroup;
@@ -886,8 +968,8 @@ export function validateProfile(profile: DeviceClassificationProfile): string[] 
               if (!ov.id || typeof ov.id !== 'string' || !ov.id.trim()) {
                 errors.push(`${where}.id: missing device id`);
               }
-              if (ov.mode !== 'include' && ov.mode !== 'exclude') {
-                errors.push(`${where}.mode: must be "include" or "exclude"`);
+              if (ov.mode !== 'include' && ov.mode !== 'exclude' && ov.mode !== 'parent') {
+                errors.push(`${where}.mode: must be "include", "exclude" or "parent"`);
               }
               if (ov.label !== undefined && typeof ov.label !== 'string') {
                 errors.push(`${where}.label: must be a string`);
@@ -988,7 +1070,8 @@ export function normalizeProfile(raw: DeviceClassificationProfile): DeviceClassi
             .map((ov) => {
               const out: DeviceOverride = {
                 id: String(ov.id).trim(),
-                mode: ov.mode === 'exclude' ? 'exclude' : 'include',
+                mode:
+                  ov.mode === 'exclude' ? 'exclude' : ov.mode === 'parent' ? 'parent' : 'include',
               };
               if (ov.label !== undefined && ov.label !== null) out.label = String(ov.label);
               return out;

--- a/tests/deviceClassificationProfile.deviceOverrides.test.ts
+++ b/tests/deviceClassificationProfile.deviceOverrides.test.ts
@@ -266,7 +266,30 @@ describe('RFC-0207 deviceOverrides — selectBreakdownItems', () => {
     const anon = { label: 'sem id', deviceProfile: 'ILUMINACAO', value: 5 } as unknown as Device;
     const p = profileWithOverrides([{ id: TRAFO_CAG_ID, mode: 'include' }]);
     const entries = selectBreakdownItems<Device>({ areacomum: [anon], entrada: [] }, p);
-    expect(entries).toEqual([{ item: anon, forcedCategory: null }]);
+    expect(entries).toEqual([
+      { item: anon, forcedCategory: null, sourceGroup: 'areacomum', fromBaseGroup: true },
+    ]);
+  });
+
+  it('marca a origem de cada entrada (fromBaseGroup / sourceGroup)', () => {
+    const p = profileWithOverrides([{ id: TRAFO_CAG_ID, mode: 'include' }]);
+    const groups = groupAll(ALL_DEVICES, p);
+    const entries = selectBreakdownItems<Device>(groups, p);
+
+    const pulled = entries.find((e) => e.item.id === TRAFO_CAG_ID)!;
+    expect(pulled.fromBaseGroup).toBe(false);
+    expect(pulled.sourceGroup).toBe('entrada');
+
+    const native = entries.find((e) => e.item.id === OUTRO_AREACOMUM.id)!;
+    expect(native.fromBaseGroup).toBe(true);
+    expect(native.sourceGroup).toBe('areacomum');
+  });
+
+  it('sem overrides, TODA entrada vem do grupo base', () => {
+    const groups = groupAll(ALL_DEVICES, DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    const entries = selectBreakdownItems<Device>(groups, DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    expect(entries.every((e) => e.fromBaseGroup === true)).toBe(true);
+    expect(entries.every((e) => e.sourceGroup === 'areacomum')).toBe(true);
   });
 
   it('baseGroup é configurável', () => {

--- a/tests/deviceClassificationProfile.deviceOverrides.test.ts
+++ b/tests/deviceClassificationProfile.deviceOverrides.test.ts
@@ -1,0 +1,353 @@
+/**
+ * RFC-0207 "Dispositivos Específicos" — device-level overrides in the breakdown.
+ *
+ * Cenário real (Shopping da Ilha):
+ *   - "Medição Geral CAG" (deviceProfile ENTRADA, identifier CAG) é um TRAFO DE
+ *     ENTRADA que mede TODA a alimentação da CAG: 637.560. Ele fica no grupo
+ *     `entrada` (correto — conta no total de entrada), mas o operador quer que o
+ *     valor apareça TAMBÉM no card de Climatização, porque aquela energia É
+ *     climatização.
+ *   - As 9 "Bomba CAG" (deviceProfile BOMBA_CAG, identifier CAG) somam 155.671 e
+ *     JÁ caem em climatização pela regra de identifier. Elas estão FISICAMENTE
+ *     DENTRO dos 637.560 do trafo → precisam sair do breakdown, senão o card
+ *     dobra a contagem (793.231).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_DEVICE_CLASSIFICATION_PROFILE,
+  resolveGroup,
+  resolveCategory,
+  validateProfile,
+  normalizeProfile,
+  collectDeviceOverrides,
+  selectBreakdownItems,
+  normalizeDeviceOverrideId,
+  type DeviceClassificationProfile,
+  type ClassifiableItem,
+  type CategoryName,
+} from '../src/utils/devices/deviceClassificationProfile';
+
+// ---------------------------------------------------------------------------
+// Fixture — números reais do Shopping da Ilha
+// ---------------------------------------------------------------------------
+
+interface Device extends ClassifiableItem {
+  id: string;
+  label: string;
+  value: number;
+}
+
+const TRAFO_CAG_ID = 'a1b2c3d4-0000-0000-0000-00000000cag0';
+
+const GERAL_ENTRADA: Device = {
+  id: 'e0000000-0000-0000-0000-000000000001',
+  label: 'Geral Entrada',
+  deviceProfile: 'ENTRADA',
+  identifier: 'ENTRADA-GERAL',
+  value: 752677,
+};
+
+const MEDICAO_GERAL_CAG: Device = {
+  id: TRAFO_CAG_ID,
+  label: 'Medição Geral CAG',
+  deviceProfile: 'ENTRADA',
+  identifier: 'CAG',
+  value: 637560,
+};
+
+// 9 bombas somando 155.671 (a 9ª fecha a conta).
+const BOMBA_VALUES = [17297, 17297, 17297, 17297, 17297, 17297, 17297, 17297, 17295];
+const BOMBAS: Device[] = BOMBA_VALUES.map((value, i) => ({
+  id: `b0000000-0000-0000-0000-00000000000${i + 1}`,
+  label: `Bomba CAG ${i + 3}`,
+  deviceProfile: 'BOMBA_CAG',
+  identifier: 'CAG',
+  value,
+}));
+
+const OUTRO_AREACOMUM: Device = {
+  id: 'c0000000-0000-0000-0000-000000000001',
+  label: 'Iluminação Mall',
+  deviceProfile: 'ILUMINACAO',
+  identifier: 'ILU-01',
+  value: 1000,
+};
+
+function clone<T>(o: T): T {
+  return JSON.parse(JSON.stringify(o));
+}
+
+/** Perfil DEFAULT + os overrides pedidos, já normalizado (como no save do modal). */
+function profileWithOverrides(
+  overrides: { id: string; label?: string; mode: 'include' | 'exclude' }[],
+  category: CategoryName = 'climatizacao',
+): DeviceClassificationProfile {
+  const p: DeviceClassificationProfile = clone(DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+  const rule = p.domains.energy.categories!.rules.find((r) => r.name === category)!;
+  rule.deviceOverrides = overrides;
+  return normalizeProfile(p);
+}
+
+/** Reproduz o laço do breakdown do MAIN_VIEW (buildSummary) sobre os grupos. */
+function runBreakdown(groups: Record<string, Device[]>, profile: DeviceClassificationProfile) {
+  const buckets: Record<string, Device[]> = {};
+  for (const { item, forcedCategory } of selectBreakdownItems<Device>(groups, profile, 'energy')) {
+    const cat = forcedCategory || resolveCategory(item, profile, 'energy').category;
+    (buckets[cat] ||= []).push(item);
+  }
+  const totals: Record<string, number> = {};
+  for (const [k, list] of Object.entries(buckets)) {
+    totals[k] = list.reduce((s, i) => s + i.value, 0);
+  }
+  return { buckets, totals };
+}
+
+/** Agrupa os devices como o categorizeItemsByGroup faria. */
+function groupAll(devices: Device[], profile: DeviceClassificationProfile) {
+  const groups: Record<string, Device[]> = { lojas: [], entrada: [], areacomum: [], ocultos: [] };
+  for (const d of devices) groups[resolveGroup(d, profile, 'energy').group].push(d);
+  return groups;
+}
+
+const ALL_DEVICES = [GERAL_ENTRADA, MEDICAO_GERAL_CAG, ...BOMBAS, OUTRO_AREACOMUM];
+
+// ---------------------------------------------------------------------------
+
+describe('RFC-0207 deviceOverrides — schema', () => {
+  it('DEFAULT profile não declara deviceOverrides (campo é opt-in)', () => {
+    for (const rule of DEFAULT_DEVICE_CLASSIFICATION_PROFILE.domains.energy.categories!.rules) {
+      expect(rule.deviceOverrides).toBeUndefined();
+    }
+  });
+
+  it('ausência do campo não gera erro de validação (retrocompat)', () => {
+    expect(validateProfile(DEFAULT_DEVICE_CLASSIFICATION_PROFILE)).toEqual([]);
+  });
+
+  it('validateProfile aceita uma lista bem formada', () => {
+    const p = profileWithOverrides([
+      { id: TRAFO_CAG_ID, label: 'Medição Geral CAG', mode: 'include' },
+      { id: BOMBAS[0].id, label: 'Bomba CAG 3', mode: 'exclude' },
+    ]);
+    expect(validateProfile(p)).toEqual([]);
+  });
+
+  it('validateProfile acusa deviceOverrides não-array, id vazio, mode inválido e label não-string', () => {
+    const p: DeviceClassificationProfile = clone(DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    const rules = p.domains.energy.categories!.rules;
+    (rules.find((r) => r.name === 'elevadores') as Record<string, unknown>).deviceOverrides =
+      'nope';
+    rules.find((r) => r.name === 'climatizacao')!.deviceOverrides = [
+      { id: '   ', mode: 'include' },
+      { id: 'x', mode: 'maybe' as unknown as 'include' },
+      { id: 'y', mode: 'include', label: 42 as unknown as string },
+    ];
+    const errs = validateProfile(p);
+    expect(errs.some((e) => e.includes('deviceOverrides: must be an array'))).toBe(true);
+    expect(errs.some((e) => e.includes('deviceOverrides[0].id'))).toBe(true);
+    expect(errs.some((e) => e.includes('deviceOverrides[1].mode'))).toBe(true);
+    expect(errs.some((e) => e.includes('deviceOverrides[2].label'))).toBe(true);
+  });
+
+  it('normalizeProfile faz round-trip: preserva id/label, NÃO faz upper-case, dropa entradas sem id', () => {
+    const p: DeviceClassificationProfile = clone(DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    p.domains.energy.categories!.rules.find((r) => r.name === 'climatizacao')!.deviceOverrides = [
+      { id: `  ${TRAFO_CAG_ID}  `, label: 'Medição Geral CAG', mode: 'include' },
+      { id: '', label: 'lixo', mode: 'include' },
+      // duplicata exata → deduplicada
+      { id: TRAFO_CAG_ID, label: 'Medição Geral CAG', mode: 'include' },
+    ];
+    const n = normalizeProfile(p);
+    const ovs = n.domains.energy.categories!.rules.find((r) => r.name === 'climatizacao')!
+      .deviceOverrides!;
+    expect(ovs).toEqual([
+      { id: TRAFO_CAG_ID, mode: 'include', label: 'Medição Geral CAG' },
+    ]);
+    // idempotente
+    expect(normalizeProfile(n)).toEqual(n);
+  });
+
+  it('normalizeProfile mantém ausência como ausência', () => {
+    const n = normalizeProfile(clone(DEFAULT_DEVICE_CLASSIFICATION_PROFILE));
+    for (const rule of n.domains.energy.categories!.rules) {
+      expect(rule.deviceOverrides).toBeUndefined();
+    }
+  });
+
+  it('normalizeDeviceOverrideId usa a mesma chave de excludeDevicesAtCountSubtotalCAG', () => {
+    expect(normalizeDeviceOverrideId('  AbC-123 ')).toBe('abc-123');
+    expect(normalizeDeviceOverrideId(null)).toBe('');
+  });
+});
+
+describe('RFC-0207 deviceOverrides — collectDeviceOverrides', () => {
+  it('mapeia include → categoria e exclude → set global', () => {
+    const p = profileWithOverrides([
+      { id: TRAFO_CAG_ID, label: 'Medição Geral CAG', mode: 'include' },
+      { id: BOMBAS[0].id, mode: 'exclude' },
+    ]);
+    const { includes, excludes, labels } = collectDeviceOverrides(p, 'energy');
+    expect(includes.get(TRAFO_CAG_ID)).toBe('climatizacao');
+    expect(excludes.has(BOMBAS[0].id)).toBe(true);
+    expect(labels.get(TRAFO_CAG_ID)).toBe('Medição Geral CAG');
+  });
+
+  it('exclude vence include quando o mesmo device aparece nos dois', () => {
+    const p = profileWithOverrides([
+      { id: TRAFO_CAG_ID, mode: 'include' },
+      { id: TRAFO_CAG_ID, mode: 'exclude' },
+    ]);
+    const { includes, excludes } = collectDeviceOverrides(p, 'energy');
+    expect(includes.has(TRAFO_CAG_ID)).toBe(false);
+    expect(excludes.has(TRAFO_CAG_ID)).toBe(true);
+  });
+
+  it('exclude vence include mesmo em categorias diferentes', () => {
+    const p: DeviceClassificationProfile = clone(DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    const rules = p.domains.energy.categories!.rules;
+    rules.find((r) => r.name === 'climatizacao')!.deviceOverrides = [
+      { id: TRAFO_CAG_ID, mode: 'include' },
+    ];
+    rules.find((r) => r.name === 'elevadores')!.deviceOverrides = [
+      { id: TRAFO_CAG_ID, mode: 'exclude' },
+    ];
+    const { includes, excludes } = collectDeviceOverrides(normalizeProfile(p), 'energy');
+    expect(includes.has(TRAFO_CAG_ID)).toBe(false);
+    expect(excludes.has(TRAFO_CAG_ID)).toBe(true);
+  });
+
+  it('perfil sem overrides devolve coleções vazias', () => {
+    const { includes, excludes } = collectDeviceOverrides(
+      DEFAULT_DEVICE_CLASSIFICATION_PROFILE,
+      'energy',
+    );
+    expect(includes.size).toBe(0);
+    expect(excludes.size).toBe(0);
+  });
+});
+
+describe('RFC-0207 deviceOverrides — selectBreakdownItems', () => {
+  it('sem overrides: devolve exatamente o grupo base (zero mudança de comportamento)', () => {
+    const groups = groupAll(ALL_DEVICES, DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    const entries = selectBreakdownItems<Device>(groups, DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    expect(entries.map((e) => e.item)).toEqual(groups.areacomum);
+    expect(entries.every((e) => e.forcedCategory === null)).toBe(true);
+  });
+
+  it('include puxa um device que NÃO está no grupo base (entrada → breakdown)', () => {
+    const p = profileWithOverrides([{ id: TRAFO_CAG_ID, mode: 'include' }]);
+    const groups = groupAll(ALL_DEVICES, p);
+    expect(groups.entrada).toContain(MEDICAO_GERAL_CAG); // continua na entrada
+    const entries = selectBreakdownItems<Device>(groups, p);
+    const pulled = entries.find((e) => e.item.id === TRAFO_CAG_ID);
+    expect(pulled).toBeDefined();
+    expect(pulled!.forcedCategory).toBe('climatizacao');
+  });
+
+  it('include NÃO altera o grupo do device (Entrada intacta)', () => {
+    const p = profileWithOverrides([{ id: TRAFO_CAG_ID, mode: 'include' }]);
+    expect(resolveGroup(MEDICAO_GERAL_CAG, p, 'energy').group).toBe('entrada');
+    expect(resolveGroup(MEDICAO_GERAL_CAG, DEFAULT_DEVICE_CLASSIFICATION_PROFILE, 'energy').group).toBe(
+      'entrada',
+    );
+  });
+
+  it('exclude remove o device do breakdown por completo', () => {
+    const p = profileWithOverrides(BOMBAS.map((b) => ({ id: b.id, mode: 'exclude' as const })));
+    const groups = groupAll(ALL_DEVICES, p);
+    const entries = selectBreakdownItems<Device>(groups, p);
+    const ids = entries.map((e) => e.item.id);
+    for (const b of BOMBAS) expect(ids).not.toContain(b.id);
+    expect(ids).toContain(OUTRO_AREACOMUM.id); // o resto do areacomum segue lá
+  });
+
+  it('device sem id nunca é puxado nem excluído (degrada para o caminho normal)', () => {
+    const anon = { label: 'sem id', deviceProfile: 'ILUMINACAO', value: 5 } as unknown as Device;
+    const p = profileWithOverrides([{ id: TRAFO_CAG_ID, mode: 'include' }]);
+    const entries = selectBreakdownItems<Device>({ areacomum: [anon], entrada: [] }, p);
+    expect(entries).toEqual([{ item: anon, forcedCategory: null }]);
+  });
+
+  it('baseGroup é configurável', () => {
+    const p = profileWithOverrides([{ id: OUTRO_AREACOMUM.id, mode: 'include' }]);
+    const entries = selectBreakdownItems<Device>(
+      { lojas: [OUTRO_AREACOMUM], entrada: [MEDICAO_GERAL_CAG] },
+      p,
+      'energy',
+      { baseGroup: 'lojas' },
+    );
+    expect(entries.map((e) => e.item.id)).toEqual([OUTRO_AREACOMUM.id]);
+  });
+});
+
+describe('RFC-0207 deviceOverrides — exclude NÃO vaza para outros', () => {
+  it('as bombas excluídas não aparecem em NENHUM bucket do breakdown', () => {
+    const p = profileWithOverrides([
+      { id: TRAFO_CAG_ID, label: 'Medição Geral CAG', mode: 'include' },
+      ...BOMBAS.map((b) => ({ id: b.id, label: b.label, mode: 'exclude' as const })),
+    ]);
+    const groups = groupAll(ALL_DEVICES, p);
+    const { buckets } = runBreakdown(groups, p);
+    const allBreakdownIds = Object.values(buckets).flat().map((d) => d.id);
+    for (const b of BOMBAS) expect(allBreakdownIds).not.toContain(b.id);
+    expect((buckets.outros || []).map((d) => d.id)).not.toContain(BOMBAS[0].id);
+  });
+
+  it('sem o override, as bombas CAIRIAM em climatização (prova que o exclude fez trabalho)', () => {
+    for (const b of BOMBAS) {
+      expect(resolveCategory(b, DEFAULT_DEVICE_CLASSIFICATION_PROFILE, 'energy').category).toBe(
+        'climatizacao',
+      );
+    }
+  });
+});
+
+describe('RFC-0207 deviceOverrides — aceitação Shopping da Ilha', () => {
+  const p = profileWithOverrides([
+    { id: TRAFO_CAG_ID, label: 'Medição Geral CAG', mode: 'include' },
+    ...BOMBAS.map((b) => ({ id: b.id, label: b.label, mode: 'exclude' as const })),
+  ]);
+  const groups = groupAll(ALL_DEVICES, p);
+
+  it('a fixture reproduz os números reais', () => {
+    expect(BOMBAS.reduce((s, b) => s + b.value, 0)).toBe(155671);
+    expect(MEDICAO_GERAL_CAG.value).toBe(637560);
+    expect(GERAL_ENTRADA.value).toBe(752677);
+  });
+
+  it('Climatização = 637.560 (NÃO 793.231 — o bug de dupla contagem)', () => {
+    const { totals } = runBreakdown(groups, p);
+    expect(totals.climatizacao).toBe(637560);
+    expect(totals.climatizacao).not.toBe(637560 + 155671);
+  });
+
+  it('Entrada = 1.390.237, inalterada pelo override', () => {
+    const entradaTotal = groups.entrada.reduce((s, d) => s + d.value, 0);
+    expect(entradaTotal).toBe(1390237);
+    const baseline = groupAll(ALL_DEVICES, DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    expect(baseline.entrada.reduce((s, d) => s + d.value, 0)).toBe(entradaTotal);
+  });
+
+  it('as 9 bombas não aparecem em bucket nenhum', () => {
+    const { buckets } = runBreakdown(groups, p);
+    const ids = Object.values(buckets).flat().map((d) => d.id);
+    expect(BOMBAS.every((b) => !ids.includes(b.id))).toBe(true);
+  });
+
+  it('o trafo incluído cai numa subcategoria defensável (regras de texto → CAG)', () => {
+    // As sub-subcategorias vivem no MAIN_VIEW (combined = labelWidget+profile+label).
+    // Aqui só garantimos que o texto do trafo bate em CAG antes de BOMBA/CHILLER.
+    const combined = `${''} ${MEDICAO_GERAL_CAG.deviceProfile} ${MEDICAO_GERAL_CAG.label}`.toUpperCase();
+    expect(combined.includes('CHILLER')).toBe(false);
+    expect(combined.includes('FANCOIL')).toBe(false);
+    expect(combined.includes('BOMBA')).toBe(false);
+    expect(combined.includes('CAG')).toBe(true);
+  });
+
+  it('baseline (perfil DEFAULT) mostraria o bug: climatização = 155.671 sem o trafo', () => {
+    const baseGroups = groupAll(ALL_DEVICES, DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    const { totals } = runBreakdown(baseGroups, DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    expect(totals.climatizacao).toBe(155671);
+  });
+});

--- a/tests/deviceClassificationProfile.parent.test.ts
+++ b/tests/deviceClassificationProfile.parent.test.ts
@@ -1,0 +1,330 @@
+/**
+ * RFC-0207 "Dispositivos Específicos" — modo `parent` (o device É PAI da composição).
+ *
+ * Caso real (Moxuara, medido ao vivo):
+ *   - `CAG-Entrada` (deviceProfile ENTRADA, identifier CAG) é o medidor de ENTRADA
+ *     da CAG: mede TODA a alimentação = 336.600. Fica no grupo `entrada`.
+ *   - A composição interna (submedidores no grupo `areacomum`) soma 326.973:
+ *     Chillers 3 = 184.661, Fancoils 14 = 96.046, Bombas 13 = 46.266.
+ *   - Containment provado: pai 336.600 ≳ filhos 326.973 (~3% de perda de linha).
+ *     Os filhos estão A JUSANTE do pai.
+ *
+ * `parent` CONTÉM a composição (o total do card = valor do pai; os filhos são o
+ * breakdown aninhado, NÃO somados por cima). Contraste com `include`, que SOMA.
+ *
+ * Os testes exercitam o código EMBARCADO da lib (`selectBreakdownItems` +
+ * `computeBaseGroupResidual`), com um `runBreakdown` que espelha exatamente o
+ * `buildSummary` do MAIN_VIEW no ponto do modo `parent`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_DEVICE_CLASSIFICATION_PROFILE,
+  resolveGroup,
+  resolveCategory,
+  normalizeProfile,
+  validateProfile,
+  collectDeviceOverrides,
+  selectBreakdownItems,
+  computeBaseGroupResidual,
+  type DeviceClassificationProfile,
+  type ClassifiableItem,
+  type DeviceOverrideMode,
+} from '../src/utils/devices/deviceClassificationProfile';
+
+interface Device extends ClassifiableItem {
+  id: string;
+  label: string;
+  value: number;
+}
+
+function clone<T>(o: T): T {
+  return JSON.parse(JSON.stringify(o));
+}
+
+function profileWithOverrides(
+  overrides: { id: string; label?: string; mode: DeviceOverrideMode }[],
+): DeviceClassificationProfile {
+  const p: DeviceClassificationProfile = clone(DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+  p.domains.energy.categories!.rules.find((r) => r.name === 'climatizacao')!.deviceOverrides =
+    overrides;
+  return normalizeProfile(p);
+}
+
+function groupAll(devices: Device[], profile: DeviceClassificationProfile) {
+  const groups: Record<string, Device[]> = { lojas: [], entrada: [], areacomum: [], ocultos: [] };
+  for (const d of devices) groups[resolveGroup(d, profile, 'energy').group].push(d);
+  return groups;
+}
+
+/**
+ * Espelha o trecho do `buildSummary` do MAIN_VIEW que trata o modo `parent`:
+ *   - pais (isParent) vão para um balde à parte e NÃO entram na composição;
+ *   - o total do card de climatização = soma dos pais (se houver) OU soma dos
+ *     filhos (composição);
+ *   - o residual desconta de `areacomumTotal` só os FILHOS de origem-base
+ *     (`baseGroupContribution`), nunca o pai (cross-group).
+ */
+function runBreakdown(groups: Record<string, Device[]>, profile: DeviceClassificationProfile) {
+  const climatizacaoChildren: Device[] = [];
+  const climatizacaoParents: Device[] = [];
+  const outros: Device[] = [];
+  const crossOrigin = new Set<Device>();
+
+  for (const { item, forcedCategory, fromBaseGroup, isParent } of selectBreakdownItems<Device>(
+    groups,
+    profile,
+    'energy',
+  )) {
+    if (fromBaseGroup === false) crossOrigin.add(item);
+    const cat = forcedCategory || resolveCategory(item, profile, 'energy').category;
+    if (cat === 'climatizacao') {
+      if (isParent === true) climatizacaoParents.push(item);
+      else climatizacaoChildren.push(item);
+    } else {
+      outros.push(item);
+    }
+  }
+
+  const sum = (list: Device[]) => list.reduce((s, d) => s + d.value, 0);
+  const crossSum = (list: Device[]) =>
+    list.reduce((s, d) => s + (crossOrigin.has(d) ? d.value : 0), 0);
+
+  const childrenTotal = sum(climatizacaoChildren);
+  const parentTotal = sum(climatizacaoParents);
+  const hasParent = climatizacaoParents.length > 0;
+  const climatizacaoTotal = hasParent ? parentTotal : childrenTotal;
+  const climatizacaoCross = crossSum(climatizacaoChildren);
+
+  const areacomumTotal = sum(groups.areacomum || []);
+
+  const residual = computeBaseGroupResidual(areacomumTotal, [
+    hasParent
+      ? {
+          category: 'climatizacao',
+          total: climatizacaoTotal,
+          crossGroupTotal: parentTotal,
+          baseGroupContribution: Math.max(0, childrenTotal - climatizacaoCross),
+        }
+      : { category: 'climatizacao', total: climatizacaoTotal, crossGroupTotal: climatizacaoCross },
+    { category: 'outros', total: sum(outros), crossGroupTotal: crossSum(outros) },
+  ]);
+
+  // composição por deviceProfile (Chillers/Fancoils/Bombas)
+  const byProfile: Record<string, number> = {};
+  for (const d of climatizacaoChildren) {
+    const p = String(d.deviceProfile || '').toUpperCase();
+    byProfile[p] = (byProfile[p] || 0) + d.value;
+  }
+
+  return {
+    climatizacaoChildren,
+    climatizacaoParents,
+    childrenTotal,
+    parentTotal,
+    climatizacaoTotal,
+    areacomumTotal,
+    residual,
+    byProfile,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixture Moxuara — números reais
+// ---------------------------------------------------------------------------
+
+const CAG_ENTRADA_ID = '82f010d0-857e-423e-be43-c1e4e51ae25d';
+
+const MEDICAO_GERAL: Device = {
+  id: 'mx-medicao-geral',
+  label: 'Medição Geral',
+  deviceProfile: 'ENTRADA',
+  identifier: 'ENTRADA-GERAL',
+  value: 783750,
+};
+const CAG_ENTRADA: Device = {
+  id: CAG_ENTRADA_ID,
+  label: 'CAG-Entrada',
+  deviceProfile: 'ENTRADA',
+  identifier: 'CAG',
+  value: 336600,
+};
+// Chillers 3 = 184.661
+const CHILLERS: Device[] = [61554, 61554, 61553].map((value, i) => ({
+  id: `mx-chiller-${i + 1}`,
+  label: `Chiller ${i + 1}`,
+  deviceProfile: 'CHILLER',
+  identifier: `CHILLER-0${i + 1}`,
+  value,
+}));
+// Fancoils 14 = 96.046  (13×6860 + 6866)
+const FANCOILS: Device[] = Array.from({ length: 14 }, (_, i) => ({
+  id: `mx-fancoil-${i + 1}`,
+  label: `Fancoil ${i + 1}`,
+  deviceProfile: 'FANCOIL',
+  identifier: `FANCOIL-${i + 1}`,
+  value: i === 13 ? 6866 : 6860,
+}));
+// Bombas 13 = 46.266  (12×3559 + 3558)
+const BOMBAS: Device[] = Array.from({ length: 13 }, (_, i) => ({
+  id: `mx-bomba-${i + 1}`,
+  label: `Bomba CAG ${i + 1}`,
+  deviceProfile: 'BOMBA_CAG',
+  identifier: 'CAG',
+  value: i === 12 ? 3558 : 3559,
+}));
+
+const MOXUARA = [MEDICAO_GERAL, CAG_ENTRADA, ...CHILLERS, ...FANCOILS, ...BOMBAS];
+
+// ---------------------------------------------------------------------------
+
+describe('RFC-0207 parent — schema/collect/normalize', () => {
+  it('validateProfile aceita mode "parent"', () => {
+    const p = profileWithOverrides([{ id: CAG_ENTRADA_ID, label: 'CAG-Entrada', mode: 'parent' }]);
+    expect(validateProfile(p)).toEqual([]);
+  });
+
+  it('validateProfile rejeita mode inválido com a mensagem dos 3 modos', () => {
+    const p: DeviceClassificationProfile = clone(DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    p.domains.energy.categories!.rules.find((r) => r.name === 'climatizacao')!.deviceOverrides = [
+      { id: 'x', mode: 'boss' as unknown as DeviceOverrideMode },
+    ];
+    const errs = validateProfile(p);
+    expect(errs.some((e) => e.includes('"include", "exclude" or "parent"'))).toBe(true);
+  });
+
+  it('normalizeProfile preserva "parent" (não coage para include)', () => {
+    const p: DeviceClassificationProfile = clone(DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    p.domains.energy.categories!.rules.find((r) => r.name === 'climatizacao')!.deviceOverrides = [
+      { id: CAG_ENTRADA_ID, label: 'CAG-Entrada', mode: 'parent' },
+    ];
+    const n = normalizeProfile(p);
+    expect(
+      n.domains.energy.categories!.rules.find((r) => r.name === 'climatizacao')!.deviceOverrides,
+    ).toEqual([{ id: CAG_ENTRADA_ID, mode: 'parent', label: 'CAG-Entrada' }]);
+  });
+
+  it('collectDeviceOverrides põe o pai em includes E em parents', () => {
+    const p = profileWithOverrides([{ id: CAG_ENTRADA_ID, mode: 'parent' }]);
+    const { includes, parents, excludes } = collectDeviceOverrides(p, 'energy');
+    expect(includes.get(CAG_ENTRADA_ID)).toBe('climatizacao');
+    expect(parents.get(CAG_ENTRADA_ID)).toBe('climatizacao');
+    expect(excludes.size).toBe(0);
+  });
+
+  it('exclude vence parent (some dos dois mapas)', () => {
+    const p: DeviceClassificationProfile = clone(DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    const rules = p.domains.energy.categories!.rules;
+    rules.find((r) => r.name === 'climatizacao')!.deviceOverrides = [
+      { id: CAG_ENTRADA_ID, mode: 'parent' },
+    ];
+    rules.find((r) => r.name === 'elevadores')!.deviceOverrides = [
+      { id: CAG_ENTRADA_ID, mode: 'exclude' },
+    ];
+    const { includes, parents, excludes } = collectDeviceOverrides(normalizeProfile(p), 'energy');
+    expect(includes.has(CAG_ENTRADA_ID)).toBe(false);
+    expect(parents.has(CAG_ENTRADA_ID)).toBe(false);
+    expect(excludes.has(CAG_ENTRADA_ID)).toBe(true);
+  });
+
+  it('selectBreakdownItems marca isParent só no pai (e o puxa da entrada)', () => {
+    const p = profileWithOverrides([{ id: CAG_ENTRADA_ID, mode: 'parent' }]);
+    const groups = groupAll(MOXUARA, p);
+    const entries = selectBreakdownItems<Device>(groups, p, 'energy');
+    const parentEntry = entries.find((e) => e.item.id === CAG_ENTRADA_ID)!;
+    expect(parentEntry.isParent).toBe(true);
+    expect(parentEntry.fromBaseGroup).toBe(false);
+    expect(parentEntry.sourceGroup).toBe('entrada');
+    // nenhum filho é marcado como pai
+    expect(entries.filter((e) => e.isParent === true)).toHaveLength(1);
+    // entradas de filhos não carregam a chave isParent (retrocompat)
+    const child = entries.find((e) => e.item.id === CHILLERS[0].id)!;
+    expect('isParent' in child).toBe(false);
+  });
+});
+
+describe('RFC-0207 parent — aceitação Moxuara', () => {
+  const p = profileWithOverrides([{ id: CAG_ENTRADA_ID, label: 'CAG-Entrada', mode: 'parent' }]);
+  const groups = groupAll(MOXUARA, p);
+  const r = runBreakdown(groups, p);
+
+  it('a fixture reproduz os números reais', () => {
+    expect(CHILLERS.reduce((s, d) => s + d.value, 0)).toBe(184661);
+    expect(FANCOILS.reduce((s, d) => s + d.value, 0)).toBe(96046);
+    expect(BOMBAS.reduce((s, d) => s + d.value, 0)).toBe(46266);
+    expect(r.childrenTotal).toBe(326973);
+    expect(CAG_ENTRADA.value).toBe(336600);
+  });
+
+  it('Climatização (card) = 336.600 — o PAI (NÃO 663.573, NÃO 326.973)', () => {
+    expect(r.climatizacaoTotal).toBe(336600);
+    expect(r.climatizacaoTotal).not.toBe(336600 + 326973); // 663.573 = dupla contagem
+    expect(r.climatizacaoTotal).not.toBe(326973); // só os filhos, sem conter o pai
+  });
+
+  it('Entrada = 1.120.350, inalterada (o pai NÃO muda de grupo)', () => {
+    expect(groups.entrada.reduce((s, d) => s + d.value, 0)).toBe(1120350);
+    expect(resolveGroup(CAG_ENTRADA, p, 'energy').group).toBe('entrada');
+    const baseline = groupAll(MOXUARA, DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    expect(baseline.entrada.reduce((s, d) => s + d.value, 0)).toBe(1120350);
+  });
+
+  it('residual sem clamp mascarando negativo (filhos 326.973 são o único desconto)', () => {
+    // areacomum = só a composição (326.973) → residual = 0, e é 0 de verdade.
+    expect(r.areacomumTotal).toBe(326973);
+    expect(r.residual.subtotalFromBaseGroup).toBe(326973); // filhos, uma vez
+    expect(r.residual.subtotalCrossGroup).toBe(336600); // pai, informativo, NÃO descontado
+    expect(r.residual.residualRaw).toBe(0);
+    expect(r.residual.negative).toBe(false);
+    // prova da não-dupla-subtração: se o pai TAMBÉM fosse descontado, daria −336.600
+    expect(r.residual.residualRaw).not.toBe(326973 - 326973 - 336600);
+  });
+
+  it('a composição segue enumerada como breakdown aninhado (Chillers/Fancoils/Bombas)', () => {
+    expect(r.climatizacaoParents).toHaveLength(1);
+    expect(r.climatizacaoChildren.length).toBe(3 + 14 + 13); // 30 equipamentos
+    expect(r.byProfile.CHILLER).toBe(184661);
+    expect(r.byProfile.FANCOIL).toBe(96046);
+    expect(r.byProfile.BOMBA_CAG).toBe(46266);
+  });
+});
+
+describe('RFC-0207 parent vs include — CONTÉM × SOMA (totais diferentes)', () => {
+  const groups = groupAll(MOXUARA, DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+
+  it('mesmo device + mesmos dados: parent=336.600, include=663.573', () => {
+    const pParent = profileWithOverrides([{ id: CAG_ENTRADA_ID, mode: 'parent' }]);
+    const pInclude = profileWithOverrides([{ id: CAG_ENTRADA_ID, mode: 'include' }]);
+
+    const rParent = runBreakdown(groupAll(MOXUARA, pParent), pParent);
+    const rInclude = runBreakdown(groupAll(MOXUARA, pInclude), pInclude);
+
+    expect(rParent.climatizacaoTotal).toBe(336600); // CONTÉM
+    expect(rInclude.climatizacaoTotal).toBe(336600 + 326973); // SOMA (feed paralelo)
+    expect(rParent.climatizacaoTotal).not.toBe(rInclude.climatizacaoTotal);
+  });
+
+  it('sem override o grupo/coluna são idênticos nos dois (o modo só muda o breakdown)', () => {
+    // sanity: sem overrides, o card de climatização é a composição pura
+    const r = runBreakdown(groups, DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    expect(r.climatizacaoTotal).toBe(326973);
+    expect(r.climatizacaoParents).toHaveLength(0);
+  });
+});
+
+describe('RFC-0207 parent — caminho sem-override é byte-idêntico', () => {
+  it('selectBreakdownItems sem overrides não emite isParent e devolve o grupo base', () => {
+    const groups = groupAll(MOXUARA, DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    const entries = selectBreakdownItems<Device>(groups, DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    expect(entries.map((e) => e.item)).toEqual(groups.areacomum);
+    expect(entries.every((e) => !('isParent' in e))).toBe(true);
+  });
+
+  it('computeBaseGroupResidual sem baseGroupContribution = total − cross (inalterado)', () => {
+    const r = computeBaseGroupResidual(1000, [
+      { category: 'climatizacao', total: 900, crossGroupTotal: 600 },
+    ]);
+    expect(r.subtotalFromBaseGroup).toBe(300);
+    expect(r.residualRaw).toBe(700);
+  });
+});

--- a/tests/deviceClassificationProfile.residual.test.ts
+++ b/tests/deviceClassificationProfile.residual.test.ts
@@ -1,0 +1,322 @@
+/**
+ * RFC-0207 — residual de Área Comum × includes cross-group.
+ *
+ * O defeito que estes testes travam: `residual = areacomumTotal − Σ subtotais`
+ * assume que todo subtotal é feito de devices que estão DENTRO de
+ * `areacomumTotal`. Um `include` cross-group quebra a premissa — o trafo da Ilha
+ * (637.560) entra no subtotal de climatização mas vive no grupo `entrada` e
+ * nunca fez parte do `areacomumTotal`. O residual ia negativo pelo valor exato
+ * do device puxado, e o `Math.max(0, …)` mascarava (na Ilha o residual já é 0,
+ * então nada parecia errado — mas qualquer cliente com Área Comum positiva
+ * veria o número encolher sem motivo).
+ *
+ * Os testes exercitam o código EMBARCADO: `selectBreakdownItems` (origem) +
+ * `computeBaseGroupResidual` (aritmética), que é exatamente o par que o
+ * `buildSummary` do MAIN_VIEW chama.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_DEVICE_CLASSIFICATION_PROFILE,
+  resolveGroup,
+  resolveCategory,
+  normalizeProfile,
+  selectBreakdownItems,
+  computeBaseGroupResidual,
+  type DeviceClassificationProfile,
+  type ClassifiableItem,
+} from '../src/utils/devices/deviceClassificationProfile';
+
+interface Device extends ClassifiableItem {
+  id: string;
+  label: string;
+  value: number;
+}
+
+function clone<T>(o: T): T {
+  return JSON.parse(JSON.stringify(o));
+}
+
+function profileWithOverrides(
+  overrides: { id: string; label?: string; mode: 'include' | 'exclude' }[],
+): DeviceClassificationProfile {
+  const p: DeviceClassificationProfile = clone(DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+  p.domains.energy.categories!.rules.find((r) => r.name === 'climatizacao')!.deviceOverrides =
+    overrides;
+  return normalizeProfile(p);
+}
+
+function groupAll(devices: Device[], profile: DeviceClassificationProfile) {
+  const groups: Record<string, Device[]> = { lojas: [], entrada: [], areacomum: [], ocultos: [] };
+  for (const d of devices) groups[resolveGroup(d, profile, 'energy').group].push(d);
+  return groups;
+}
+
+/**
+ * Espelha o trecho do `buildSummary` (MAIN_VIEW) que importa: monta os baldes do
+ * breakdown, soma os totais CHEIOS (o que os cards exibem), soma em paralelo a
+ * parcela cross-group de cada balde, e delega o residual a
+ * `computeBaseGroupResidual` — a mesma função que o controller chama.
+ */
+function runBreakdown(groups: Record<string, Device[]>, profile: DeviceClassificationProfile) {
+  const buckets: Record<string, Device[]> = {
+    climatizacao: [],
+    elevadores: [],
+    escadas_rolantes: [],
+    outros: [],
+  };
+  const cross = new Set<Device>();
+
+  for (const { item, forcedCategory, fromBaseGroup } of selectBreakdownItems<Device>(
+    groups,
+    profile,
+    'energy',
+  )) {
+    if (fromBaseGroup === false) cross.add(item);
+    const cat = forcedCategory || resolveCategory(item, profile, 'energy').category;
+    (buckets[cat] ||= []).push(item);
+  }
+
+  const sum = (list: Device[]) => list.reduce((s, d) => s + d.value, 0);
+  const crossSum = (list: Device[]) =>
+    list.reduce((s, d) => s + (cross.has(d) ? d.value : 0), 0);
+
+  const totals = {
+    climatizacao: sum(buckets.climatizacao),
+    elevadores: sum(buckets.elevadores),
+    escadas_rolantes: sum(buckets.escadas_rolantes),
+    outros: sum(buckets.outros),
+  };
+  const crossTotals = {
+    climatizacao: crossSum(buckets.climatizacao),
+    elevadores: crossSum(buckets.elevadores),
+    escadas_rolantes: crossSum(buckets.escadas_rolantes),
+    outros: crossSum(buckets.outros),
+  };
+
+  // `areacomumTotal` é o total do GRUPO — não é afetado por override nenhum
+  // (é exatamente o que o MAIN_VIEW passa para buildSummary).
+  const areacomumTotal = sum(groups.areacomum || []);
+
+  const residual = computeBaseGroupResidual(areacomumTotal, [
+    { category: 'climatizacao', total: totals.climatizacao, crossGroupTotal: crossTotals.climatizacao },
+    { category: 'elevadores', total: totals.elevadores, crossGroupTotal: crossTotals.elevadores },
+    {
+      category: 'escadas_rolantes',
+      total: totals.escadas_rolantes,
+      crossGroupTotal: crossTotals.escadas_rolantes,
+    },
+    { category: 'outros', total: totals.outros, crossGroupTotal: crossTotals.outros },
+  ]);
+
+  /** A fórmula ANTIGA (buggy), para provar que o fix fez trabalho. */
+  const legacyResidualRaw =
+    areacomumTotal -
+    (totals.climatizacao + totals.elevadores + totals.escadas_rolantes + totals.outros);
+
+  return { buckets, totals, crossTotals, areacomumTotal, residual, legacyResidualRaw };
+}
+
+// ---------------------------------------------------------------------------
+// CENÁRIO 1 — Shopping da Ilha, números reais medidos em produção, INCLUDE-ONLY
+// ---------------------------------------------------------------------------
+
+const ILHA_TRAFO_ID = 'a1b2c3d4-0000-0000-0000-00000000cag0';
+
+const ILHA: Device[] = [
+  // ---- grupo `entrada` ----
+  {
+    id: 'e-geral',
+    label: 'Geral Entrada',
+    deviceProfile: 'ENTRADA',
+    identifier: 'ENTRADA-GERAL',
+    value: 752677,
+  },
+  {
+    id: ILHA_TRAFO_ID,
+    label: 'Medição Geral CAG',
+    deviceProfile: 'ENTRADA',
+    identifier: 'CAG',
+    value: 637560,
+  },
+  // ---- grupo `areacomum` — climatização soma 1.152.603 ----
+  { id: 'ac-chiller', label: 'Chiller 1', deviceProfile: 'CHILLER', identifier: 'CHILLER-01', value: 996932 },
+  ...Array.from({ length: 9 }, (_, i) => ({
+    id: `ac-bomba-${i + 1}`,
+    label: `Bomba CAG ${i + 3}`,
+    deviceProfile: 'BOMBA_CAG',
+    identifier: 'CAG',
+    value: i === 8 ? 17295 : 17297, // 8×17.297 + 17.295 = 155.671
+  })),
+  // ---- resto do areacomum ----
+  { id: 'ac-elev', label: 'Elevadores', deviceProfile: 'ELEVADOR', identifier: 'ELV-01', value: 25559 },
+  { id: 'ac-esc', label: 'Escadas', deviceProfile: 'ESCADA_ROLANTE', identifier: 'ESC-01', value: 51942 },
+  { id: 'ac-ilum', label: 'Iluminação Mall', deviceProfile: 'ILUMINACAO', identifier: 'ILU-01', value: 10399 },
+];
+
+describe('RFC-0207 residual — Shopping da Ilha (include-only, números reais)', () => {
+  const p = profileWithOverrides([
+    { id: ILHA_TRAFO_ID, label: 'Medição Geral CAG', mode: 'include' },
+  ]);
+  const groups = groupAll(ILHA, p);
+  const r = runBreakdown(groups, p);
+
+  it('a fixture reproduz a medição de produção', () => {
+    expect(r.areacomumTotal).toBe(1240503);
+    expect(r.totals.elevadores).toBe(25559);
+    expect(r.totals.escadas_rolantes).toBe(51942);
+    expect(r.totals.outros).toBe(10399);
+    // climatização de origem areacomum = chiller 996.932 + 9 bombas 155.671
+    expect(r.totals.climatizacao - r.crossTotals.climatizacao).toBe(1152603);
+  });
+
+  it('o card de Climatização mostra o total CHEIO: 1.790.163', () => {
+    expect(r.totals.climatizacao).toBe(1790163);
+    expect(r.crossTotals.climatizacao).toBe(637560);
+  });
+
+  it('a Entrada continua 1.390.237 (o include não move o grupo)', () => {
+    expect(groups.entrada.reduce((s, d) => s + d.value, 0)).toBe(1390237);
+  });
+
+  it('residual = 0 SEM depender do clamp (pré-clamp é 0, não negativo)', () => {
+    expect(r.residual.residualRaw).toBe(0);
+    expect(r.residual.residual).toBe(0);
+    expect(r.residual.negative).toBe(false);
+    expect(r.residual.subtotalFromBaseGroup).toBe(1240503);
+    expect(r.residual.subtotalCrossGroup).toBe(637560);
+  });
+
+  it('a fórmula ANTIGA daria −637.560, mascarado pelo clamp', () => {
+    expect(r.legacyResidualRaw).toBe(-637560);
+    expect(Math.max(0, r.legacyResidualRaw)).toBe(0); // exatamente o mascaramento
+  });
+
+  it('sem o override, o cenário base fecha em residual 0 do mesmo jeito', () => {
+    const base = groupAll(ILHA, DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    const rb = runBreakdown(base, DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    expect(rb.areacomumTotal).toBe(1240503);
+    expect(rb.totals.climatizacao).toBe(1152603);
+    expect(rb.crossTotals.climatizacao).toBe(0);
+    expect(rb.residual.residualRaw).toBe(0);
+    expect(rb.legacyResidualRaw).toBe(0); // as duas fórmulas coincidem sem override
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CENÁRIO 2 — shopping com Área Comum GENUINAMENTE positiva (sintético)
+//
+// É o caso que teria quebrado em silêncio: hoje o residual é positivo; adicionar
+// um include cross-group NÃO pode encolhê-lo. A Área Comum positiva é produzida
+// aqui por um device que sai do breakdown (exclude) mas continua no total do
+// grupo — estruturalmente idêntico a qualquer outra divergência
+// `areacomumTotal > Σ subtotais`.
+// ---------------------------------------------------------------------------
+
+const SINT_TRAFO_ID = 'sint-trafo-clima';
+const SINT_FORA_ID = 'sint-fora-do-breakdown';
+
+const SINTETICO: Device[] = [
+  { id: 'sx-entrada', label: 'Entrada Geral', deviceProfile: 'ENTRADA', identifier: 'ENT-1', value: 900000 },
+  {
+    id: SINT_TRAFO_ID,
+    label: 'Trafo Climatização',
+    deviceProfile: 'ENTRADA',
+    identifier: 'CAG',
+    value: 200000,
+  },
+  { id: 'sx-chiller', label: 'Chiller', deviceProfile: 'CHILLER', identifier: 'CHILLER-1', value: 300000 },
+  { id: 'sx-elev', label: 'Elevador', deviceProfile: 'ELEVADOR', identifier: 'ELV-1', value: 100000 },
+  { id: 'sx-esc', label: 'Escada', deviceProfile: 'ESCADA_ROLANTE', identifier: 'ESC-1', value: 50000 },
+  { id: 'sx-ilum', label: 'Iluminação', deviceProfile: 'ILUMINACAO', identifier: 'ILU-1', value: 50000 },
+  // fica no total do grupo (1.000.000) mas fora do breakdown → residual 500.000
+  { id: SINT_FORA_ID, label: 'Medidor Redundante', deviceProfile: 'ILUMINACAO', identifier: 'RED-1', value: 500000 },
+];
+
+describe('RFC-0207 residual — shopping com Área Comum positiva', () => {
+  const semInclude = profileWithOverrides([{ id: SINT_FORA_ID, mode: 'exclude' }]);
+  const comInclude = profileWithOverrides([
+    { id: SINT_FORA_ID, mode: 'exclude' },
+    { id: SINT_TRAFO_ID, label: 'Trafo Climatização', mode: 'include' },
+  ]);
+
+  const antes = runBreakdown(groupAll(SINTETICO, semInclude), semInclude);
+  const depois = runBreakdown(groupAll(SINTETICO, comInclude), comInclude);
+
+  it('linha de base: Área Comum genuinamente positiva (500.000)', () => {
+    expect(antes.areacomumTotal).toBe(1000000);
+    expect(antes.totals.climatizacao).toBe(300000);
+    expect(antes.residual.residualRaw).toBe(500000);
+    expect(antes.residual.residual).toBe(500000);
+  });
+
+  it('o include cross-group FAZ o card crescer: 300.000 → 500.000', () => {
+    expect(depois.totals.climatizacao).toBe(500000);
+    expect(depois.crossTotals.climatizacao).toBe(200000);
+  });
+
+  it('e NÃO mexe no residual: continua 500.000', () => {
+    expect(depois.residual.residualRaw).toBe(500000);
+    expect(depois.residual.residual).toBe(500000);
+    expect(depois.residual.negative).toBe(false);
+    expect(depois.residual.residual).toBe(antes.residual.residual);
+  });
+
+  it('a fórmula ANTIGA teria encolhido o residual em exatamente 200.000', () => {
+    expect(antes.legacyResidualRaw).toBe(500000);
+    expect(depois.legacyResidualRaw).toBe(300000); // 500.000 − 200.000 → o bug silencioso
+  });
+
+  it('o total do grupo areacomum não muda com o include', () => {
+    expect(depois.areacomumTotal).toBe(antes.areacomumTotal);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeBaseGroupResidual — unidade
+// ---------------------------------------------------------------------------
+
+describe('computeBaseGroupResidual', () => {
+  it('sem parcela cross-group é a subtração de sempre', () => {
+    const r = computeBaseGroupResidual(1000, [
+      { category: 'climatizacao', total: 300, crossGroupTotal: 0 },
+      { category: 'outros', total: 200, crossGroupTotal: 0 },
+    ]);
+    expect(r.subtotalFromBaseGroup).toBe(500);
+    expect(r.subtotalCrossGroup).toBe(0);
+    expect(r.residualRaw).toBe(500);
+    expect(r.residual).toBe(500);
+    expect(r.negative).toBe(false);
+  });
+
+  it('desconta apenas a parcela de origem-base', () => {
+    const r = computeBaseGroupResidual(1000, [
+      { category: 'climatizacao', total: 900, crossGroupTotal: 600 },
+      { category: 'outros', total: 200, crossGroupTotal: 0 },
+    ]);
+    expect(r.subtotalFromBaseGroup).toBe(500); // (900−600) + 200
+    expect(r.subtotalCrossGroup).toBe(600);
+    expect(r.residualRaw).toBe(500);
+  });
+
+  it('lista vazia devolve o total do grupo', () => {
+    expect(computeBaseGroupResidual(1234, []).residualRaw).toBe(1234);
+  });
+
+  it('negativo REAL é sinalizado e clampado (não some)', () => {
+    const r = computeBaseGroupResidual(100, [
+      { category: 'climatizacao', total: 250, crossGroupTotal: 0 },
+    ]);
+    expect(r.residualRaw).toBe(-150);
+    expect(r.residual).toBe(0);
+    expect(r.negative).toBe(true);
+  });
+
+  it('valores não-numéricos degradam para 0 em vez de NaN', () => {
+    const r = computeBaseGroupResidual(100, [
+      { category: 'x', total: undefined as unknown as number, crossGroupTotal: null as unknown as number },
+    ]);
+    expect(r.residualRaw).toBe(100);
+    expect(Number.isNaN(r.residual)).toBe(false);
+  });
+});

--- a/tests/deviceProfileModal.deviceOverrides.test.ts
+++ b/tests/deviceProfileModal.deviceOverrides.test.ts
@@ -1,0 +1,280 @@
+/**
+ * RFC-0207 "Dispositivos Específicos" — UI do picker no modal de perfil.
+ *
+ * Cobre o que o spec exige da UI: seção só na Climatização, "+" abre o picker,
+ * busca por label, devices já adicionados somem da lista (não dá para adicionar
+ * duas vezes), chips removíveis, modo read-only sem "+", e round-trip do campo
+ * novo pelo `onSave`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { openDeviceProfileModal } from '../src/components/premium-modals/device-profile/openDeviceProfileModal';
+import {
+  DEFAULT_DEVICE_CLASSIFICATION_PROFILE,
+  setActiveProfile,
+  type DeviceClassificationProfile,
+} from '../src/utils/devices/deviceClassificationProfile';
+
+const DEVICES = [
+  { id: 'dev-trafo-cag', label: 'Medição Geral CAG', deviceProfile: 'ENTRADA', identifier: 'CAG' },
+  { id: 'dev-entrada', label: 'Geral Entrada', deviceProfile: 'ENTRADA', identifier: 'ENTRADA-GERAL' },
+  { id: 'dev-bomba-3', label: 'Bomba CAG 3', deviceProfile: 'BOMBA_CAG', identifier: 'CAG' },
+  { id: 'dev-bomba-4', label: 'Bomba CAG 4', deviceProfile: 'BOMBA_CAG', identifier: 'CAG' },
+  { id: 'dev-elevador', label: 'Elevador Social 1', deviceProfile: 'ELEVADOR', identifier: 'ELV-01' },
+];
+
+function clone<T>(o: T): T {
+  return JSON.parse(JSON.stringify(o));
+}
+
+function open(opts: Partial<Parameters<typeof openDeviceProfileModal>[0]> = {}) {
+  return openDeviceProfileModal({
+    customerId: 'cust-1',
+    canEdit: true,
+    getDevices: () => clone(DEVICES),
+    ...opts,
+  });
+}
+
+/** Índice da regra `climatizacao` dentro de categories.rules (cat-N nos data-attrs). */
+const CLIMA_IDX = DEFAULT_DEVICE_CLASSIFICATION_PROFILE.domains.energy.categories!.rules.findIndex(
+  (r) => r.name === 'climatizacao',
+);
+
+function overrideSectionEl(): HTMLElement | null {
+  return document.querySelector<HTMLElement>('.mdp-ovr');
+}
+function addButtons(): HTMLButtonElement[] {
+  return Array.from(document.querySelectorAll<HTMLButtonElement>('.mdp-ovr-add'));
+}
+function pickerRowNames(): string[] {
+  return Array.from(document.querySelectorAll('.mdp-picker-row .mdp-picker-name')).map(
+    (el) => el.textContent?.trim() || '',
+  );
+}
+function chipTexts(): string[] {
+  return Array.from(document.querySelectorAll('.mdp-ovr-chip')).map((el) =>
+    (el.textContent || '').replace(/\s+/g, ' ').trim(),
+  );
+}
+function pick(label: string, mode: 'include' | 'exclude') {
+  const row = Array.from(document.querySelectorAll('.mdp-picker-row')).find(
+    (r) => r.querySelector('.mdp-picker-name')?.textContent?.trim() === label,
+  );
+  if (!row) throw new Error(`picker row not found: ${label}`);
+  row.querySelector<HTMLButtonElement>(`.mdp-picker-pick.is-${mode}`)!.click();
+}
+
+let handle: { close: () => void } | null = null;
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  setActiveProfile(null);
+});
+
+afterEach(() => {
+  try {
+    handle?.close();
+  } catch {
+    /* noop */
+  }
+  handle = null;
+  document.body.innerHTML = '';
+  setActiveProfile(null);
+});
+
+describe('openDeviceProfileModal — seção Dispositivos Específicos', () => {
+  it('renderiza a seção APENAS na categoria Climatização', () => {
+    handle = open();
+    const sections = document.querySelectorAll('.mdp-ovr');
+    expect(sections.length).toBe(1);
+    expect(overrideSectionEl()!.textContent).toContain('Dispositivos Específicos');
+    expect(addButtons()).toHaveLength(1);
+    expect(addButtons()[0].dataset.cat).toBe(String(CLIMA_IDX));
+  });
+
+  it('parte vazia e o "+" abre o picker com busca (lupa)', () => {
+    handle = open();
+    expect(overrideSectionEl()!.textContent).toContain('Nenhum dispositivo específico');
+    expect(document.querySelector('.mdp-picker')).toBeNull();
+
+    addButtons()[0].click();
+
+    expect(document.querySelector('.mdp-picker')).not.toBeNull();
+    expect(document.querySelector('.mdp-picker-mag')?.textContent).toBe('🔍');
+    expect(document.querySelector('.mdp-picker-input')).not.toBeNull();
+    expect(pickerRowNames()).toEqual(DEVICES.map((d) => d.label));
+  });
+
+  it('a busca filtra por device.label', () => {
+    handle = open();
+    addButtons()[0].click();
+    const input = document.querySelector<HTMLInputElement>('.mdp-picker-input')!;
+    input.value = 'bomba';
+    input.dispatchEvent(new Event('input'));
+    expect(pickerRowNames()).toEqual(['Bomba CAG 3', 'Bomba CAG 4']);
+
+    input.value = 'zzz-nao-existe';
+    input.dispatchEvent(new Event('input'));
+    expect(pickerRowNames()).toEqual([]);
+    expect(document.querySelector('.mdp-picker-list')!.textContent).toContain('Nenhum dispositivo');
+  });
+
+  it('o picker REMOVE os devices já adicionados (não dá para adicionar duas vezes)', () => {
+    handle = open();
+    addButtons()[0].click();
+    pick('Medição Geral CAG', 'include');
+
+    // chip criado, picker fechado
+    expect(chipTexts().some((t) => t.includes('Medição Geral CAG'))).toBe(true);
+    expect(document.querySelector('.mdp-picker')).toBeNull();
+
+    // reabre: o device já adicionado não está mais na lista
+    addButtons()[0].click();
+    const names = pickerRowNames();
+    expect(names).not.toContain('Medição Geral CAG');
+    expect(names).toEqual(['Geral Entrada', 'Bomba CAG 3', 'Bomba CAG 4', 'Elevador Social 1']);
+
+    // e continua fora depois de uma busca (o filtro roda sobre a lista já reduzida)
+    const input = document.querySelector<HTMLInputElement>('.mdp-picker-input')!;
+    input.value = 'CAG';
+    input.dispatchEvent(new Event('input'));
+    expect(pickerRowNames()).toEqual(['Bomba CAG 3', 'Bomba CAG 4']);
+  });
+
+  it('marca incluir/excluir e a chip mostra o modo', () => {
+    handle = open();
+    addButtons()[0].click();
+    pick('Medição Geral CAG', 'include');
+    addButtons()[0].click();
+    pick('Bomba CAG 3', 'exclude');
+
+    const chips = chipTexts();
+    expect(chips.some((t) => t.startsWith('incluir') && t.includes('Medição Geral CAG'))).toBe(true);
+    expect(chips.some((t) => t.startsWith('excluir') && t.includes('Bomba CAG 3'))).toBe(true);
+    expect(document.querySelectorAll('.mdp-ovr-chip.is-include')).toHaveLength(1);
+    expect(document.querySelectorAll('.mdp-ovr-chip.is-exclude')).toHaveLength(1);
+  });
+
+  it('cada chip é removível', () => {
+    handle = open();
+    addButtons()[0].click();
+    pick('Medição Geral CAG', 'include');
+    expect(document.querySelectorAll('.mdp-ovr-chip')).toHaveLength(1);
+
+    document.querySelector<HTMLButtonElement>('.mdp-ovr-x')!.click();
+    expect(document.querySelectorAll('.mdp-ovr-chip')).toHaveLength(0);
+    expect(overrideSectionEl()!.textContent).toContain('Nenhum dispositivo específico');
+  });
+
+  it('read-only (canEdit=false): sem "+" e sem "×" nas chips', () => {
+    const profile: DeviceClassificationProfile = clone(DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    profile.domains.energy.categories!.rules[CLIMA_IDX].deviceOverrides = [
+      { id: 'dev-trafo-cag', label: 'Medição Geral CAG', mode: 'include' },
+    ];
+    handle = open({ canEdit: false, profile });
+
+    expect(overrideSectionEl()).not.toBeNull();
+    expect(addButtons()).toHaveLength(0);
+    expect(document.querySelectorAll('.mdp-ovr-x')).toHaveLength(0);
+    expect(document.querySelectorAll('.mdp-picker')).toHaveLength(0);
+    // a chip existente continua visível
+    expect(chipTexts().some((t) => t.includes('Medição Geral CAG'))).toBe(true);
+  });
+
+  it('getDevices vazio/ausente não quebra — mostra dica', () => {
+    handle = open({ getDevices: undefined });
+    expect(addButtons()).toHaveLength(1);
+    addButtons()[0].click();
+    expect(document.querySelector('.mdp-picker-list')!.textContent).toContain(
+      'Nenhum dispositivo disponível',
+    );
+  });
+
+  it('getDevices que lança não quebra o modal', () => {
+    handle = open({
+      getDevices: () => {
+        throw new Error('boom');
+      },
+    });
+    expect(overrideSectionEl()).not.toBeNull();
+    addButtons()[0].click();
+    expect(document.querySelector('.mdp-picker')).not.toBeNull();
+  });
+
+  it('device removido do dashboard aparece com o label salvo + aviso "não encontrado"', () => {
+    const profile: DeviceClassificationProfile = clone(DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    profile.domains.energy.categories!.rules[CLIMA_IDX].deviceOverrides = [
+      { id: 'dev-que-sumiu', label: 'Trafo Antigo', mode: 'include' },
+    ];
+    handle = open({ profile });
+    const chip = document.querySelector('.mdp-ovr-chip')!;
+    expect(chip.classList.contains('is-missing')).toBe(true);
+    expect(chip.textContent).toContain('Trafo Antigo');
+    expect(chip.querySelector('.mdp-ovr-warn')).not.toBeNull();
+  });
+
+  it('round-trip: o campo novo chega ao onSave e some quando esvaziado', async () => {
+    const onSave = vi.fn();
+    handle = open({ onSave, userName: 'tester' });
+
+    addButtons()[0].click();
+    pick('Medição Geral CAG', 'include');
+    addButtons()[0].click();
+    pick('Bomba CAG 3', 'exclude');
+
+    document.getElementById('mdp-save')!.click();
+    await vi.waitFor(() => expect(onSave).toHaveBeenCalled());
+
+    const saved: DeviceClassificationProfile = onSave.mock.calls[0][0];
+    const rule = saved.domains.energy.categories!.rules[CLIMA_IDX];
+    expect(rule.deviceOverrides).toEqual([
+      { id: 'dev-trafo-cag', label: 'Medição Geral CAG', mode: 'include' },
+      { id: 'dev-bomba-3', label: 'Bomba CAG 3', mode: 'exclude' },
+    ]);
+    // as demais regras continuam sem o campo (opt-in)
+    expect(saved.domains.energy.categories!.rules.filter((r) => r.deviceOverrides).length).toBe(1);
+  });
+
+  it('remover a última chip apaga a chave do JSON salvo (perfil volta ao formato anterior)', async () => {
+    const onSave = vi.fn();
+    handle = open({ onSave });
+    addButtons()[0].click();
+    pick('Medição Geral CAG', 'include');
+    document.querySelector<HTMLButtonElement>('.mdp-ovr-x')!.click();
+
+    document.getElementById('mdp-save')!.click();
+    await vi.waitFor(() => expect(onSave).toHaveBeenCalled());
+    const saved: DeviceClassificationProfile = onSave.mock.calls[0][0];
+    expect(saved.domains.energy.categories!.rules[CLIMA_IDX].deviceOverrides).toBeUndefined();
+  });
+
+  it('o preview ao vivo reflete os overrides (exclude some, include muda de bucket)', () => {
+    handle = open();
+    const breakdownText = () =>
+      Array.from(document.querySelectorAll('#mdp-preview-cats .mdp-pv-row'))
+        .map((r) => r.textContent?.replace(/\s+/g, ' ').trim() || '')
+        .join(' | ');
+
+    // baseline: 2 bombas + o trafo (identifier CAG) caem em climatizacao
+    expect(breakdownText()).toMatch(/climatizacao\s*3/);
+
+    addButtons()[0].click();
+    pick('Bomba CAG 3', 'exclude');
+    addButtons()[0].click();
+    pick('Bomba CAG 4', 'exclude');
+
+    // as duas bombas saíram do breakdown por completo; sobrou o trafo
+    expect(breakdownText()).toMatch(/climatizacao\s*1/);
+    expect(breakdownText()).not.toMatch(/Bomba CAG 3/);
+  });
+
+  it('a seção NÃO aparece nas abas água/temperatura (sem breakdown)', () => {
+    handle = open();
+    const waterTab = Array.from(document.querySelectorAll<HTMLButtonElement>('.mdp-tab')).find(
+      (t) => t.dataset.domain === 'water',
+    )!;
+    waterTab.click();
+    expect(document.querySelector('.mdp-ovr')).toBeNull();
+  });
+});

--- a/tests/deviceProfileModal.parent.test.ts
+++ b/tests/deviceProfileModal.parent.test.ts
@@ -1,0 +1,118 @@
+/**
+ * RFC-0207 "parent" — terceira opção ("como pai") no picker de Dispositivos
+ * Específicos do modal de perfil.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { openDeviceProfileModal } from '../src/components/premium-modals/device-profile/openDeviceProfileModal';
+import {
+  DEFAULT_DEVICE_CLASSIFICATION_PROFILE,
+  setActiveProfile,
+  type DeviceClassificationProfile,
+} from '../src/utils/devices/deviceClassificationProfile';
+
+const DEVICES = [
+  { id: 'dev-cag-entrada', label: 'CAG-Entrada', deviceProfile: 'ENTRADA', identifier: 'CAG' },
+  { id: 'dev-chiller', label: 'Chiller 1', deviceProfile: 'CHILLER', identifier: 'CHILLER-01' },
+];
+
+function clone<T>(o: T): T {
+  return JSON.parse(JSON.stringify(o));
+}
+
+const CLIMA_IDX = DEFAULT_DEVICE_CLASSIFICATION_PROFILE.domains.energy.categories!.rules.findIndex(
+  (r) => r.name === 'climatizacao',
+);
+
+function open(opts: Partial<Parameters<typeof openDeviceProfileModal>[0]> = {}) {
+  return openDeviceProfileModal({
+    customerId: 'cust-1',
+    canEdit: true,
+    getDevices: () => clone(DEVICES),
+    ...opts,
+  });
+}
+
+function addButtons(): HTMLButtonElement[] {
+  return Array.from(document.querySelectorAll<HTMLButtonElement>('.mdp-ovr-add'));
+}
+function pick(label: string, mode: 'include' | 'exclude' | 'parent') {
+  const row = Array.from(document.querySelectorAll('.mdp-picker-row')).find(
+    (r) => r.querySelector('.mdp-picker-name')?.textContent?.trim() === label,
+  );
+  if (!row) throw new Error(`picker row not found: ${label}`);
+  row.querySelector<HTMLButtonElement>(`.mdp-picker-pick.is-${mode}`)!.click();
+}
+function chipTexts(): string[] {
+  return Array.from(document.querySelectorAll('.mdp-ovr-chip')).map((el) =>
+    (el.textContent || '').replace(/\s+/g, ' ').trim(),
+  );
+}
+
+let handle: { close: () => void } | null = null;
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  setActiveProfile(null);
+});
+afterEach(() => {
+  try {
+    handle?.close();
+  } catch {
+    /* noop */
+  }
+  handle = null;
+  document.body.innerHTML = '';
+  setActiveProfile(null);
+});
+
+describe('openDeviceProfileModal — modo "como pai"', () => {
+  it('o picker oferece as TRÊS opções (incluir / como pai / excluir)', () => {
+    handle = open();
+    addButtons()[0].click();
+    const row = document.querySelector('.mdp-picker-row')!;
+    const modes = Array.from(row.querySelectorAll<HTMLButtonElement>('.mdp-picker-pick')).map(
+      (b) => b.dataset.mode,
+    );
+    expect(modes).toEqual(['include', 'parent', 'exclude']);
+    expect(row.querySelector('.mdp-picker-pick.is-parent')?.textContent?.trim()).toBe('como pai');
+  });
+
+  it('escolher "como pai" cria uma chip com o modo e a classe is-parent', () => {
+    handle = open();
+    addButtons()[0].click();
+    pick('CAG-Entrada', 'parent');
+
+    expect(document.querySelectorAll('.mdp-ovr-chip.is-parent')).toHaveLength(1);
+    expect(chipTexts().some((t) => t.startsWith('como pai') && t.includes('CAG-Entrada'))).toBe(true);
+    // não é confundido com include/exclude
+    expect(document.querySelectorAll('.mdp-ovr-chip.is-include')).toHaveLength(0);
+    expect(document.querySelectorAll('.mdp-ovr-chip.is-exclude')).toHaveLength(0);
+  });
+
+  it('round-trip: o modo "parent" chega ao onSave', async () => {
+    const onSave = vi.fn();
+    handle = open({ onSave, userName: 'tester' });
+    addButtons()[0].click();
+    pick('CAG-Entrada', 'parent');
+
+    document.getElementById('mdp-save')!.click();
+    await vi.waitFor(() => expect(onSave).toHaveBeenCalled());
+    const saved: DeviceClassificationProfile = onSave.mock.calls[0][0];
+    expect(saved.domains.energy.categories!.rules[CLIMA_IDX].deviceOverrides).toEqual([
+      { id: 'dev-cag-entrada', label: 'CAG-Entrada', mode: 'parent' },
+    ]);
+  });
+
+  it('read-only renderiza a chip "como pai" salva (sem remover)', () => {
+    const profile: DeviceClassificationProfile = clone(DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    profile.domains.energy.categories!.rules[CLIMA_IDX].deviceOverrides = [
+      { id: 'dev-cag-entrada', label: 'CAG-Entrada', mode: 'parent' },
+    ];
+    handle = open({ canEdit: false, profile });
+    expect(document.querySelectorAll('.mdp-ovr-chip.is-parent')).toHaveLength(1);
+    expect(chipTexts().some((t) => t.includes('como pai') && t.includes('CAG-Entrada'))).toBe(true);
+    expect(document.querySelectorAll('.mdp-ovr-x')).toHaveLength(0);
+    expect(addButtons()).toHaveLength(0);
+  });
+});

--- a/tests/telemetryInfo.climatizacaoParent.test.ts
+++ b/tests/telemetryInfo.climatizacaoParent.test.ts
@@ -1,0 +1,156 @@
+/**
+ * RFC-0207 "parent" — renderização do tooltip de Climatização no TELEMETRY_INFO.
+ *
+ * Extrai a FUNÇÃO REAL `buildClimatizacaoContent` (e suas dependências) do
+ * controller do widget e a executa num sandbox com STATE/window injetados. Assim
+ * o teste trava o HTML de fato produzido em produção — sem espelhar/copiar a
+ * lógica.
+ *
+ * Contrato coberto:
+ *   - COM pai em STATE.consumidores.climatizacao.parents: linha do pai no TOPO da
+ *     Composição, subcategorias ANINHADAS abaixo, header mostra o total do pai.
+ *   - SEM pai (campo vazio OU ausente): saída idêntica à de antes (composição
+ *     plana; nada de linha de pai nem wrapper aninhado).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CONTROLLER = resolve(
+  __dirname,
+  '../src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/TELEMETRY_INFO/controller.js',
+);
+
+/** Extrai o texto de uma função top-level `function NAME(...) { ... }`. */
+function extractFn(src: string, name: string): string {
+  const lines = src.replace(/\r/g, '').split('\n');
+  const start = lines.findIndex((l) => l.startsWith(`function ${name}(`));
+  if (start < 0) throw new Error(`função não encontrada: ${name}`);
+  let end = -1;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (lines[i] === '}') {
+      end = i;
+      break;
+    }
+  }
+  if (end < 0) throw new Error(`fim da função não encontrado: ${name}`);
+  return lines.slice(start, end + 1).join('\n');
+}
+
+/**
+ * Monta um `buildClimatizacaoContent` executável a partir do source real,
+ * com STATE/window injetados. formatEnergy é resolvido via window.MyIOUtils.
+ */
+function makeBuilder(state: Record<string, unknown>): () => string {
+  const src = readFileSync(CONTROLLER, 'utf8');
+  const body =
+    extractFn(src, 'formatEnergy') +
+    '\n' +
+    extractFn(src, 'buildDeviceExpandList') +
+    '\n' +
+    extractFn(src, 'buildExcludedFromCAGNotice') +
+    '\n' +
+    extractFn(src, 'buildClimatizacaoContent') +
+    '\nreturn buildClimatizacaoContent;';
+  const win = {
+    MyIOUtils: {
+      // total previsível: "<n> MWh" com separador de milhar por ponto
+      formatEnergy: (v: number) =>
+        `${Number(v).toLocaleString('en-US', { maximumFractionDigits: 0 })} MWh`,
+    },
+  };
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+  const factory = new Function('STATE', 'window', 'console', body) as (
+    s: unknown,
+    w: unknown,
+    c: unknown,
+  ) => () => string;
+  return factory(state, win, console);
+}
+
+function subcat(name: string, count: number, total: number) {
+  return { summary: { count, total }, details: { name, devices: [] } };
+}
+
+function baseState(parents: Array<{ id: string; label: string; total: number }> | undefined) {
+  const climatizacao: Record<string, unknown> = {
+    devices: new Array(30).fill(0).map((_, i) => ({ id: `d${i}`, label: `d${i}`, value: 1 })),
+    total: parents && parents.length ? 336600 : 326973,
+    perc: 30,
+    subcategories: {
+      chillers: subcat('Chillers', 3, 184661),
+      fancoils: subcat('Fancoils', 14, 96046),
+      bombasClimatizacao: subcat('Bombas', 13, 46266),
+    },
+  };
+  if (parents !== undefined) climatizacao.parents = parents;
+  return {
+    consumidores: { climatizacao },
+    tooltipData: { excludedFromCAG: [] },
+  };
+}
+
+let htmlWithParent: string;
+let htmlNoParent: string;
+let htmlFieldAbsent: string;
+
+beforeEach(() => {
+  htmlWithParent = makeBuilder(
+    baseState([{ id: '82f0', label: 'CAG-Entrada', total: 336600 }]),
+  )();
+  htmlNoParent = makeBuilder(baseState([]))();
+  htmlFieldAbsent = makeBuilder(baseState(undefined))();
+});
+
+describe('buildClimatizacaoContent — modo parent', () => {
+  it('COM pai: renderiza a linha do pai com label e valor', () => {
+    expect(htmlWithParent).toContain('CAG-Entrada');
+    expect(htmlWithParent).toContain('Medidor pai da composição');
+    expect(htmlWithParent).toContain('336,600 MWh');
+    expect(htmlWithParent).toContain('myio-info-tooltip__category--parent');
+  });
+
+  it('COM pai: a composição fica ANINHADA (wrapper indentado) abaixo do pai', () => {
+    expect(htmlWithParent).toContain('myio-info-tooltip__nested');
+    const posPai = htmlWithParent.indexOf('CAG-Entrada');
+    const posNested = htmlWithParent.indexOf('myio-info-tooltip__nested');
+    const posChiller = htmlWithParent.indexOf('Chillers');
+    // pai ANTES do wrapper aninhado, e o wrapper ANTES das subcategorias
+    expect(posPai).toBeGreaterThan(-1);
+    expect(posNested).toBeGreaterThan(posPai);
+    expect(posChiller).toBeGreaterThan(posNested);
+  });
+
+  it('COM pai: as subcategorias continuam presentes (breakdown enumerado)', () => {
+    expect(htmlWithParent).toContain('Chillers');
+    expect(htmlWithParent).toContain('Fancoils');
+    expect(htmlWithParent).toContain('Bombas');
+    expect(htmlWithParent).toContain('184,661 MWh');
+    expect(htmlWithParent).toContain('96,046 MWh');
+    expect(htmlWithParent).toContain('46,266 MWh');
+  });
+
+  it('COM pai: o header "Consumo Total" mostra o total do pai (336.600)', () => {
+    const header = htmlWithParent.slice(0, htmlWithParent.indexOf('Composição'));
+    expect(header).toContain('336,600 MWh');
+  });
+
+  it('SEM pai (lista vazia): composição PLANA, sem linha de pai nem wrapper', () => {
+    expect(htmlNoParent).not.toContain('myio-info-tooltip__nested');
+    expect(htmlNoParent).not.toContain('Medidor pai da composição');
+    expect(htmlNoParent).not.toContain('myio-info-tooltip__category--parent');
+    expect(htmlNoParent).toContain('Chillers');
+  });
+
+  it('campo `parents` AUSENTE ⇒ byte-idêntico à lista vazia (retrocompat)', () => {
+    expect(htmlFieldAbsent).toBe(htmlNoParent);
+  });
+
+  it('a nota explicativa muda conforme haja pai ou não', () => {
+    expect(htmlWithParent).toContain('medidor pai');
+    expect(htmlNoParent).toContain('soma do consumo de todos os equipamentos');
+  });
+});


### PR DESCRIPTION
Adiciona, no modal **Gestão de Perfil de Dispositivos**, uma seção **"Dispositivos Específicos"** no card de Climatização: um device pode passar a somar no card **mantendo o grupo dele**.

## O caso real que motivou (Shopping da Ilha)

`Medição Geral CAG` (`deviceProfile: ENTRADA`, **637.560**) é um trafo de **entrada** que mede o feed do CAG. Deve continuar contando na Entrada — e também aparecer no card de Climatização. Hoje isso é impossível por duas razões estruturais, **ambas preservadas** (não foram abolidas):

1. **Alocação única** — `resolveGroup` devolve um grupo só. É o que mantém os totais coerentes.
2. **O breakdown só lê `areacomum`** — devices de entrada são invisíveis ao card.

A solução não muda o grupo do device: adiciona uma **agregação cross-group**.

## UI (spec do usuário, seguida à risca)

Seção **"Dispositivos Específicos"**, **apenas no card de Climatização** (o schema é genérico por categoria; estender a UI é trivial depois):
- Botão **"+"** abre um seletor com os `device.label`
- **Lupa de filtro** para buscar
- **Devices já adicionados somem do seletor** — impossível adicionar duas vezes
- Ao selecionar, marca-se **incluir** ou **excluir**; chips removíveis mostram o modo
- O **"Preview ao vivo"** reflete os overrides antes de salvar

Alimentado pelo `getDevices(domain)` que o modal **já recebia**. Persiste no JSON do perfil pelo caminho do PR #108.

## Semântica

- **incluir** — agrega na categoria **mantendo o grupo**. Entrada fica inalterada.
- **excluir** — sai do breakdown **por completo**; não cai em "Outros" (senão recontaria).
- exclusão vence inclusão.

## ⚠️ Correção de um defeito que só apareceu no dado real

Medindo o Ilha ao vivo durante a revisão, o residual quebrava:

```
_areacomumResidual = Math.max(0, areacomumTotal − subtotais)
```

O trafo incluído (637.560) está no grupo `entrada` — **nunca esteve em `areacomumTotal`**. Subtraí-lo de um pool que não o contém levava o residual a **−637.560**, que o `Math.max(0, …)` **mascarava como 0**. No Ilha a Área Comum já é 0, então nada pareceria errado — mas qualquer cliente com Área Comum positiva veria ela encolher pelo valor do device incluído, sem razão legítima.

**Correção:** cada subtotal é dividido em parcela de **origem `areacomum`** e parcela **cross-group**. O card mantém o total cheio; **o residual desconta só a parcela de origem**. Novo `computeBaseGroupResidual` (lib pura) expõe `residualRaw` e `negative` — o clamp continua, mas um residual genuinamente negativo agora emite `LogHelper.warn` uma vez por sessão, com os números, em vez de sumir.

## Números do Ilha (assertados, não estimados)

| | Antes | Depois |
|---|---|---|
| Card Climatização | 1.152.603 | **1.790.163** (cross: 637.560) |
| Entrada | 1.390.237 | **1.390.237** (inalterada) |
| Residual (pré-clamp) | 0 | **0** — pela fórmula antiga seria **−637.560** |

Um teste sintético cobre o caso que quebraria em produção: shopping com Área Comum **positiva** (500.000) — o card cresce para 500.000 e o residual **permanece** 500.000, enquanto a fórmula antiga cairia para 300.000.

## Verificação (reconferida pelo revisor)

- **131 testes passando em 12 arquivos** (`deviceClassificationProfile*` + `deviceProfileModal*`); +18 nesta rodada. Rodei na worktree.
- Suíte completa: 825 passed / 105 failed — as **mesmas 105 pré-existentes** nos mesmos 9 arquivos intocados (confirmado pelo agente via stash contra `desenv` limpo).
- `npm run build` OK, DTS verificado, `computeBaseGroupResidual` presente no UMD. `node --check` OK. ESLint no controller: 0 erros.
- Campo ausente = comportamento byte-idêntico ao atual; o modal apaga a chave quando a lista esvazia.

## Ressalvas para o revisor

1. **Override por ID é *escape hatch* topológico** — quebra em reprovisionamento (o UUID muda) e não deve virar a forma normal de classificar. Documentado no RFC-0207.
2. **`TELEMETRY_INFO/controller.js` não foi tocado.** Seus residuais (`:722`, `:1582`) usam `Entrada − consumidores`, uma forma que se autocorrige sob include cross-group — mas isso foi **raciocinado, não testado**, e `:722` roda uma classificação própria. Vale o olhar de quem conhece o widget antes do rollout.
3. Uma mudança incidental: `refreshPreview` passou a envolver `getDevices()` em try/catch (um callback que lançasse já matava o modal). Fora do escopo estrito — reverter se preferir raio zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
