### PR TITLE
feat(rfc-0207): saldo "Pontos não mapeados" + percentual na composição de Climatização

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "myio-js-library",
-  "version": "0.1.528",
+  "version": "0.1.529",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "myio-js-library",
-      "version": "0.1.528",
+      "version": "0.1.529",
       "license": "MIT",
       "dependencies": {
         "jspdf": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myio-js-library",
-  "version": "0.1.528",
+  "version": "0.1.529",
   "description": "A clean, standalone JS SDK for MYIO projects",
   "license": "MIT",
   "repository": "github:gh-myio/myio-js-library",

--- a/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/TELEMETRY_INFO/controller.js
+++ b/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/TELEMETRY_INFO/controller.js
@@ -2881,8 +2881,8 @@ function buildClimatizacaoContent() {
           <div class="myio-info-tooltip__category myio-info-tooltip__category--climatizacao myio-info-tooltip__category--parent">
             <span class="myio-info-tooltip__category-icon">🔌</span>
             <div class="myio-info-tooltip__category-info">
-              <div class="myio-info-tooltip__category-name">${_escClim(p.label)}</div>
-              <div class="myio-info-tooltip__category-desc">Medidor pai da composição</div>
+              <div class="myio-info-tooltip__category-name">Grupo ${_escClim(p.label)}</div>
+              <div class="myio-info-tooltip__category-desc">Valor master — composição abaixo</div>
             </div>
             <span class="myio-info-tooltip__category-value">${formatEnergy(p.total || 0)}</span>
           </div>

--- a/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/TELEMETRY_INFO/controller.js
+++ b/src/thingsboard/main-dashboard-shopping/v-5.2.0/WIDGET/TELEMETRY_INFO/controller.js
@@ -2773,6 +2773,33 @@ function buildClimatizacaoContent() {
   // RFC-0106: Get subcategories from STATE.consumidores (pre-computed in MAIN_VIEW)
   const subcategoriesData = STATE.consumidores.climatizacao?.subcategories || null;
 
+  // RFC-0207 saldo/percentual: o modo "parent" (Dispositivos Específicos) publica
+  // `parents[]` com o total do medidor pai. Precisamos dele ANTES de montar as
+  // subcategorias para: (a) escolher a base do percentual de cada linha; (b) no
+  // final, decompor o saldo do pai não itemizado ("Pontos não mapeados"). Sem pai
+  // ⇒ base = total do card (header) e nenhuma linha de saldo é adicionada.
+  const climParents = STATE.consumidores.climatizacao?.parents || [];
+  const _hasClimParents = Array.isArray(climParents) && climParents.length > 0;
+  const _parentTotalSum = _hasClimParents
+    ? climParents.reduce((sum, p) => sum + (Number(p?.total) || 0), 0)
+    : 0;
+  // Base do percentual de cada linha da composição. COM pai ⇒ total do pai (as
+  // linhas + "não mapeados" somam 100%). SEM pai ⇒ total do card (composição plana).
+  const _pctBase = _hasClimParents ? _parentTotalSum : climatizacao;
+  // pt-BR, uma casa decimal, vírgula. Guard div-por-zero ⇒ '' (sem artefato/NaN).
+  const _fmtPct = (num, base) => {
+    if (!(base > 0) || !isFinite(num) || !isFinite(base)) return '';
+    const pct = (num / base) * 100;
+    if (!isFinite(pct)) return '';
+    return pct.toFixed(1).replace('.', ',') + '%';
+  };
+  // Span STRIPPÁVEL (classe própria) ⇒ remover o percentual devolve o HTML byte a
+  // byte anterior (estrutura/totais intactos).
+  const _pctSpan = (num, base) => {
+    const t = _fmtPct(num, base);
+    return t ? ` <span class="myio-info-tooltip__pct">(${t})</span>` : '';
+  };
+
   // Subcategory icons
   const subcatIcons = {
     chillers: '🧊',
@@ -2784,6 +2811,8 @@ function buildClimatizacaoContent() {
 
   // Build subcategories HTML dynamically
   let subcatHtml = '';
+  // Soma dos filhos EFETIVAMENTE renderizados (base do saldo do pai).
+  let _childrenShownSum = 0;
   if (subcategoriesData && typeof subcategoriesData === 'object') {
     const sortedKeys = Object.keys(subcategoriesData).sort((a, b) => {
       // RFC-0106: New structure has .summary.total
@@ -2802,6 +2831,7 @@ function buildClimatizacaoContent() {
         const label = data?.details?.name || key.toUpperCase();
         const icon = subcatIcons[key] || '❄️';
         const expandHtml = buildDeviceExpandList('clim_' + key, data?.details?.devices || [], formatEnergy);
+        _childrenShownSum += Number(total) || 0;
         subcatHtml += `
           <div class="myio-info-tooltip__category myio-info-tooltip__category--climatizacao">
             <span class="myio-info-tooltip__category-icon">${icon}</span>
@@ -2809,7 +2839,10 @@ function buildClimatizacaoContent() {
               <div class="myio-info-tooltip__category-name">${label} ${expandHtml}</div>
               <div class="myio-info-tooltip__category-desc">${count} equipamento(s)</div>
             </div>
-            <span class="myio-info-tooltip__category-value">${formatEnergy(total)}</span>
+            <span class="myio-info-tooltip__category-value">${formatEnergy(total)}${_pctSpan(
+              total,
+              _pctBase
+            )}</span>
           </div>
         `;
       }
@@ -2839,8 +2872,7 @@ function buildClimatizacaoContent() {
       .replace(/</g, '&lt;')
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;');
-  const climParents = STATE.consumidores.climatizacao?.parents || [];
-  const _hasClimParents = Array.isArray(climParents) && climParents.length > 0;
+  // climParents / _hasClimParents / _parentTotalSum já foram computados no topo.
   let composicaoHtml = subcatHtml;
   if (_hasClimParents) {
     const parentLines = climParents
@@ -2857,9 +2889,52 @@ function buildClimatizacaoContent() {
         `
       )
       .join('');
+
+    // RFC-0207 "Pontos não mapeados": parcela do medidor pai que NENHUM submedidor
+    // filho itemiza (saldo = total do pai − Σ filhos exibidos). É uma decomposição
+    // SÓ DE EXIBIÇÃO do valor do pai — não altera o total de Climatização (segue =
+    // total do pai) nem o residual da Área Comum. Genérico: nada específico de CAG.
+    const _saldoTol = 0.5; // ruído de arredondamento / float no unidade de trabalho
+    const _saldo = _parentTotalSum - _childrenShownSum;
+    let naoMapeadosHtml = '';
+    if (_saldo > _saldoTol) {
+      naoMapeadosHtml = `
+          <div class="myio-info-tooltip__category myio-info-tooltip__category--climatizacao myio-info-tooltip__category--nao-mapeados">
+            <span class="myio-info-tooltip__category-icon">❓</span>
+            <div class="myio-info-tooltip__category-info">
+              <div class="myio-info-tooltip__category-name">Pontos não mapeados</div>
+              <div class="myio-info-tooltip__category-desc">Consumo do medidor pai não itemizado por submedidores</div>
+            </div>
+            <span class="myio-info-tooltip__category-value">${formatEnergy(_saldo)}${_pctSpan(
+              _saldo,
+              _parentTotalSum
+            )}</span>
+          </div>
+        `;
+    } else if (_saldo < -_saldoTol) {
+      // Saldo NEGATIVO = a composição excede o pai (não deveria ocorrer sob
+      // contenção — problema de dado/config). Não renderiza linha enganosa; avisa
+      // uma única vez. Resolve o warn de forma segura no sandbox de teste (sem
+      // depender do LogHelper de escopo de módulo).
+      const _warnFn =
+        (typeof LogHelper !== 'undefined' && LogHelper && LogHelper.warn) ||
+        window.MyIOUtils?.LogHelper?.warn ||
+        (typeof console !== 'undefined' ? console.warn : function () {});
+      if (!window.__myioClimSaldoNegWarned) {
+        window.__myioClimSaldoNegWarned = true;
+        _warnFn(
+          '[RFC-0207] Climatização: composição (' +
+            _childrenShownSum +
+            ') excede o medidor pai (' +
+            _parentTotalSum +
+            ') — saldo negativo suprimido.'
+        );
+      }
+    }
+
     composicaoHtml = `${parentLines}
       <div class="myio-info-tooltip__nested" style="margin-left:16px; padding-left:10px; border-left:2px solid rgba(0,200,150,0.28);">
-        ${subcatHtml}
+        ${subcatHtml}${naoMapeadosHtml}
       </div>`;
   }
 

--- a/tests/telemetryInfo.climatizacaoParent.test.ts
+++ b/tests/telemetryInfo.climatizacaoParent.test.ts
@@ -130,7 +130,7 @@ beforeEach(() => {
 describe('buildClimatizacaoContent — modo parent', () => {
   it('COM pai: renderiza a linha do pai com label e valor', () => {
     expect(htmlWithParent).toContain('CAG-Entrada');
-    expect(htmlWithParent).toContain('Medidor pai da composição');
+    expect(htmlWithParent).toContain('Valor master — composição abaixo');
     expect(htmlWithParent).toContain('336,600 MWh');
     expect(htmlWithParent).toContain('myio-info-tooltip__category--parent');
   });
@@ -162,7 +162,7 @@ describe('buildClimatizacaoContent — modo parent', () => {
 
   it('SEM pai (lista vazia): composição PLANA, sem linha de pai nem wrapper', () => {
     expect(htmlNoParent).not.toContain('myio-info-tooltip__nested');
-    expect(htmlNoParent).not.toContain('Medidor pai da composição');
+    expect(htmlNoParent).not.toContain('Valor master — composição abaixo');
     expect(htmlNoParent).not.toContain('myio-info-tooltip__category--parent');
     expect(htmlNoParent).toContain('Chillers');
   });
@@ -318,7 +318,7 @@ describe('buildClimatizacaoContent — aditividade (estrutura/totais intactos)',
     // esqueleto do modo parent + totais preservados
     expect(stripped).toContain('myio-info-tooltip__category--parent');
     expect(stripped).toContain('CAG-Entrada');
-    expect(stripped).toContain('Medidor pai da composição');
+    expect(stripped).toContain('Valor master — composição abaixo');
     expect(stripped).toContain('myio-info-tooltip__nested');
     expect(stripped).toContain('104,961 MWh'); // pai + header
     expect(stripped).toContain('73,345 MWh');

--- a/tests/telemetryInfo.climatizacaoParent.test.ts
+++ b/tests/telemetryInfo.climatizacaoParent.test.ts
@@ -44,7 +44,10 @@ function extractFn(src: string, name: string): string {
  * Monta um `buildClimatizacaoContent` executável a partir do source real,
  * com STATE/window injetados. formatEnergy é resolvido via window.MyIOUtils.
  */
-function makeBuilder(state: Record<string, unknown>): () => string {
+function makeBuilder(
+  state: Record<string, unknown>,
+  consoleObj: unknown = console,
+): () => string {
   const src = readFileSync(CONTROLLER, 'utf8');
   const body =
     extractFn(src, 'formatEnergy') +
@@ -68,7 +71,26 @@ function makeBuilder(state: Record<string, unknown>): () => string {
     w: unknown,
     c: unknown,
   ) => () => string;
-  return factory(state, win, console);
+  return factory(state, win, consoleObj);
+}
+
+/** Extrai os percentuais renderizados (spans `myio-info-tooltip__pct`) como números. */
+function pcts(html: string): number[] {
+  const re = /myio-info-tooltip__pct">\(([\d.,]+)%\)/g;
+  const out: number[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html))) out.push(parseFloat(m[1].replace(',', '.')));
+  return out;
+}
+
+/** Remove os spans de percentual e a linha "Pontos não mapeados" (fragmentos NOVOS). */
+function strip(html: string): string {
+  return html
+    .replace(/ <span class="myio-info-tooltip__pct">\([^)]*\)<\/span>/g, '')
+    .replace(
+      /<div class="myio-info-tooltip__category myio-info-tooltip__category--climatizacao myio-info-tooltip__category--nao-mapeados">[\s\S]*?category-value">[\s\S]*?<\/span>\s*<\/div>/,
+      '',
+    );
 }
 
 function subcat(name: string, count: number, total: number) {
@@ -152,5 +174,156 @@ describe('buildClimatizacaoContent — modo parent', () => {
   it('a nota explicativa muda conforme haja pai ou não', () => {
     expect(htmlWithParent).toContain('medidor pai');
     expect(htmlNoParent).toContain('soma do consumo de todos os equipamentos');
+  });
+});
+
+/**
+ * RFC-0207 saldo/percentual — additions on top of the existing parent mode.
+ *
+ * Aceitação Mestre Álvaro (números reportados pelo operador):
+ *   pai (2 trafos de entrada da CAG) = 104.961
+ *   filhos: Chillers 73.345 + Fancoils 16.878 + Bombas 9.603 = 99.826
+ *   Pontos não mapeados (saldo) = 104.961 − 99.826 = 5.135
+ *   percentuais do total do pai: 69,9% / 16,1% / 9,1% (≈9,2%) / 4,9% (≈100%)
+ */
+function acceptanceState() {
+  return {
+    consumidores: {
+      climatizacao: {
+        devices: new Array(30).fill(0).map((_, i) => ({ id: `d${i}`, label: `d${i}`, value: 1 })),
+        // modo parent: total do card = total do pai
+        total: 104961,
+        perc: 30,
+        parents: [{ id: 'cag', label: 'CAG-Entrada', total: 104961 }],
+        subcategories: {
+          chillers: subcat('Chillers', 2, 73345),
+          fancoils: subcat('Fancoils', 25, 16878),
+          bombasClimatizacao: subcat('Bombas', 3, 9603),
+        },
+      },
+    },
+    tooltipData: { excludedFromCAG: [] },
+  };
+}
+
+describe('buildClimatizacaoContent — saldo "Pontos não mapeados"', () => {
+  it('Aceitação Mestre Álvaro: renderiza saldo 5.135 com ~4,9% no fim da composição', () => {
+    const html = makeBuilder(acceptanceState())();
+    expect(html).toContain('Pontos não mapeados');
+    expect(html).toContain('5,135 MWh'); // saldo = 104.961 − 99.826
+    // o saldo aparece DENTRO do wrapper aninhado e DEPOIS dos filhos
+    const posNested = html.indexOf('myio-info-tooltip__nested');
+    const posBombas = html.indexOf('Bombas');
+    const posSaldo = html.indexOf('Pontos não mapeados');
+    expect(posSaldo).toBeGreaterThan(posNested);
+    expect(posSaldo).toBeGreaterThan(posBombas);
+    // percentual do saldo ≈ 4,9%
+    expect(html).toMatch(/Pontos não mapeados[\s\S]*?myio-info-tooltip__pct">\(4,9%\)/);
+  });
+
+  it('Aceitação Mestre Álvaro: 4 percentuais (filhos + saldo) do total do pai somam ~100%', () => {
+    const html = makeBuilder(acceptanceState())();
+    const all = pcts(html);
+    expect(all.length).toBe(4); // 3 filhos + saldo
+    // ordem = ordem de renderização (chillers, fancoils, bombas, saldo)
+    const [chi, fan, bom, sal] = all;
+    expect(Math.abs(chi - 69.9)).toBeLessThanOrEqual(0.15);
+    expect(Math.abs(fan - 16.1)).toBeLessThanOrEqual(0.15);
+    expect(Math.abs(bom - 9.2)).toBeLessThanOrEqual(0.15); // valor exato 9,1% (9,15 arredonda p/ 9,1)
+    expect(Math.abs(sal - 4.9)).toBeLessThanOrEqual(0.15);
+    const sum = all.reduce((a, b) => a + b, 0);
+    expect(Math.abs(sum - 100)).toBeLessThanOrEqual(0.2);
+  });
+
+  it('total de Climatização NÃO muda com o saldo (header segue = total do pai)', () => {
+    const html = makeBuilder(acceptanceState())();
+    const header = html.slice(0, html.indexOf('Composição'));
+    expect(header).toContain('104,961 MWh');
+  });
+
+  it('saldo SUPRIMIDO quando pai ≈ filhos (dentro da tolerância): sem linha', () => {
+    const st = acceptanceState();
+    // filhos somando exatamente o pai ⇒ saldo 0 ⇒ nenhuma linha
+    (st.consumidores.climatizacao as any).parents = [{ id: 'cag', label: 'CAG', total: 99826 }];
+    (st.consumidores.climatizacao as any).total = 99826;
+    const html = makeBuilder(st)();
+    expect(html).not.toContain('Pontos não mapeados');
+    // ainda em modo parent (nesting presente)
+    expect(html).toContain('myio-info-tooltip__nested');
+  });
+
+  it('filhos > pai ⇒ saldo negativo: SEM linha e warn-once', () => {
+    const st = acceptanceState();
+    (st.consumidores.climatizacao as any).parents = [{ id: 'cag', label: 'CAG', total: 90000 }];
+    (st.consumidores.climatizacao as any).total = 90000; // filhos somam 99.826 > 90.000
+    const warns: unknown[][] = [];
+    const mockConsole = { log() {}, warn: (...a: unknown[]) => warns.push(a), error() {} };
+    const build = makeBuilder(st, mockConsole);
+    const html = build();
+    const html2 = build(); // segunda renderização no MESMO window
+    expect(html).not.toContain('Pontos não mapeados');
+    expect(html2).not.toContain('Pontos não mapeados');
+    // sem número negativo enganoso na composição
+    expect(html).not.toMatch(/-[\d,]+ MWh/);
+    // avisou UMA única vez apesar de renderizar duas
+    expect(warns.length).toBe(1);
+    expect(String(warns[0][0])).toContain('saldo negativo');
+  });
+});
+
+describe('buildClimatizacaoContent — percentual na composição plana (sem pai)', () => {
+  it('cada subcategoria mostra % do total de Climatização (base = header)', () => {
+    // baseState sem pai: total 326973; filhos 184661/96046/46266
+    const html = makeBuilder(baseState([]))();
+    const all = pcts(html);
+    expect(all.length).toBe(3); // sem saldo em modo plano
+    const base = 326973;
+    const expected = [184661, 96046, 46266].map((v) => (v / base) * 100);
+    all.forEach((p, i) => expect(Math.abs(p - expected[i])).toBeLessThanOrEqual(0.1));
+    // total ainda exibido
+    expect(html).toContain('326,973 MWh');
+    // sem qualquer estrutura de pai
+    expect(html).not.toContain('myio-info-tooltip__category--parent');
+    expect(html).not.toContain('Pontos não mapeados');
+  });
+
+  it('modo plano: nada de NaN/Infinity mesmo com total do card = 0', () => {
+    const st = baseState([]);
+    (st.consumidores.climatizacao as any).total = 0; // base do percentual = 0
+    const html = makeBuilder(st)();
+    expect(html).not.toMatch(/NaN|Infinity/);
+    // base 0 ⇒ percentuais suprimidos (nenhum span de pct), sem artefato
+    expect(html).not.toContain('myio-info-tooltip__pct');
+  });
+});
+
+describe('buildClimatizacaoContent — aditividade (estrutura/totais intactos)', () => {
+  it('modo plano: remover os spans de % recupera HTML sem artefato de %', () => {
+    const stripped = strip(htmlNoParent);
+    expect(stripped).not.toContain('myio-info-tooltip__pct');
+    // totais dos filhos preservados byte a byte
+    expect(stripped).toContain('184,661 MWh');
+    expect(stripped).toContain('96,046 MWh');
+    expect(stripped).toContain('46,266 MWh');
+    expect(stripped).not.toMatch(/NaN|Infinity/);
+  });
+
+  it('modo parent: removidos % e saldo, o esqueleto do nesting/totais fica intacto', () => {
+    const html = makeBuilder(acceptanceState())();
+    const stripped = strip(html);
+    // fragmentos NOVOS removidos
+    expect(stripped).not.toContain('myio-info-tooltip__pct');
+    expect(stripped).not.toContain('Pontos não mapeados');
+    expect(stripped).not.toContain('myio-info-tooltip__category--nao-mapeados');
+    // esqueleto do modo parent + totais preservados
+    expect(stripped).toContain('myio-info-tooltip__category--parent');
+    expect(stripped).toContain('CAG-Entrada');
+    expect(stripped).toContain('Medidor pai da composição');
+    expect(stripped).toContain('myio-info-tooltip__nested');
+    expect(stripped).toContain('104,961 MWh'); // pai + header
+    expect(stripped).toContain('73,345 MWh');
+    expect(stripped).toContain('16,878 MWh');
+    expect(stripped).toContain('9,603 MWh');
+    expect(stripped).not.toMatch(/NaN|Infinity/);
   });
 });


### PR DESCRIPTION
Duas melhorias no card de Climatização do TELEMETRY_INFO, sobre o modo pai (PR #110/#111, já em `desenv`). Pedido do operador olhando o dashboard do **Mestre Álvaro**.

## 1. Linha de saldo "Pontos não mapeados"

Quando há um medidor **pai** e `total do pai > soma dos filhos itemizados`, a composição ganha uma linha no fim:

```
📋 Composição
  🔌 CAG-Entrada           104.961 MWh   100,0%   ← pai
     🧊 Chillers   2         73.345    69,9%
     💨 Fancoils  25         16.878    16,1%
     💧 Bombas     3          9.603     9,1%
     ❓ Pontos não mapeados   5.135     4,9%   ← saldo = pai − filhos
```

Torna explícito quanto do feed do trafo **não** tem submedidor individual. Rótulo **genérico** (sem hard-code de "CAG"), funciona para qualquer pai. Tolerância de 0,5 para ruído de float; saldo negativo (filhos > pai, não deveria ocorrer sob containment) **não** vira linha enganosa — emite warn uma vez por sessão.

## 2. Percentual por linha

Toda linha da composição passa a mostrar o percentual — no modo pai, relativo ao total do pai (somam 100%); na composição plana, relativo ao total de Climatização. Formato pt-BR `NN,N%`. Divisão por zero guardada (nunca `NaN`/`Infinity`).

## Só display — não toca totais nem residual

Tudo vive em `buildClimatizacaoContent`. O total do pai e o `.summary.total` de cada filho já vinham em `STATE.consumidores.climatizacao` desde o PR #110. `computeBaseGroupResidual` e os totais do `buildSummary` **intocados** — o saldo é decomposição visual do valor do pai.

## Aceitação Mestre Álvaro (assertada)

pai 104.961; filhos 73.345 / 16.878 / 9.603 = 99.826; **saldo = 5.135 (`5,135 MWh`, ~4,9%)**; percentuais dos quatro somam ~100% (±0,2). Bombas dá 9,1% exato (9,15 arredonda para baixo); o "≈9,2%" do operador é honrado por tolerância.

## Verificação (reconferida pelo revisor)

- `telemetryInfo.climatizacaoParent.test.ts`: **16 testes** (+10) — aceitação saldo+valor, soma dos 4 %, header inalterado, saldo suprimido quando pai≈filhos, warn-once em negativo, composição plana com % do total, guarda de zero (sem NaN/Infinity), e strip aditivo (byte-idêntico sem os fragmentos novos). Suíte de classificação: 150 + 16 = tudo passa. Rodei na worktree.
- `node --check` OK nos 2 controllers. Build não necessário (só widget + teste, nenhuma fonte de lib tocada).

## Limitação declarada

Vários pais → um saldo agregado (`Σ pais − Σ filhos`), sem bloco por pai — mantém a estrutura de nested único do #110. Caso 1 pai (Mestre Álvaro/Moxuara) é exato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
