### PR TITLE
feat(rfc-0207): modo "pai" — device de entrada como pai da composição de Climatização

### DIFF
--- a/docs/rfcs/RFC-0207-CustomerScopedDeviceClassificationProfile.md
+++ b/docs/rfcs/RFC-0207-CustomerScopedDeviceClassificationProfile.md
@@ -1301,7 +1301,7 @@ Cada regra de categoria (`domains.<domain>.categories.rules[]`) ganha um campo *
 deviceOverrides?: Array<{
   id: string;              // TB entity id — mesma chave de `excludeDevicesAtCountSubtotalCAG`
   label?: string;          // guardado só para exibição/resiliência na UI
-  mode: 'include' | 'exclude';
+  mode: 'include' | 'exclude' | 'parent';  // `parent` adicionado em 2026-07-24 — ver §DE-G
 }>;
 ```
 
@@ -1318,8 +1318,9 @@ apaga a chave quando a lista esvazia).
 
 | modo | efeito |
 | --- | --- |
-| `include` | O device **agrega nesta categoria mantendo o seu grupo**. `resolveGroup` não muda: o total da coluna Entrada fica **idêntico**. Ele é apenas somado a mais nos itens/total da categoria do breakdown. |
+| `include` | O device **agrega nesta categoria mantendo o seu grupo** (feed **paralelo**). `resolveGroup` não muda: o total da coluna Entrada fica **idêntico**. Ele é apenas somado a mais nos itens/total da categoria do breakdown. |
 | `exclude` | O device sai do breakdown **inteiro**. **Não** cai em `outros` nem em bucket nenhum. |
+| `parent` | O device **contém** a composição da categoria (ver **§DE-G**): o valor DELE vira o total da categoria e a composição auto-classificada é o **breakdown aninhado**, **não somado por cima** (evita a dupla contagem). Grupo inalterado (Entrada intacta), como no `include`. |
 
 Por que `exclude` não cai em `outros`: o `exclude` existe para **dupla medição** — a bomba já
 está dentro da leitura do trafo. Roteá-la para `outros` seria recontá-la, que é exatamente o
@@ -1434,6 +1435,93 @@ anterior.
 O clamp em 0 **fica** — mas um `residualRaw` negativo agora significa problema real de
 dado/configuração (soma dos subtotais maior que o total do grupo), não artefato deste recurso.
 Por isso ele é logado uma vez por sessão (`LogHelper.warn`) com os números, em vez de sumir.
+
+### DE-G. Modo `parent` — o device CONTÉM a composição (2026-07-24)
+
+`include` resolve o caso da **Ilha** (feed **paralelo**: o trafo da CAG é energia *adicional*, some
+com os submedidores). Mas há o caso oposto, medido ao vivo no **Moxuara**:
+
+```
+CAG-Entrada  (deviceProfile ENTRADA, identifier CAG, grupo entrada)  = 336.600   ← PAI
+  ├─ Chillers 3                                                        = 184.661
+  ├─ Fancoils 14                                                       =  96.046   } composição
+  └─ Bombas  13                                                        =  46.266   } (grupo areacomum)
+                                                                        ---------
+                                                         Σ filhos      = 326.973
+```
+
+`CAG-Entrada` é o medidor de **entrada** da Central de Água Gelada: mede TODA a alimentação da
+CAG. Os submedidores internos (Chillers/Fancoils/Bombas) estão **a jusante** dele — 336.600 ≳
+326.973 (~3% de perda de linha). Não são feeds paralelos: o pai **contém** os filhos.
+
+Com `include` o card mostraria `336.600 + 326.973 = 663.573` — **dupla contagem**. Com a
+composição pura (sem override) mostraria 326.973 e o pai ficaria invisível. O correto é
+**336.600** (o pai), com a composição como **detalhamento aninhado**.
+
+**Schema.** `mode` passa a ser `'include' | 'exclude' | 'parent'` (valor puro, §A respeitada;
+ausente/bundles antigos ⇒ comportamento de antes — a lib antiga coage `parent` → `include`).
+
+**Semântica de `parent` para a Climatização:**
+
+| | `include` (Ilha) | `parent` (Moxuara) |
+|---|---|---|
+| Relação com a composição | **paralelo** | **contém** |
+| Total do card | composição **+** device | **valor do device** (a composição não soma por cima) |
+| Composição | some no total | vira **breakdown aninhado** sob o pai |
+| Grupo do device | inalterado (Entrada intacta) | inalterado (Entrada intacta) |
+
+Mesmo gesto de UI, matemática de total **oposta** — só o operador sabe qual é o caso, por isso é
+escolha **explícita** ("como pai" no picker), nunca inferida.
+
+**Fórmula do total** (MAIN_VIEW `buildSummary`):
+`climatizacaoTotal = hasParent ? Σ(pais) : Σ(filhos)`. Os pais vão para um balde à parte
+(`climatizacaoParentItems`) e **não** entram nem em `climatizacaoItems` nem nas subcategorias;
+`climatizacaoItems` continua sendo só a composição (os filhos). Moxuara: `climatizacaoTotal =
+336.600` (≠ 663.573, ≠ 326.973). Entrada continua `783.750 + 336.600 = 1.120.350` — o pai não
+muda de grupo.
+
+**Fórmula do residual** e a **prevenção da dupla subtração** (o ponto delicado). O modo `parent`
+quebra a premissa `base = total − cross` do §DE-E: quando o card mostra o valor do pai
+(cross-group), `total` **não** é mais a soma dos filhos. Se descontássemos `total − cross` do
+residual daria `336.600 − 336.600 = 0` — e os filhos (326.973), que ESTÃO em `areacomumTotal`,
+ficariam sem desconto. Se descontássemos os dois, o residual cairia por `−336.600`.
+
+A solução: `computeBaseGroupResidual` ganhou `baseGroupContribution` (opcional). Para a
+climatização com pai o `buildSummary` passa:
+
+```
+{ category:'climatizacao',
+  total: 336.600,                         // = card (o pai, cross-group)
+  crossGroupTotal: 336.600,               // o pai — informativo, NUNCA descontado
+  baseGroupContribution: 326.973 }        // os FILHOS de origem-base — o único desconto
+```
+
+`computeBaseGroupResidual` então faz `subtotalFromBaseGroup += baseGroupContribution` em vez de
+`total − cross`. Resultado: **só os filhos (326.973) são descontados, uma vez**; o pai (336.600),
+por ser cross-group, entra apenas em `subtotalCrossGroup` (informativo) e **nunca** toca o
+residual. É exatamente isso que impede o pai E os filhos de baterem no residual cada um:
+`residual = areacomumTotal − 326.973`. No Moxuara `areacomumTotal = 326.973` (só a composição)
+⇒ `residual = 0`, **de verdade** (pré-clamp 0, não negativo mascarado). `baseGroupContribution`
+ausente ⇒ cai em `total − cross` (byte-idêntico ao §DE-E; `include`/sem-override intocados).
+
+Na reconstrução da Área Comum efetiva (quando `excludeGroupsTotals` está ligado), a parcela de
+climatização usada é a dos **filhos** (`Math.max(0, Σfilhos − crossFilhos)`), não a do pai — o pai
+mora em Entrada e somá-lo ali dobraria com `_entradaEff`.
+
+**Tooltip** (TELEMETRY_INFO `buildClimatizacaoContent`). `STATE.consumidores.climatizacao` ganhou
+`parents: [{id,label,total}]` (threaded pelo MAIN_VIEW). Com pai, a **Composição** renderiza uma
+linha `🔌 <label> … <total>` no topo (classe `myio-info-tooltip__category--parent`, "Medidor pai
+da composição") e as subcategorias existentes vão num wrapper `myio-info-tooltip__nested`
+indentado abaixo. Campo ausente/vazio ⇒ composição plana, **byte-idêntica** à de antes.
+
+**Limitação assumida — N pais.** O modelo trata **todos** os pais de uma categoria como cobrindo
+**coletivamente** a composição inteira dela (a composição não é atribuída pai-a-pai). Para o caso
+de **um** pai que cobre toda a Climatização — que é o Moxuara — isso é exato. Com dois ou mais
+pais na mesma categoria, a partição "qual filho está sob qual pai" não é derivável dos dados
+disponíveis; o comportamento resultante (todos os pais somam no total da categoria; toda a
+composição vira o breakdown coletivo) é uma simplificação **documentada**, não um palpite. Se
+esse caso surgir de verdade, é sinal de que falta modelar a topologia com mais estrutura (ex.:
+um pai por sub-árvore), não de forçar heurística.
 
 ### DE-F. Ressalva — isto é um escape hatch, não um método
 

--- a/src/components/premium-modals/device-profile/openDeviceProfileModal.ts
+++ b/src/components/premium-modals/device-profile/openDeviceProfileModal.ts
@@ -469,11 +469,14 @@ export function openDeviceProfileModal(params: OpenDeviceProfileModalParams) {
         // label guardado no perfil e sinalizamos.
         const name = found?.label || ov.label || ov.id;
         const missing = !found;
-        const isExc = ov.mode === 'exclude';
-        return `<span class="mdp-ovr-chip ${isExc ? 'is-exclude' : 'is-include'} ${
+        const modeClass =
+          ov.mode === 'exclude' ? 'is-exclude' : ov.mode === 'parent' ? 'is-parent' : 'is-include';
+        const modeLabel =
+          ov.mode === 'exclude' ? 'excluir' : ov.mode === 'parent' ? 'como pai' : 'incluir';
+        return `<span class="mdp-ovr-chip ${modeClass} ${
           missing ? 'is-missing' : ''
         }" title="${escHtml(ov.id)}">
-          <span class="mdp-ovr-mode">${isExc ? 'excluir' : 'incluir'}</span>
+          <span class="mdp-ovr-mode">${modeLabel}</span>
           <span class="mdp-ovr-name">${escHtml(name)}</span>
           ${missing ? '<span class="mdp-ovr-warn" title="Dispositivo não encontrado na lista atual">⚠</span>' : ''}
           ${
@@ -498,9 +501,11 @@ export function openDeviceProfileModal(params: OpenDeviceProfileModalParams) {
     return `<div class="mdp-field mdp-ovr">
       <label>Dispositivos Específicos</label>
       <div class="mdp-ovr-hint">
-        <b>incluir</b>: soma o device nesta categoria <i>sem</i> mudar o grupo dele (o total da coluna
-        de origem continua igual). <b>excluir</b>: tira o device do breakdown por completo (não cai em
-        “outros”) — use para dupla-medição.
+        <b>incluir</b>: <i>soma</i> o device nesta categoria sem mudar o grupo dele (feed paralelo — o
+        total da coluna de origem continua igual). <b>como pai</b>: o device <i>contém</i> a composição —
+        o valor DELE vira o total da categoria e as subcategorias viram o detalhamento aninhado (não
+        somam por cima). <b>excluir</b>: tira o device do breakdown por completo (não cai em “outros”)
+        — use para dupla-medição.
       </div>
       <div class="mdp-ovr-row">
         <div class="mdp-ovr-list">${rows}${empty}</div>
@@ -552,6 +557,8 @@ export function openDeviceProfileModal(params: OpenDeviceProfileModalParams) {
           <span class="mdp-picker-actions">
             <button type="button" class="mdp-picker-pick is-include" data-id="${escHtml(d.id)}"
                     data-label="${escHtml(d.label)}" data-mode="include">incluir</button>
+            <button type="button" class="mdp-picker-pick is-parent" data-id="${escHtml(d.id)}"
+                    data-label="${escHtml(d.label)}" data-mode="parent">como pai</button>
             <button type="button" class="mdp-picker-pick is-exclude" data-id="${escHtml(d.id)}"
                     data-label="${escHtml(d.label)}" data-mode="exclude">excluir</button>
           </span>
@@ -1003,6 +1010,7 @@ function injectStyles() {
   .mdp-ovr-chip { display: inline-flex; align-items: center; gap: 5px; border-radius: 12px;
     padding: 2px 8px; font-size: 11px; font-weight: 600; border: 1px solid; max-width: 100%; }
   .mdp-ovr-chip.is-include { background: #ede9fe; border-color: #c4b5fd; color: #5b21b6; }
+  .mdp-ovr-chip.is-parent { background: #ccfbf1; border-color: #5eead4; color: #0f766e; }
   .mdp-ovr-chip.is-exclude { background: #fee2e2; border-color: #fca5a5; color: #991b1b; }
   .mdp-ovr-chip.is-missing { opacity: .75; border-style: dashed; }
   .mdp-ovr-mode { font-size: 9px; font-weight: 800; text-transform: uppercase; letter-spacing: .04em; opacity: .8; }
@@ -1036,6 +1044,8 @@ function injectStyles() {
     padding: 3px 8px; cursor: pointer; border: 1px solid; }
   .mdp-picker-pick.is-include { background: #ede9fe; border-color: #c4b5fd; color: #5b21b6; }
   .mdp-picker-pick.is-include:hover { background: #ddd6fe; }
+  .mdp-picker-pick.is-parent { background: #ccfbf1; border-color: #5eead4; color: #0f766e; }
+  .mdp-picker-pick.is-parent:hover { background: #99f6e4; }
   .mdp-picker-pick.is-exclude { background: #fee2e2; border-color: #fca5a5; color: #991b1b; }
   .mdp-picker-pick.is-exclude:hover { background: #fecaca; }
   .mdp-picker-empty { font-size: 11px; color: #94a3b8; padding: 10px 8px; text-align: center; font-style: italic; }

--- a/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/MAIN_VIEW/controller.js
+++ b/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/MAIN_VIEW/controller.js
@@ -4170,6 +4170,11 @@ function buildSummary(lojas, entrada, areacomum, periodKey) {
   const GERADOR_PATTERNS = ['GERADOR', 'NOBREAK', 'UPS'];
 
   const climatizacaoItems = [];
+  // RFC-0207 "parent" — devices marcados como PAI da composição de Climatização.
+  // O valor deles VIRA o total do card; a composição (chillers/fancoils/bombas)
+  // é o breakdown aninhado, NÃO somado por cima (evita a dupla contagem). Ficam
+  // FORA de `climatizacaoItems` e das subcategorias por isso.
+  const climatizacaoParentItems = [];
   const elevadoresItems = [];
   const escadasRolantesItems = [];
   const outrosItems = [];
@@ -4228,7 +4233,7 @@ function buildSummary(lojas, entrada, areacomum, periodKey) {
   // `computeBaseGroupResidual`. Fica vazio quando não há override nenhum.
   const _crossOriginItems = new Set();
 
-  for (const { item, forcedCategory, fromBaseGroup } of _breakdownEntries) {
+  for (const { item, forcedCategory, fromBaseGroup, isParent } of _breakdownEntries) {
     // `=== false` de propósito: bundles antigos da lib não emitem o campo, e
     // `undefined` deve significar "veio do grupo base" (comportamento de antes).
     if (fromBaseGroup === false) _crossOriginItems.add(item);
@@ -4253,6 +4258,13 @@ function buildSummary(lojas, entrada, areacomum, periodKey) {
     } else if (_topCat === 'escadas_rolantes') {
       escadasRolantesItems.push(item);
     } else if (_topCat === 'climatizacao') {
+      // RFC-0207 "parent": o PAI da composição CONTÉM os filhos — o valor dele
+      // é o total do card e os filhos são só o breakdown aninhado. Não entra em
+      // climatizacaoItems (não infla o total) nem nas subcategorias.
+      if (isParent === true) {
+        climatizacaoParentItems.push(item);
+        continue;
+      }
       climatizacaoItems.push(item);
       if (combined.includes('CHILLER') || id.startsWith('CHILLER-')) chillerItems.push(item);
       else if (combined.includes('FANCOIL') || id.startsWith('FANCOIL-')) fancoilItems.push(item);
@@ -4305,7 +4317,22 @@ function buildSummary(lojas, entrada, areacomum, periodKey) {
   }
 
   // ============ CALCULATE SUB-TOTAIS (Usando o Helper) ============
-  const climatizacaoTotal = climatizacaoItems.reduce((sum, i) => sum + getValorEfetivo(i, 'climatizacao'), 0);
+  // RFC-0207 "parent": `climatizacaoItems` é a COMPOSIÇÃO (filhos auto-classificados,
+  // sempre no grupo base). Quando há um PAI declarado, o total do card passa a ser
+  // o valor do pai (ele CONTÉM os filhos), e os filhos viram só o breakdown aninhado
+  // — nunca somados por cima (a dupla contagem que o modo existe para evitar).
+  const _climatizacaoChildrenTotal = climatizacaoItems.reduce(
+    (sum, i) => sum + getValorEfetivo(i, 'climatizacao'),
+    0
+  );
+  const _climatizacaoParentTotal = climatizacaoParentItems.reduce(
+    (sum, i) => sum + getValorEfetivo(i, 'climatizacao'),
+    0
+  );
+  const _hasClimatizacaoParent = climatizacaoParentItems.length > 0;
+  const climatizacaoTotal = _hasClimatizacaoParent
+    ? _climatizacaoParentTotal
+    : _climatizacaoChildrenTotal;
   const elevadoresTotal = elevadoresItems.reduce((sum, i) => sum + getValorEfetivo(i, 'elevadores'), 0);
   const escadasRolantesTotal = escadasRolantesItems.reduce(
     (sum, i) => sum + getValorEfetivo(i, 'escadas_rolantes'),
@@ -4351,7 +4378,15 @@ function buildSummary(lojas, entrada, areacomum, periodKey) {
     const _exclGroups = _excludeGroupsTotals.groups || {};
     const _lojasEff = _exclGroups.lojas ? 0 : lojasTotal;
     const _entradaEff = _exclGroups.entrada ? 0 : entradaTotal;
-    const _climatizacaoEff = _exclGroups.climatizacao ? 0 : climatizacaoTotal;
+    // RFC-0207 "parent": ao reconstruir a Área Comum efetiva, a parcela de
+    // climatização que REALMENTE mora em `areacomum` é a dos FILHOS (a composição),
+    // não a do pai — o pai é cross-group (mora em Entrada) e somá-lo aqui dobraria
+    // com `_entradaEff`. Sem pai, usa `climatizacaoTotal` cheio (include/normal
+    // seguem byte-idênticos: o quirk cross-group do include é pré-existente).
+    const _climatizacaoAreacomumPortion = _hasClimatizacaoParent
+      ? Math.max(0, _climatizacaoChildrenTotal - climatizacaoCrossTotal)
+      : climatizacaoTotal;
+    const _climatizacaoEff = _exclGroups.climatizacao ? 0 : _climatizacaoAreacomumPortion;
     const _elevadoresEff = _exclGroups.elevadores ? 0 : elevadoresTotal;
     const _escadasEff = _exclGroups.escadas_rolantes ? 0 : escadasRolantesTotal;
     const _outrosEff = _exclGroups.outros ? 0 : outrosTotal;
@@ -4362,7 +4397,21 @@ function buildSummary(lojas, entrada, areacomum, periodKey) {
     // e o clamp em 0 mascararia. Sem overrides, cross = 0 e a conta é a de antes.
     const _residualCalc = _computeBaseGroupResidual
       ? _computeBaseGroupResidual(areacomumTotal, [
-          { category: 'climatizacao', total: climatizacaoTotal, crossGroupTotal: climatizacaoCrossTotal },
+          // RFC-0207 "parent": o card mostra o valor do PAI (cross-group), mas o
+          // residual só pode descontar de `areacomumTotal` os FILHOS que de fato
+          // estão nele. `baseGroupContribution` = soma dos filhos de origem-base;
+          // o pai entra em crossGroupTotal (informativo, nunca descontado). Assim
+          // nem o pai (336.600) nem os filhos (326.973) são descontados duas vezes:
+          // só os filhos, uma vez. Sem pai, o campo fica ausente e a conta é a de
+          // antes (total − crossGroupTotal).
+          _hasClimatizacaoParent
+            ? {
+                category: 'climatizacao',
+                total: climatizacaoTotal,
+                crossGroupTotal: _climatizacaoParentTotal,
+                baseGroupContribution: Math.max(0, _climatizacaoChildrenTotal - climatizacaoCrossTotal),
+              }
+            : { category: 'climatizacao', total: climatizacaoTotal, crossGroupTotal: climatizacaoCrossTotal },
           { category: 'elevadores', total: elevadoresTotal, crossGroupTotal: elevadoresCrossTotal },
           {
             category: 'escadas_rolantes',
@@ -4462,6 +4511,14 @@ function buildSummary(lojas, entrada, areacomum, periodKey) {
     lojas: buildCategorySummary(lojas, lojasTotal, 'Lojas'),
     climatizacao: {
       ...buildCategorySummary(climatizacaoItems, climatizacaoTotal, 'Climatização'),
+      // RFC-0207 "parent": devices que HEADAM a composição (o total do card é o
+      // valor deles; a composição abaixo é o breakdown aninhado). Vazio quando não
+      // há pai — nesse caso o TELEMETRY_INFO renderiza a composição plana, como antes.
+      parents: climatizacaoParentItems.map((i) => ({
+        id: i.id,
+        label: i.label || i.name || i.identifier || i.id,
+        total: getValorEfetivo(i, 'climatizacao'),
+      })),
       subcategories: {
         chillers: buildCategorySummary(chillerItems, chillerTotal, 'Chillers'),
         fancoils: buildCategorySummary(fancoilItems, fancoilTotal, 'Fancoils'),

--- a/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/TELEMETRY_INFO/controller.js
+++ b/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/TELEMETRY_INFO/controller.js
@@ -1591,6 +1591,10 @@ function processStateFromSummaryEnergy(summary, _grandTotal) {
       perc: _pct(_climatTot),
       // Subcategories available for detailed tooltips
       subcategories: summary.climatizacao?.subcategories || null,
+      // RFC-0207 "parent": device(s) que headam a composição. Quando presente e
+      // não-vazio, o tooltip renderiza o pai no topo e a composição aninhada
+      // abaixo dele. Ausente/vazio ⇒ composição plana (comportamento de antes).
+      parents: summary.climatizacao?.parents || [],
     },
     elevadores: {
       devices: elevadoresDevices,
@@ -2824,6 +2828,41 @@ function buildClimatizacaoContent() {
     `;
   }
 
+  // RFC-0207 "parent": quando um device foi declarado PAI da composição, ele
+  // aparece como uma linha no TOPO da Composição (com o valor dele = total do
+  // card) e as subcategorias existentes ficam ANINHADAS (indentadas) abaixo. O
+  // pai NÃO é somado por cima da composição — o total já é o valor dele. Campo
+  // ausente/vazio ⇒ composição plana, exatamente como antes.
+  const _escClim = (s) =>
+    String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  const climParents = STATE.consumidores.climatizacao?.parents || [];
+  const _hasClimParents = Array.isArray(climParents) && climParents.length > 0;
+  let composicaoHtml = subcatHtml;
+  if (_hasClimParents) {
+    const parentLines = climParents
+      .map(
+        (p) => `
+          <div class="myio-info-tooltip__category myio-info-tooltip__category--climatizacao myio-info-tooltip__category--parent">
+            <span class="myio-info-tooltip__category-icon">🔌</span>
+            <div class="myio-info-tooltip__category-info">
+              <div class="myio-info-tooltip__category-name">${_escClim(p.label)}</div>
+              <div class="myio-info-tooltip__category-desc">Medidor pai da composição</div>
+            </div>
+            <span class="myio-info-tooltip__category-value">${formatEnergy(p.total || 0)}</span>
+          </div>
+        `
+      )
+      .join('');
+    composicaoHtml = `${parentLines}
+      <div class="myio-info-tooltip__nested" style="margin-left:16px; padding-left:10px; border-left:2px solid rgba(0,200,150,0.28);">
+        ${subcatHtml}
+      </div>`;
+  }
+
   return `
     <div class="myio-info-tooltip__section">
       <div class="myio-info-tooltip__section-title">
@@ -2849,13 +2888,17 @@ function buildClimatizacaoContent() {
       <div class="myio-info-tooltip__section-title">
         <span>📋</span> Composição
       </div>
-      ${subcatHtml}
+      ${composicaoHtml}
     </div>
 
     <div class="myio-info-tooltip__notice">
       <span class="myio-info-tooltip__notice-icon">💡</span>
       <div class="myio-info-tooltip__notice-text">
-        O valor de <strong>Climatização</strong> é calculado pela soma do consumo de todos os equipamentos classificados nestas categorias.
+        ${
+          _hasClimParents
+            ? 'O valor de <strong>Climatização</strong> é o do <strong>medidor pai</strong> da composição; as subcategorias abaixo dele são o detalhamento (não somam por cima).'
+            : 'O valor de <strong>Climatização</strong> é calculado pela soma do consumo de todos os equipamentos classificados nestas categorias.'
+        }
       </div>
     </div>
     ${buildExcludedFromCAGNotice()}

--- a/src/utils/devices/deviceClassificationProfile.ts
+++ b/src/utils/devices/deviceClassificationProfile.ts
@@ -114,12 +114,26 @@ export interface ConditionalRule extends IdentifierMatch {
  *
  * - `include` — o device AGREGA nesta categoria do breakdown **mantendo o seu
  *   grupo**. `resolveGroup` não muda: o total da coluna (ex.: Entrada) fica
- *   idêntico. O device é apenas somado a mais na categoria.
+ *   idêntico. O device é apenas somado a mais na categoria (feed PARALELO — o
+ *   caso do Shopping da Ilha, onde o trafo da CAG é energia ADICIONAL).
  * - `exclude` — o device sai do breakdown **inteiro**. Não cai em `outros` nem em
  *   nenhum outro bucket. Existe para dupla-medição (o submedidor já está dentro
  *   da leitura do trafo); mandá-lo para `outros` seria recontá-lo.
+ * - `parent` — o device é o **PAI** da composição da categoria: o valor DELE vira
+ *   o total da categoria e a composição auto-classificada (Chillers/Fancoils/…)
+ *   é o BREAKDOWN dele — mostrada aninhada, mas **NÃO somada por cima** do pai
+ *   (evita a dupla contagem). É o caso do Moxuara: o medidor de ENTRADA da CAG
+ *   (`CAG-Entrada`, 336.600) CONTÉM os submedidores internos (326.973); os filhos
+ *   estão a jusante do pai. Contraste com `include`: `include` SOMA (feed
+ *   paralelo), `parent` CONTÉM (a composição). Mesmo gesto de UI, matemática de
+ *   total OPOSTA — só o operador sabe qual dos dois é, por isso é escolha
+ *   explícita, nunca inferida. Como `include`, o device é PUXADO do grupo dele
+ *   (o grupo NÃO muda; o total da coluna de origem continua igual).
+ *
+ * Retrocompat: ausência do campo = comportamento de sempre; bundles antigos da
+ * lib coagem `parent` → `include` (degradação documentada — vira feed paralelo).
  */
-export type DeviceOverrideMode = 'include' | 'exclude';
+export type DeviceOverrideMode = 'include' | 'exclude' | 'parent';
 
 /**
  * Override explícito por dispositivo (escape hatch topológico).
@@ -576,8 +590,20 @@ export function normalizeDeviceOverrideId(id: unknown): string {
 }
 
 export interface CollectedDeviceOverrides {
-  /** device id normalizado → categoria na qual ele deve ser AGREGADO. */
+  /**
+   * device id normalizado → categoria na qual ele deve ser PUXADO ao breakdown.
+   * Contém tanto os `include` quanto os `parent` (ambos são puxados do grupo de
+   * origem e recebem `forcedCategory`); o que distingue os dois é o mapa
+   * `parents` abaixo, que só a matemática do total lê.
+   */
   includes: Map<string, CategoryName>;
+  /**
+   * device id normalizado → categoria da qual ele é PAI. Subconjunto de
+   * `includes`. Um pai CONTÉM a composição da categoria (o total da categoria
+   * passa a ser o valor do pai; a composição vira breakdown aninhado, não somado
+   * por cima). Vazio quando não há nenhum `parent`.
+   */
+  parents: Map<string, CategoryName>;
   /** device ids normalizados removidos do breakdown por inteiro. */
   excludes: Set<string>;
   /** device id normalizado → label capturado na edição (exibição/diagnóstico). */
@@ -599,6 +625,7 @@ export function collectDeviceOverrides(
   domain: ClassificationDomain = 'energy',
 ): CollectedDeviceOverrides {
   const includes = new Map<string, CategoryName>();
+  const parents = new Map<string, CategoryName>();
   const excludes = new Set<string>();
   const labels = new Map<string, string>();
 
@@ -608,14 +635,24 @@ export function collectDeviceOverrides(
       const key = normalizeDeviceOverrideId(ov?.id);
       if (!key) continue;
       if (ov.label) labels.set(key, String(ov.label));
-      if (ov.mode === 'exclude') excludes.add(key);
-      else if (!includes.has(key)) includes.set(key, rule.name);
+      if (ov.mode === 'exclude') {
+        excludes.add(key);
+      } else if (!includes.has(key)) {
+        // `parent` e `include` ambos entram em `includes` (ambos são puxados +
+        // recebem forcedCategory); `parent` é adicionalmente marcado em `parents`
+        // para que só a matemática do total troque SOMAR por CONTER.
+        includes.set(key, rule.name);
+        if (ov.mode === 'parent') parents.set(key, rule.name);
+      }
     }
   }
-  // exclude vence include
-  for (const key of excludes) includes.delete(key);
+  // exclude vence include (e vence parent — parent é uma variante de include)
+  for (const key of excludes) {
+    includes.delete(key);
+    parents.delete(key);
+  }
 
-  return { includes, excludes, labels };
+  return { includes, parents, excludes, labels };
 }
 
 /** Um item elegível ao breakdown + a categoria forçada por override (ou `null`). */
@@ -638,6 +675,18 @@ export interface BreakdownEntry<T> {
    * Ver `computeBaseGroupResidual`.
    */
   fromBaseGroup: boolean;
+  /**
+   * `true` quando o item é PAI da composição da sua categoria (override `parent`).
+   * O consumidor usa isto para trocar a matemática do total: o valor do pai
+   * VIRA o total da categoria, e a composição auto-classificada é o breakdown
+   * aninhado (não somado por cima).
+   *
+   * OPCIONAL e emitido SÓ quando `true` (nunca `false`): mantém as entradas de
+   * `include`/base/fast-path byte-idênticas às de antes do modo `parent`
+   * (retrocompat — perfis sem pai não ganham chave nova). Leia como
+   * `entry.isParent === true`; ausência ⇒ não é pai.
+   */
+  isParent?: boolean;
 }
 
 export interface SelectBreakdownItemsOptions {
@@ -667,7 +716,7 @@ export function selectBreakdownItems<T extends ClassifiableItem>(
   const baseGroup = options.baseGroup || 'areacomum';
   const base = (groups?.[baseGroup] ?? []) as T[];
 
-  const { includes, excludes } = collectDeviceOverrides(profile, domain);
+  const { includes, parents, excludes } = collectDeviceOverrides(profile, domain);
 
   // Fast-path: perfil sem Dispositivos Específicos ⇒ o breakdown de sempre.
   if (includes.size === 0 && excludes.size === 0) {
@@ -681,6 +730,10 @@ export function selectBreakdownItems<T extends ClassifiableItem>(
 
   const out: BreakdownEntry<T>[] = [];
   const seen = new Set<string>();
+  // `isParent` só é emitido quando true (ver BreakdownEntry) — mantém entradas
+  // de include/base byte-idênticas.
+  const parentFlag = (key: string): { isParent: true } | Record<string, never> =>
+    parents.has(key) ? { isParent: true } : {};
 
   for (const item of base) {
     const key = normalizeDeviceOverrideId((item as { id?: unknown })?.id);
@@ -694,6 +747,7 @@ export function selectBreakdownItems<T extends ClassifiableItem>(
         forcedCategory: forced ?? null,
         sourceGroup: baseGroup,
         fromBaseGroup: true,
+        ...parentFlag(key),
       });
       continue;
     }
@@ -702,7 +756,7 @@ export function selectBreakdownItems<T extends ClassifiableItem>(
 
   if (includes.size === 0) return out;
 
-  // Puxa os `include` que vivem FORA do grupo base (tipicamente `entrada`).
+  // Puxa os `include`/`parent` que vivem FORA do grupo base (tipicamente `entrada`).
   // Estes NÃO estão dentro do total do grupo base — daí `fromBaseGroup: false`.
   for (const groupKey of Object.keys(groups || {})) {
     if (groupKey === baseGroup) continue;
@@ -712,7 +766,13 @@ export function selectBreakdownItems<T extends ClassifiableItem>(
       const forced = includes.get(key);
       if (!forced) continue;
       seen.add(key);
-      out.push({ item, forcedCategory: forced, sourceGroup: groupKey, fromBaseGroup: false });
+      out.push({
+        item,
+        forcedCategory: forced,
+        sourceGroup: groupKey,
+        fromBaseGroup: false,
+        ...parentFlag(key),
+      });
     }
   }
 
@@ -731,6 +791,21 @@ export interface BreakdownSubtotalInput {
   total: number;
   /** Parcela de `total` que veio de devices FORA do grupo base. */
   crossGroupTotal: number;
+  /**
+   * RFC-0207 "parent" — parcela EXPLÍCITA que está de fato dentro do
+   * `baseGroupTotal` e deve ser descontada no residual.
+   *
+   * Existe porque o modo `parent` QUEBRA a premissa `base = total − cross`: quando
+   * o pai (ex.: CAG-Entrada, 336.600, cross-group) SUBSTITUI a composição no card,
+   * `total` passa a ser o valor do pai — não mais a soma dos filhos. Os FILHOS
+   * (326.973), que continuam fisicamente no grupo base, é que precisam ser
+   * descontados do residual; o pai, nunca (é cross-group, jamais esteve em
+   * `baseGroupTotal`). Passe aqui a soma dos filhos de origem-base.
+   *
+   * Ausente/`undefined` ⇒ cai no cálculo de sempre `total − crossGroupTotal`
+   * (byte-idêntico ao de antes; `include`/sem-override não usam este campo).
+   */
+  baseGroupContribution?: number;
 }
 
 export interface BaseGroupResidual {
@@ -768,7 +843,14 @@ export function computeBaseGroupResidual(
   for (const s of subtotals ?? []) {
     const total = Number(s?.total) || 0;
     const cross = Number(s?.crossGroupTotal) || 0;
-    subtotalFromBaseGroup += total - cross;
+    // `parent`: quando o card mostra o valor do PAI (cross-group) no lugar da
+    // composição, a parcela de origem-base é a soma dos FILHOS, não `total−cross`
+    // (que daria ~0 porque total==cross). O caller passa essa parcela explícita.
+    const base =
+      s?.baseGroupContribution !== undefined && s?.baseGroupContribution !== null
+        ? Number(s.baseGroupContribution) || 0
+        : total - cross;
+    subtotalFromBaseGroup += base;
     subtotalCrossGroup += cross;
   }
   const residualRaw = (Number(baseGroupTotal) || 0) - subtotalFromBaseGroup;
@@ -886,8 +968,8 @@ export function validateProfile(profile: DeviceClassificationProfile): string[] 
               if (!ov.id || typeof ov.id !== 'string' || !ov.id.trim()) {
                 errors.push(`${where}.id: missing device id`);
               }
-              if (ov.mode !== 'include' && ov.mode !== 'exclude') {
-                errors.push(`${where}.mode: must be "include" or "exclude"`);
+              if (ov.mode !== 'include' && ov.mode !== 'exclude' && ov.mode !== 'parent') {
+                errors.push(`${where}.mode: must be "include", "exclude" or "parent"`);
               }
               if (ov.label !== undefined && typeof ov.label !== 'string') {
                 errors.push(`${where}.label: must be a string`);
@@ -988,7 +1070,8 @@ export function normalizeProfile(raw: DeviceClassificationProfile): DeviceClassi
             .map((ov) => {
               const out: DeviceOverride = {
                 id: String(ov.id).trim(),
-                mode: ov.mode === 'exclude' ? 'exclude' : 'include',
+                mode:
+                  ov.mode === 'exclude' ? 'exclude' : ov.mode === 'parent' ? 'parent' : 'include',
               };
               if (ov.label !== undefined && ov.label !== null) out.label = String(ov.label);
               return out;

--- a/tests/deviceClassificationProfile.parent.test.ts
+++ b/tests/deviceClassificationProfile.parent.test.ts
@@ -1,0 +1,330 @@
+/**
+ * RFC-0207 "Dispositivos Específicos" — modo `parent` (o device É PAI da composição).
+ *
+ * Caso real (Moxuara, medido ao vivo):
+ *   - `CAG-Entrada` (deviceProfile ENTRADA, identifier CAG) é o medidor de ENTRADA
+ *     da CAG: mede TODA a alimentação = 336.600. Fica no grupo `entrada`.
+ *   - A composição interna (submedidores no grupo `areacomum`) soma 326.973:
+ *     Chillers 3 = 184.661, Fancoils 14 = 96.046, Bombas 13 = 46.266.
+ *   - Containment provado: pai 336.600 ≳ filhos 326.973 (~3% de perda de linha).
+ *     Os filhos estão A JUSANTE do pai.
+ *
+ * `parent` CONTÉM a composição (o total do card = valor do pai; os filhos são o
+ * breakdown aninhado, NÃO somados por cima). Contraste com `include`, que SOMA.
+ *
+ * Os testes exercitam o código EMBARCADO da lib (`selectBreakdownItems` +
+ * `computeBaseGroupResidual`), com um `runBreakdown` que espelha exatamente o
+ * `buildSummary` do MAIN_VIEW no ponto do modo `parent`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_DEVICE_CLASSIFICATION_PROFILE,
+  resolveGroup,
+  resolveCategory,
+  normalizeProfile,
+  validateProfile,
+  collectDeviceOverrides,
+  selectBreakdownItems,
+  computeBaseGroupResidual,
+  type DeviceClassificationProfile,
+  type ClassifiableItem,
+  type DeviceOverrideMode,
+} from '../src/utils/devices/deviceClassificationProfile';
+
+interface Device extends ClassifiableItem {
+  id: string;
+  label: string;
+  value: number;
+}
+
+function clone<T>(o: T): T {
+  return JSON.parse(JSON.stringify(o));
+}
+
+function profileWithOverrides(
+  overrides: { id: string; label?: string; mode: DeviceOverrideMode }[],
+): DeviceClassificationProfile {
+  const p: DeviceClassificationProfile = clone(DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+  p.domains.energy.categories!.rules.find((r) => r.name === 'climatizacao')!.deviceOverrides =
+    overrides;
+  return normalizeProfile(p);
+}
+
+function groupAll(devices: Device[], profile: DeviceClassificationProfile) {
+  const groups: Record<string, Device[]> = { lojas: [], entrada: [], areacomum: [], ocultos: [] };
+  for (const d of devices) groups[resolveGroup(d, profile, 'energy').group].push(d);
+  return groups;
+}
+
+/**
+ * Espelha o trecho do `buildSummary` do MAIN_VIEW que trata o modo `parent`:
+ *   - pais (isParent) vão para um balde à parte e NÃO entram na composição;
+ *   - o total do card de climatização = soma dos pais (se houver) OU soma dos
+ *     filhos (composição);
+ *   - o residual desconta de `areacomumTotal` só os FILHOS de origem-base
+ *     (`baseGroupContribution`), nunca o pai (cross-group).
+ */
+function runBreakdown(groups: Record<string, Device[]>, profile: DeviceClassificationProfile) {
+  const climatizacaoChildren: Device[] = [];
+  const climatizacaoParents: Device[] = [];
+  const outros: Device[] = [];
+  const crossOrigin = new Set<Device>();
+
+  for (const { item, forcedCategory, fromBaseGroup, isParent } of selectBreakdownItems<Device>(
+    groups,
+    profile,
+    'energy',
+  )) {
+    if (fromBaseGroup === false) crossOrigin.add(item);
+    const cat = forcedCategory || resolveCategory(item, profile, 'energy').category;
+    if (cat === 'climatizacao') {
+      if (isParent === true) climatizacaoParents.push(item);
+      else climatizacaoChildren.push(item);
+    } else {
+      outros.push(item);
+    }
+  }
+
+  const sum = (list: Device[]) => list.reduce((s, d) => s + d.value, 0);
+  const crossSum = (list: Device[]) =>
+    list.reduce((s, d) => s + (crossOrigin.has(d) ? d.value : 0), 0);
+
+  const childrenTotal = sum(climatizacaoChildren);
+  const parentTotal = sum(climatizacaoParents);
+  const hasParent = climatizacaoParents.length > 0;
+  const climatizacaoTotal = hasParent ? parentTotal : childrenTotal;
+  const climatizacaoCross = crossSum(climatizacaoChildren);
+
+  const areacomumTotal = sum(groups.areacomum || []);
+
+  const residual = computeBaseGroupResidual(areacomumTotal, [
+    hasParent
+      ? {
+          category: 'climatizacao',
+          total: climatizacaoTotal,
+          crossGroupTotal: parentTotal,
+          baseGroupContribution: Math.max(0, childrenTotal - climatizacaoCross),
+        }
+      : { category: 'climatizacao', total: climatizacaoTotal, crossGroupTotal: climatizacaoCross },
+    { category: 'outros', total: sum(outros), crossGroupTotal: crossSum(outros) },
+  ]);
+
+  // composição por deviceProfile (Chillers/Fancoils/Bombas)
+  const byProfile: Record<string, number> = {};
+  for (const d of climatizacaoChildren) {
+    const p = String(d.deviceProfile || '').toUpperCase();
+    byProfile[p] = (byProfile[p] || 0) + d.value;
+  }
+
+  return {
+    climatizacaoChildren,
+    climatizacaoParents,
+    childrenTotal,
+    parentTotal,
+    climatizacaoTotal,
+    areacomumTotal,
+    residual,
+    byProfile,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixture Moxuara — números reais
+// ---------------------------------------------------------------------------
+
+const CAG_ENTRADA_ID = '82f010d0-857e-423e-be43-c1e4e51ae25d';
+
+const MEDICAO_GERAL: Device = {
+  id: 'mx-medicao-geral',
+  label: 'Medição Geral',
+  deviceProfile: 'ENTRADA',
+  identifier: 'ENTRADA-GERAL',
+  value: 783750,
+};
+const CAG_ENTRADA: Device = {
+  id: CAG_ENTRADA_ID,
+  label: 'CAG-Entrada',
+  deviceProfile: 'ENTRADA',
+  identifier: 'CAG',
+  value: 336600,
+};
+// Chillers 3 = 184.661
+const CHILLERS: Device[] = [61554, 61554, 61553].map((value, i) => ({
+  id: `mx-chiller-${i + 1}`,
+  label: `Chiller ${i + 1}`,
+  deviceProfile: 'CHILLER',
+  identifier: `CHILLER-0${i + 1}`,
+  value,
+}));
+// Fancoils 14 = 96.046  (13×6860 + 6866)
+const FANCOILS: Device[] = Array.from({ length: 14 }, (_, i) => ({
+  id: `mx-fancoil-${i + 1}`,
+  label: `Fancoil ${i + 1}`,
+  deviceProfile: 'FANCOIL',
+  identifier: `FANCOIL-${i + 1}`,
+  value: i === 13 ? 6866 : 6860,
+}));
+// Bombas 13 = 46.266  (12×3559 + 3558)
+const BOMBAS: Device[] = Array.from({ length: 13 }, (_, i) => ({
+  id: `mx-bomba-${i + 1}`,
+  label: `Bomba CAG ${i + 1}`,
+  deviceProfile: 'BOMBA_CAG',
+  identifier: 'CAG',
+  value: i === 12 ? 3558 : 3559,
+}));
+
+const MOXUARA = [MEDICAO_GERAL, CAG_ENTRADA, ...CHILLERS, ...FANCOILS, ...BOMBAS];
+
+// ---------------------------------------------------------------------------
+
+describe('RFC-0207 parent — schema/collect/normalize', () => {
+  it('validateProfile aceita mode "parent"', () => {
+    const p = profileWithOverrides([{ id: CAG_ENTRADA_ID, label: 'CAG-Entrada', mode: 'parent' }]);
+    expect(validateProfile(p)).toEqual([]);
+  });
+
+  it('validateProfile rejeita mode inválido com a mensagem dos 3 modos', () => {
+    const p: DeviceClassificationProfile = clone(DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    p.domains.energy.categories!.rules.find((r) => r.name === 'climatizacao')!.deviceOverrides = [
+      { id: 'x', mode: 'boss' as unknown as DeviceOverrideMode },
+    ];
+    const errs = validateProfile(p);
+    expect(errs.some((e) => e.includes('"include", "exclude" or "parent"'))).toBe(true);
+  });
+
+  it('normalizeProfile preserva "parent" (não coage para include)', () => {
+    const p: DeviceClassificationProfile = clone(DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    p.domains.energy.categories!.rules.find((r) => r.name === 'climatizacao')!.deviceOverrides = [
+      { id: CAG_ENTRADA_ID, label: 'CAG-Entrada', mode: 'parent' },
+    ];
+    const n = normalizeProfile(p);
+    expect(
+      n.domains.energy.categories!.rules.find((r) => r.name === 'climatizacao')!.deviceOverrides,
+    ).toEqual([{ id: CAG_ENTRADA_ID, mode: 'parent', label: 'CAG-Entrada' }]);
+  });
+
+  it('collectDeviceOverrides põe o pai em includes E em parents', () => {
+    const p = profileWithOverrides([{ id: CAG_ENTRADA_ID, mode: 'parent' }]);
+    const { includes, parents, excludes } = collectDeviceOverrides(p, 'energy');
+    expect(includes.get(CAG_ENTRADA_ID)).toBe('climatizacao');
+    expect(parents.get(CAG_ENTRADA_ID)).toBe('climatizacao');
+    expect(excludes.size).toBe(0);
+  });
+
+  it('exclude vence parent (some dos dois mapas)', () => {
+    const p: DeviceClassificationProfile = clone(DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    const rules = p.domains.energy.categories!.rules;
+    rules.find((r) => r.name === 'climatizacao')!.deviceOverrides = [
+      { id: CAG_ENTRADA_ID, mode: 'parent' },
+    ];
+    rules.find((r) => r.name === 'elevadores')!.deviceOverrides = [
+      { id: CAG_ENTRADA_ID, mode: 'exclude' },
+    ];
+    const { includes, parents, excludes } = collectDeviceOverrides(normalizeProfile(p), 'energy');
+    expect(includes.has(CAG_ENTRADA_ID)).toBe(false);
+    expect(parents.has(CAG_ENTRADA_ID)).toBe(false);
+    expect(excludes.has(CAG_ENTRADA_ID)).toBe(true);
+  });
+
+  it('selectBreakdownItems marca isParent só no pai (e o puxa da entrada)', () => {
+    const p = profileWithOverrides([{ id: CAG_ENTRADA_ID, mode: 'parent' }]);
+    const groups = groupAll(MOXUARA, p);
+    const entries = selectBreakdownItems<Device>(groups, p, 'energy');
+    const parentEntry = entries.find((e) => e.item.id === CAG_ENTRADA_ID)!;
+    expect(parentEntry.isParent).toBe(true);
+    expect(parentEntry.fromBaseGroup).toBe(false);
+    expect(parentEntry.sourceGroup).toBe('entrada');
+    // nenhum filho é marcado como pai
+    expect(entries.filter((e) => e.isParent === true)).toHaveLength(1);
+    // entradas de filhos não carregam a chave isParent (retrocompat)
+    const child = entries.find((e) => e.item.id === CHILLERS[0].id)!;
+    expect('isParent' in child).toBe(false);
+  });
+});
+
+describe('RFC-0207 parent — aceitação Moxuara', () => {
+  const p = profileWithOverrides([{ id: CAG_ENTRADA_ID, label: 'CAG-Entrada', mode: 'parent' }]);
+  const groups = groupAll(MOXUARA, p);
+  const r = runBreakdown(groups, p);
+
+  it('a fixture reproduz os números reais', () => {
+    expect(CHILLERS.reduce((s, d) => s + d.value, 0)).toBe(184661);
+    expect(FANCOILS.reduce((s, d) => s + d.value, 0)).toBe(96046);
+    expect(BOMBAS.reduce((s, d) => s + d.value, 0)).toBe(46266);
+    expect(r.childrenTotal).toBe(326973);
+    expect(CAG_ENTRADA.value).toBe(336600);
+  });
+
+  it('Climatização (card) = 336.600 — o PAI (NÃO 663.573, NÃO 326.973)', () => {
+    expect(r.climatizacaoTotal).toBe(336600);
+    expect(r.climatizacaoTotal).not.toBe(336600 + 326973); // 663.573 = dupla contagem
+    expect(r.climatizacaoTotal).not.toBe(326973); // só os filhos, sem conter o pai
+  });
+
+  it('Entrada = 1.120.350, inalterada (o pai NÃO muda de grupo)', () => {
+    expect(groups.entrada.reduce((s, d) => s + d.value, 0)).toBe(1120350);
+    expect(resolveGroup(CAG_ENTRADA, p, 'energy').group).toBe('entrada');
+    const baseline = groupAll(MOXUARA, DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    expect(baseline.entrada.reduce((s, d) => s + d.value, 0)).toBe(1120350);
+  });
+
+  it('residual sem clamp mascarando negativo (filhos 326.973 são o único desconto)', () => {
+    // areacomum = só a composição (326.973) → residual = 0, e é 0 de verdade.
+    expect(r.areacomumTotal).toBe(326973);
+    expect(r.residual.subtotalFromBaseGroup).toBe(326973); // filhos, uma vez
+    expect(r.residual.subtotalCrossGroup).toBe(336600); // pai, informativo, NÃO descontado
+    expect(r.residual.residualRaw).toBe(0);
+    expect(r.residual.negative).toBe(false);
+    // prova da não-dupla-subtração: se o pai TAMBÉM fosse descontado, daria −336.600
+    expect(r.residual.residualRaw).not.toBe(326973 - 326973 - 336600);
+  });
+
+  it('a composição segue enumerada como breakdown aninhado (Chillers/Fancoils/Bombas)', () => {
+    expect(r.climatizacaoParents).toHaveLength(1);
+    expect(r.climatizacaoChildren.length).toBe(3 + 14 + 13); // 30 equipamentos
+    expect(r.byProfile.CHILLER).toBe(184661);
+    expect(r.byProfile.FANCOIL).toBe(96046);
+    expect(r.byProfile.BOMBA_CAG).toBe(46266);
+  });
+});
+
+describe('RFC-0207 parent vs include — CONTÉM × SOMA (totais diferentes)', () => {
+  const groups = groupAll(MOXUARA, DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+
+  it('mesmo device + mesmos dados: parent=336.600, include=663.573', () => {
+    const pParent = profileWithOverrides([{ id: CAG_ENTRADA_ID, mode: 'parent' }]);
+    const pInclude = profileWithOverrides([{ id: CAG_ENTRADA_ID, mode: 'include' }]);
+
+    const rParent = runBreakdown(groupAll(MOXUARA, pParent), pParent);
+    const rInclude = runBreakdown(groupAll(MOXUARA, pInclude), pInclude);
+
+    expect(rParent.climatizacaoTotal).toBe(336600); // CONTÉM
+    expect(rInclude.climatizacaoTotal).toBe(336600 + 326973); // SOMA (feed paralelo)
+    expect(rParent.climatizacaoTotal).not.toBe(rInclude.climatizacaoTotal);
+  });
+
+  it('sem override o grupo/coluna são idênticos nos dois (o modo só muda o breakdown)', () => {
+    // sanity: sem overrides, o card de climatização é a composição pura
+    const r = runBreakdown(groups, DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    expect(r.climatizacaoTotal).toBe(326973);
+    expect(r.climatizacaoParents).toHaveLength(0);
+  });
+});
+
+describe('RFC-0207 parent — caminho sem-override é byte-idêntico', () => {
+  it('selectBreakdownItems sem overrides não emite isParent e devolve o grupo base', () => {
+    const groups = groupAll(MOXUARA, DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    const entries = selectBreakdownItems<Device>(groups, DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    expect(entries.map((e) => e.item)).toEqual(groups.areacomum);
+    expect(entries.every((e) => !('isParent' in e))).toBe(true);
+  });
+
+  it('computeBaseGroupResidual sem baseGroupContribution = total − cross (inalterado)', () => {
+    const r = computeBaseGroupResidual(1000, [
+      { category: 'climatizacao', total: 900, crossGroupTotal: 600 },
+    ]);
+    expect(r.subtotalFromBaseGroup).toBe(300);
+    expect(r.residualRaw).toBe(700);
+  });
+});

--- a/tests/deviceProfileModal.parent.test.ts
+++ b/tests/deviceProfileModal.parent.test.ts
@@ -1,0 +1,118 @@
+/**
+ * RFC-0207 "parent" — terceira opção ("como pai") no picker de Dispositivos
+ * Específicos do modal de perfil.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { openDeviceProfileModal } from '../src/components/premium-modals/device-profile/openDeviceProfileModal';
+import {
+  DEFAULT_DEVICE_CLASSIFICATION_PROFILE,
+  setActiveProfile,
+  type DeviceClassificationProfile,
+} from '../src/utils/devices/deviceClassificationProfile';
+
+const DEVICES = [
+  { id: 'dev-cag-entrada', label: 'CAG-Entrada', deviceProfile: 'ENTRADA', identifier: 'CAG' },
+  { id: 'dev-chiller', label: 'Chiller 1', deviceProfile: 'CHILLER', identifier: 'CHILLER-01' },
+];
+
+function clone<T>(o: T): T {
+  return JSON.parse(JSON.stringify(o));
+}
+
+const CLIMA_IDX = DEFAULT_DEVICE_CLASSIFICATION_PROFILE.domains.energy.categories!.rules.findIndex(
+  (r) => r.name === 'climatizacao',
+);
+
+function open(opts: Partial<Parameters<typeof openDeviceProfileModal>[0]> = {}) {
+  return openDeviceProfileModal({
+    customerId: 'cust-1',
+    canEdit: true,
+    getDevices: () => clone(DEVICES),
+    ...opts,
+  });
+}
+
+function addButtons(): HTMLButtonElement[] {
+  return Array.from(document.querySelectorAll<HTMLButtonElement>('.mdp-ovr-add'));
+}
+function pick(label: string, mode: 'include' | 'exclude' | 'parent') {
+  const row = Array.from(document.querySelectorAll('.mdp-picker-row')).find(
+    (r) => r.querySelector('.mdp-picker-name')?.textContent?.trim() === label,
+  );
+  if (!row) throw new Error(`picker row not found: ${label}`);
+  row.querySelector<HTMLButtonElement>(`.mdp-picker-pick.is-${mode}`)!.click();
+}
+function chipTexts(): string[] {
+  return Array.from(document.querySelectorAll('.mdp-ovr-chip')).map((el) =>
+    (el.textContent || '').replace(/\s+/g, ' ').trim(),
+  );
+}
+
+let handle: { close: () => void } | null = null;
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  setActiveProfile(null);
+});
+afterEach(() => {
+  try {
+    handle?.close();
+  } catch {
+    /* noop */
+  }
+  handle = null;
+  document.body.innerHTML = '';
+  setActiveProfile(null);
+});
+
+describe('openDeviceProfileModal — modo "como pai"', () => {
+  it('o picker oferece as TRÊS opções (incluir / como pai / excluir)', () => {
+    handle = open();
+    addButtons()[0].click();
+    const row = document.querySelector('.mdp-picker-row')!;
+    const modes = Array.from(row.querySelectorAll<HTMLButtonElement>('.mdp-picker-pick')).map(
+      (b) => b.dataset.mode,
+    );
+    expect(modes).toEqual(['include', 'parent', 'exclude']);
+    expect(row.querySelector('.mdp-picker-pick.is-parent')?.textContent?.trim()).toBe('como pai');
+  });
+
+  it('escolher "como pai" cria uma chip com o modo e a classe is-parent', () => {
+    handle = open();
+    addButtons()[0].click();
+    pick('CAG-Entrada', 'parent');
+
+    expect(document.querySelectorAll('.mdp-ovr-chip.is-parent')).toHaveLength(1);
+    expect(chipTexts().some((t) => t.startsWith('como pai') && t.includes('CAG-Entrada'))).toBe(true);
+    // não é confundido com include/exclude
+    expect(document.querySelectorAll('.mdp-ovr-chip.is-include')).toHaveLength(0);
+    expect(document.querySelectorAll('.mdp-ovr-chip.is-exclude')).toHaveLength(0);
+  });
+
+  it('round-trip: o modo "parent" chega ao onSave', async () => {
+    const onSave = vi.fn();
+    handle = open({ onSave, userName: 'tester' });
+    addButtons()[0].click();
+    pick('CAG-Entrada', 'parent');
+
+    document.getElementById('mdp-save')!.click();
+    await vi.waitFor(() => expect(onSave).toHaveBeenCalled());
+    const saved: DeviceClassificationProfile = onSave.mock.calls[0][0];
+    expect(saved.domains.energy.categories!.rules[CLIMA_IDX].deviceOverrides).toEqual([
+      { id: 'dev-cag-entrada', label: 'CAG-Entrada', mode: 'parent' },
+    ]);
+  });
+
+  it('read-only renderiza a chip "como pai" salva (sem remover)', () => {
+    const profile: DeviceClassificationProfile = clone(DEFAULT_DEVICE_CLASSIFICATION_PROFILE);
+    profile.domains.energy.categories!.rules[CLIMA_IDX].deviceOverrides = [
+      { id: 'dev-cag-entrada', label: 'CAG-Entrada', mode: 'parent' },
+    ];
+    handle = open({ canEdit: false, profile });
+    expect(document.querySelectorAll('.mdp-ovr-chip.is-parent')).toHaveLength(1);
+    expect(chipTexts().some((t) => t.includes('como pai') && t.includes('CAG-Entrada'))).toBe(true);
+    expect(document.querySelectorAll('.mdp-ovr-x')).toHaveLength(0);
+    expect(addButtons()).toHaveLength(0);
+  });
+});

--- a/tests/telemetryInfo.climatizacaoParent.test.ts
+++ b/tests/telemetryInfo.climatizacaoParent.test.ts
@@ -1,0 +1,156 @@
+/**
+ * RFC-0207 "parent" — renderização do tooltip de Climatização no TELEMETRY_INFO.
+ *
+ * Extrai a FUNÇÃO REAL `buildClimatizacaoContent` (e suas dependências) do
+ * controller do widget e a executa num sandbox com STATE/window injetados. Assim
+ * o teste trava o HTML de fato produzido em produção — sem espelhar/copiar a
+ * lógica.
+ *
+ * Contrato coberto:
+ *   - COM pai em STATE.consumidores.climatizacao.parents: linha do pai no TOPO da
+ *     Composição, subcategorias ANINHADAS abaixo, header mostra o total do pai.
+ *   - SEM pai (campo vazio OU ausente): saída idêntica à de antes (composição
+ *     plana; nada de linha de pai nem wrapper aninhado).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CONTROLLER = resolve(
+  __dirname,
+  '../src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/TELEMETRY_INFO/controller.js',
+);
+
+/** Extrai o texto de uma função top-level `function NAME(...) { ... }`. */
+function extractFn(src: string, name: string): string {
+  const lines = src.replace(/\r/g, '').split('\n');
+  const start = lines.findIndex((l) => l.startsWith(`function ${name}(`));
+  if (start < 0) throw new Error(`função não encontrada: ${name}`);
+  let end = -1;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (lines[i] === '}') {
+      end = i;
+      break;
+    }
+  }
+  if (end < 0) throw new Error(`fim da função não encontrado: ${name}`);
+  return lines.slice(start, end + 1).join('\n');
+}
+
+/**
+ * Monta um `buildClimatizacaoContent` executável a partir do source real,
+ * com STATE/window injetados. formatEnergy é resolvido via window.MyIOUtils.
+ */
+function makeBuilder(state: Record<string, unknown>): () => string {
+  const src = readFileSync(CONTROLLER, 'utf8');
+  const body =
+    extractFn(src, 'formatEnergy') +
+    '\n' +
+    extractFn(src, 'buildDeviceExpandList') +
+    '\n' +
+    extractFn(src, 'buildExcludedFromCAGNotice') +
+    '\n' +
+    extractFn(src, 'buildClimatizacaoContent') +
+    '\nreturn buildClimatizacaoContent;';
+  const win = {
+    MyIOUtils: {
+      // total previsível: "<n> MWh" com separador de milhar por ponto
+      formatEnergy: (v: number) =>
+        `${Number(v).toLocaleString('en-US', { maximumFractionDigits: 0 })} MWh`,
+    },
+  };
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+  const factory = new Function('STATE', 'window', 'console', body) as (
+    s: unknown,
+    w: unknown,
+    c: unknown,
+  ) => () => string;
+  return factory(state, win, console);
+}
+
+function subcat(name: string, count: number, total: number) {
+  return { summary: { count, total }, details: { name, devices: [] } };
+}
+
+function baseState(parents: Array<{ id: string; label: string; total: number }> | undefined) {
+  const climatizacao: Record<string, unknown> = {
+    devices: new Array(30).fill(0).map((_, i) => ({ id: `d${i}`, label: `d${i}`, value: 1 })),
+    total: parents && parents.length ? 336600 : 326973,
+    perc: 30,
+    subcategories: {
+      chillers: subcat('Chillers', 3, 184661),
+      fancoils: subcat('Fancoils', 14, 96046),
+      bombasClimatizacao: subcat('Bombas', 13, 46266),
+    },
+  };
+  if (parents !== undefined) climatizacao.parents = parents;
+  return {
+    consumidores: { climatizacao },
+    tooltipData: { excludedFromCAG: [] },
+  };
+}
+
+let htmlWithParent: string;
+let htmlNoParent: string;
+let htmlFieldAbsent: string;
+
+beforeEach(() => {
+  htmlWithParent = makeBuilder(
+    baseState([{ id: '82f0', label: 'CAG-Entrada', total: 336600 }]),
+  )();
+  htmlNoParent = makeBuilder(baseState([]))();
+  htmlFieldAbsent = makeBuilder(baseState(undefined))();
+});
+
+describe('buildClimatizacaoContent — modo parent', () => {
+  it('COM pai: renderiza a linha do pai com label e valor', () => {
+    expect(htmlWithParent).toContain('CAG-Entrada');
+    expect(htmlWithParent).toContain('Medidor pai da composição');
+    expect(htmlWithParent).toContain('336,600 MWh');
+    expect(htmlWithParent).toContain('myio-info-tooltip__category--parent');
+  });
+
+  it('COM pai: a composição fica ANINHADA (wrapper indentado) abaixo do pai', () => {
+    expect(htmlWithParent).toContain('myio-info-tooltip__nested');
+    const posPai = htmlWithParent.indexOf('CAG-Entrada');
+    const posNested = htmlWithParent.indexOf('myio-info-tooltip__nested');
+    const posChiller = htmlWithParent.indexOf('Chillers');
+    // pai ANTES do wrapper aninhado, e o wrapper ANTES das subcategorias
+    expect(posPai).toBeGreaterThan(-1);
+    expect(posNested).toBeGreaterThan(posPai);
+    expect(posChiller).toBeGreaterThan(posNested);
+  });
+
+  it('COM pai: as subcategorias continuam presentes (breakdown enumerado)', () => {
+    expect(htmlWithParent).toContain('Chillers');
+    expect(htmlWithParent).toContain('Fancoils');
+    expect(htmlWithParent).toContain('Bombas');
+    expect(htmlWithParent).toContain('184,661 MWh');
+    expect(htmlWithParent).toContain('96,046 MWh');
+    expect(htmlWithParent).toContain('46,266 MWh');
+  });
+
+  it('COM pai: o header "Consumo Total" mostra o total do pai (336.600)', () => {
+    const header = htmlWithParent.slice(0, htmlWithParent.indexOf('Composição'));
+    expect(header).toContain('336,600 MWh');
+  });
+
+  it('SEM pai (lista vazia): composição PLANA, sem linha de pai nem wrapper', () => {
+    expect(htmlNoParent).not.toContain('myio-info-tooltip__nested');
+    expect(htmlNoParent).not.toContain('Medidor pai da composição');
+    expect(htmlNoParent).not.toContain('myio-info-tooltip__category--parent');
+    expect(htmlNoParent).toContain('Chillers');
+  });
+
+  it('campo `parents` AUSENTE ⇒ byte-idêntico à lista vazia (retrocompat)', () => {
+    expect(htmlFieldAbsent).toBe(htmlNoParent);
+  });
+
+  it('a nota explicativa muda conforme haja pai ou não', () => {
+    expect(htmlWithParent).toContain('medidor pai');
+    expect(htmlNoParent).toContain('soma do consumo de todos os equipamentos');
+  });
+});


### PR DESCRIPTION
**PR empilhado sobre o #110** (base = `feat/rfc-0207-dispositivos-especificos`). Mergear o #110 primeiro; o diff aqui é só o delta do modo "pai".

## O caso (Moxuara, medido ao vivo)

`CAG-Entrada` (`deviceProfile: ENTRADA`, `identifier: CAG`, group `entrada`) mede o feed inteiro do CAG = **336.600**. A composição interna de Climatização (submedidores em `areacomum`) — Chillers 3 (184.661) + Fancoils 14 (96.046) + Bombas 13 (46.266) = **326.973** — está **abaixo** dele (containment provado: pai ≈ filhos, ~3% de perda de linha).

O operador quer ver o CAG-Entrada como **pai** no card de Climatização, com a composição existente **aninhada** abaixo.

## O modo `parent` (distinto de `include`)

Terceiro valor em `deviceOverrides[].mode`: `'include' | 'exclude' | 'parent'`.

- **`include`** (Ilha) — feed **paralelo**: SOMA o device ao total.
- **`parent`** (Moxuara) — o device **CONTÉM** a composição: seu valor É o total; os filhos aparecem aninhados, **sem** somar por cima.

Mesmo gesto na UI, matemática oposta — só o operador conhece a topologia, então é escolha explícita, nunca inferida. Lib antiga / campo ausente degrada `parent`→`include` (documentado).

## Números do Moxuara (assertados)

| | Valor |
|---|---|
| Card Climatização | **336.600** (não 663.573, não 326.973) |
| Entrada | **1.120.350** (inalterada — pai continua em `entrada`) |
| Residual | filhos descontados 1×; **pai (cross-group) não descontado** |

Fórmula do total (`MAIN_VIEW` buildSummary): pais vão para `climatizacaoParentItems`; `climatizacaoTotal = hasParent ? Σ(pais) : Σ(filhos)`.

Guard da dupla-subtração (`computeBaseGroupResidual` + novo `baseGroupContribution`): o residual desconta **só** a parcela dos filhos (`areacomumTotal − 326.973`), nunca o pai. Também corrigida a reconstrução da Área Comum no caminho `excludeGroupsTotals`.

## Tooltip (TELEMETRY_INFO)

`buildClimatizacaoContent` passa a ler `STATE.consumidores.climatizacao.parents`:

```
📋 Composição
  🔌 CAG-Entrada        336.600 MWh   ← "Medidor pai da composição"
     🧊 Chillers   3     184.661
     💨 Fancoils  14      96.046
     💧 Bombas    13      46.266
```

Sem parent ⇒ composição plana, byte-idêntica.

## Modal

Picker ganha 3 botões: **incluir / como pai / excluir**; a chip mostra o modo; read-only respeitado; round-trip preserva `mode:'parent'`.

## Verificação (reconferida pelo revisor)

- **157/157** em 15 arquivos (`deviceClassificationProfile*` + `deviceProfileModal*` + `telemetryInfo.climatizacaoParent` — este extrai e roda a função **real** do controller). +26 nesta rodada.
- `npm run build` OK, `node --check` OK nos 2 controllers. 9 falhas pré-existentes, idênticas na branch base (confirmado por stash).

## Limitação documentada (RFC §DE-G)

Vários pais na mesma categoria são tratados como cobrindo **coletivamente** toda a composição (sem atribuição filho-a-pai). O caso 1 pai cobrindo toda a climatização (Moxuara) é exato; multi-pai é simplificação declarada, não chute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
