### PR TITLE
feat(rfc-0228): Track A completo — Metas Financeiras frontend HO (A1·F0·A4·A2a·A3·A5a·A6·A7·A2b)

### DIFF
--- a/src/components/cards/customer-goals/v1.0.0/CustomerGoalsCard.ts
+++ b/src/components/cards/customer-goals/v1.0.0/CustomerGoalsCard.ts
@@ -18,6 +18,10 @@ import {
   CustomerGoalsTotals,
 } from './types';
 import { injectCustomerGoalsCardStyles } from './styles';
+// RFC-0228 A7 — per-consumer realized-vs-goal R$ variance readout (additive + gated).
+// `renderMoneyVariance` returns null when the money gate is off → card byte-identical.
+// Naming bridge: reads `monetaryProjection`/`currencyBudget`, never `series.budget`.
+import { renderMoneyVariance } from '../../../financial-goals/moneyVariance';
 
 // Esquema de cores padrão das Metas (fonte única — igual em card/gráfico/legenda):
 // A-1 cinza, Realizado AZUL fixo, Orçado LARANJA, Meta ROXO.
@@ -89,11 +93,12 @@ export class CustomerGoalsCard implements CustomerGoalsCardInstance {
   // ── Public API ────────────────────────────────────────────────────────────
 
   public update(
-    partial: Partial<Pick<CustomerGoalsCardParams, 'series' | 'totals' | 'title'>>
+    partial: Partial<Pick<CustomerGoalsCardParams, 'series' | 'totals' | 'title' | 'moneyVariance'>>
   ): void {
     if (partial.title !== undefined) this.params.title = partial.title;
     if (partial.series !== undefined) this.params.series = { ...partial.series };
     if (partial.totals !== undefined) this.params.totals = partial.totals;
+    if (partial.moneyVariance !== undefined) this.params.moneyVariance = partial.moneyVariance;
     this.renderInner();
     this.renderChart();
   }
@@ -409,6 +414,33 @@ export class CustomerGoalsCard implements CustomerGoalsCardInstance {
           this.toggleExpand();
         });
     }
+
+    this.renderMoneyVariance();
+  }
+
+  /**
+   * RFC-0228 A7 — append the R$ variance readout below the totals/deltas strip when a
+   * money overlay/amount is present. `renderMoneyVariance` returns `null` when the gate
+   * is off (no `params.moneyVariance`), so the card stays byte-identical to before.
+   * Reads only money names (`monetaryProjection`/`currencyBudget`) — never the quantity
+   * `series.budget` prop (naming bridge). Honors DEC-6 withholding inside the renderer.
+   */
+  private renderMoneyVariance(): void {
+    const mv = this.params.moneyVariance;
+    if (!mv) return; // gate off → nothing appended (byte-identical)
+    const el = renderMoneyVariance({
+      monetaryProjection: mv.monetaryProjection,
+      currencyBudget: mv.currencyBudget,
+      overlay: mv.overlay,
+      withheld: mv.withheld,
+      label: mv.label != null ? mv.label : 'Variação vs meta (R$)',
+      document,
+    });
+    if (!el) return;
+    el.classList.add('myio-cgc__money-variance');
+    el.style.padding = '6px 8px 8px';
+    el.style.borderTop = '1px solid var(--cgc-border)';
+    this.el.appendChild(el);
   }
 
   private destroyChart(): void {

--- a/src/components/cards/customer-goals/v1.0.0/index.ts
+++ b/src/components/cards/customer-goals/v1.0.0/index.ts
@@ -10,4 +10,5 @@ export type {
   CustomerGoalsSeries,
   CustomerGoalsTotals,
   CustomerGoalsThemeMode,
+  CustomerGoalsMoneyVariance,
 } from './types';

--- a/src/components/cards/customer-goals/v1.0.0/types.ts
+++ b/src/components/cards/customer-goals/v1.0.0/types.ts
@@ -101,11 +101,43 @@ export interface CustomerGoalsTotals {
   orcado?: number | null;
 }
 
+/**
+ * RFC-0228 A7 — optional R$ realized-vs-goal variance readout for the card (additive
+ * + gated). Uses the money **naming bridge**: `monetaryProjection` = realized R$,
+ * `currencyBudget` = the R$ goal/budget. It NEVER touches the card's `series.budget`
+ * (a QUANTITY goal in kWh/m³) — money and quantity stay in separate props. Absent →
+ * the card renders exactly as before (byte-identical to the quantity-only view).
+ * Withheld per DEC-6 ("Variação indisponível") when coverage is incomplete or the
+ * verdict is indeterminate — never a fabricated number, never a green/red judgment.
+ */
+export interface CustomerGoalsMoneyVariance {
+  /** Realizado em R$ (RFC-0054 monetary projection). Decimal STRING (e.g. "223000.00"). */
+  monetaryProjection?: string | null;
+  /** Meta/orçamento em R$ (RFC-0054 CURRENCY target). Decimal STRING. */
+  currencyBudget?: string | null;
+  /**
+   * Normalized money overlay (F0) — the DEC-6 coverage gate. `unavailable` /
+   * `coverageComplete:false` → withheld chip. Optional; when omitted the caller
+   * vouches the amounts are confidently priced.
+   */
+  overlay?: import('../../../financial-goals/moneyTypes').MoneyOverlay | null;
+  /** Explicit withhold override (a null verdict already resolved by the host). */
+  withheld?: boolean;
+  /** Leading label for the readout (default "Variação vs meta (R$)"). */
+  label?: string;
+}
+
 export interface CustomerGoalsCardParams {
   container: HTMLElement;
   /** Shopping / unit name (card title) */
   title: string;
   series: CustomerGoalsSeries;
+  /**
+   * RFC-0228 A7 — optional R$ variance readout (realized R$ − goal R$). Additive +
+   * gated: absent → card byte-identical to the quantity-only view. Uses money names
+   * (`monetaryProjection`/`currencyBudget`), never the quantity `series.budget`.
+   */
+  moneyVariance?: CustomerGoalsMoneyVariance;
   /** Unit driving tick/total formatting. Default 'kWh'. */
   unit?: string;
   /** e.g. { current: '2026', previous: '2025' } — used in tooltips/aria only */
@@ -126,7 +158,9 @@ export interface CustomerGoalsCardParams {
 
 export interface CustomerGoalsCardInstance {
   el: HTMLElement;
-  update(partial: Partial<Pick<CustomerGoalsCardParams, 'series' | 'totals' | 'title'>>): void;
+  update(
+    partial: Partial<Pick<CustomerGoalsCardParams, 'series' | 'totals' | 'title' | 'moneyVariance'>>
+  ): void;
   setThemeMode(mode: CustomerGoalsThemeMode): void;
   /** Apply chart options (points on/off, line|bar) and re-render the chart */
   setOptions(options: CustomerGoalsCardOptions): void;

--- a/src/components/financial-goals/budgetView.ts
+++ b/src/components/financial-goals/budgetView.ts
@@ -1,0 +1,326 @@
+/**
+ * RFC-0228 A3 — Native CURRENCY budget view (the R$ budget target + verdict).
+ *
+ * Given a normalized {@link MoneyOverlay} (F0, `moneyTypes.ts`) that carries a
+ * native `budget` block (GCDR RFC-0054 `measure=CURRENCY`, API guide §4.2), this
+ * renderer produces the **budget** face that sits **beside the A2a R$ row**:
+ *
+ *  - **Target** — the committed R$ budget (`budget.target.amount`,
+ *    `source:NATIVE`) via {@link formatBRL}.
+ *  - **Projected** — the R$ projection from the overlay (`budget.projected.amount`,
+ *    `source:OVERLAY`) via {@link formatBRL}.
+ *  - **Verdict** — the headline honesty invariant (GCDR RFC-0054 **DEC-6**):
+ *      · `withinBudget === true`  → a green chip "Dentro do orçamento" + the R$/%
+ *        variance.
+ *      · `withinBudget === false` → a red chip "Acima do orçamento" + the R$/%
+ *        variance.
+ *      · `withinBudget === null`  → **explicitly withheld**: "Veredito indisponível
+ *        — cobertura incompleta". The UI **never** declares in/over budget over a
+ *        partial projection. When `coverageComplete:false`, it defers to **A4**
+ *        ({@link renderCoverageView}) for the *why* (uncategorized devices / gaps).
+ *  - **No native budget** (`budget` absent) → an empty state, never an error and
+ *    never `R$ 0`.
+ *  - **No overlay** (money off / not resolved) → returns `null`; the caller
+ *    appends nothing and the card stays byte-identical to the kWh-only view.
+ *
+ * ── WORDING CONTRACT (RFC-0228 feedback §8) — DO NOT DRIFT ──────────────────────
+ * This is coverage/estimation UX, not billing. ALLOWED: "Orçamento", "Projeção",
+ * "Estimativa em R$". FORBIDDEN (never emit): "Fatura", "Faturamento",
+ * "Valor final", "Total a pagar". The withheld state carries NO in/over-budget
+ * word — declaring a verdict over a partial projection breaks DEC-6.
+ * ───────────────────────────────────────────────────────────────────────────────
+ *
+ * Design rules (mirroring F0/A4/A2a on this branch):
+ *  - **Pure component.** DOM/HTML output + inputs/callbacks only. No `fetch`, no
+ *    ThingsBoard, no API calls. It receives a `MoneyOverlay`; it never fetches one.
+ *    The optional {@link BudgetViewOptions.onSaveBudget} callback is a **stub**
+ *    affordance the host wires to `goalsMoneyClient.putBudget` — A3 does not build
+ *    a full editor (deferred).
+ *  - **Amounts are decimal STRINGS.** The only `Number()` is the derived variance
+ *    percent ({@link computeDeltaPct}) — a display metric. The R$ figures are
+ *    formatted string-in / string-out ({@link formatBRL}), never round-tripped
+ *    through a float.
+ *  - **Never `R$ 0`, never `NaN`.** A missing amount renders `—` (F0 `DASH`).
+ */
+
+import type { MoneyOverlay, BudgetOverlay, GoalTreeNode } from './moneyTypes';
+import { renderCoverageView, type CoverageViewOptions } from './coverageView';
+import {
+  DASH,
+  formatBRL,
+  formatBRLDelta,
+  formatDeltaPct,
+  computeDeltaPct,
+} from './moneyFormat';
+
+/** Per-role value colours for the two R$ figures (label tint). */
+export interface BudgetValueColors {
+  /** Target (committed budget) label tint. Default: purple. */
+  target?: string;
+  /** Projected (overlay projection) label tint. Default: blue. */
+  projected?: string;
+}
+
+/** Verdict chip palette (defaults mirror the Metas × Consumo `devChip`). */
+export interface BudgetChipColors {
+  /** Acima do orçamento (over): red by default. */
+  overBg?: string;
+  overText?: string;
+  /** Dentro do orçamento (within): green by default. */
+  withinBg?: string;
+  withinText?: string;
+  /** Withheld / no data: grey by default. */
+  neutralBg?: string;
+  neutralText?: string;
+}
+
+/** Options for {@link renderBudgetView}. */
+export interface BudgetViewOptions {
+  /**
+   * The normalized money overlay for this shopping/portfolio (F0). Drives the gate:
+   *  - `null`/`undefined` (no `state`) → renderer returns `null` (money off).
+   *  - present but no `budget` block → empty state (no error, no R$ 0).
+   *  - `budget` present → Target/Projected + the DEC-6 verdict.
+   */
+  overlay: MoneyOverlay | null | undefined;
+  /**
+   * **Stub** edit affordance. When given, a single "Editar orçamento" button is
+   * rendered; clicking it fires this callback so the host can open its own editor
+   * and call `goalsMoneyClient.putBudget`. A3 does NOT build a full editor — it
+   * hands back a best-effort annual echo of the current target (or `{}` when the
+   * target is absent). The real write path lives in F0's client (deferred).
+   */
+  onSaveBudget?: (tree: GoalTreeNode) => void;
+  /** A5a per-device deep-link, passed through to A4 in the withheld/incomplete state. */
+  onCategorizeDevice?: (deviceId: string) => void;
+  /** A5a generic deep-link, passed through to A4 in the withheld/incomplete state. */
+  onManageCategories?: () => void;
+  /** Value-figure colour override. */
+  valueColors?: BudgetValueColors;
+  /** Verdict-chip palette override. */
+  chipColors?: BudgetChipColors;
+  /** Document to build in (defaults to the ambient `document`). */
+  document?: Document;
+}
+
+/** Default value hues — Target purple, Projected blue. */
+const DEFAULT_VALUE_COLORS: Required<BudgetValueColors> = {
+  target: '#7c3aed',
+  projected: '#2563eb',
+};
+
+/** Default verdict-chip palette — identical hues to the Metas × Consumo `devChip`. */
+const DEFAULT_CHIP: Required<BudgetChipColors> = {
+  overBg: '#fee2e2',
+  overText: '#b91c1c',
+  withinBg: '#dcfce7',
+  withinText: '#15803d',
+  neutralBg: '#f1f5f9',
+  neutralText: '#64748b',
+};
+
+const CHIP_BASE =
+  'border-radius:999px;padding:3px 12px;font:800 12px Nunito,sans-serif;white-space:nowrap;display:inline-flex;align-items:center;gap:6px;';
+
+/** A decimal string is "present" when it is a non-empty, non-null string. */
+function hasAmount(s: string | null | undefined): s is string {
+  return typeof s === 'string' && s.trim() !== '';
+}
+
+/**
+ * Extract the {@link BudgetOverlay} from an overlay, or `undefined` when there is
+ * no native budget (unavailable overlay, or available without a `budget` block).
+ * Pure — amounts pass through verbatim, never `Number()`-ed.
+ */
+export function resolveBudget(
+  overlay: MoneyOverlay | null | undefined
+): BudgetOverlay | undefined {
+  if (!overlay || typeof (overlay as { state?: unknown }).state !== 'string') {
+    return undefined;
+  }
+  if (overlay.state !== 'available') return undefined;
+  return overlay.budget;
+}
+
+/** One R$ figure cell: coloured label + formatted amount (or `—`). */
+function figureHTML(label: string, amount: string | null | undefined, color: string): string {
+  return (
+    `<span style="display:inline-flex;align-items:center;gap:4px;white-space:nowrap;">` +
+    `<span style="color:${color};font-weight:700;">${label}</span>` +
+    `<b style="color:var(--gc-text2, #334155);font-weight:800;">${formatBRL(amount ?? null)}</b>` +
+    `</span>`
+  );
+}
+
+/**
+ * Build the verdict chip from the {@link BudgetOverlay} verdict. **DEC-6 invariant**:
+ * a conclusion ("Dentro do orçamento" / "Acima do orçamento") is emitted **only**
+ * when `withinBudget` is a strict boolean. When it is `null` (or anything else),
+ * the withheld chip is returned instead — no in/over-budget word, ever.
+ */
+export function buildVerdictHTML(
+  budget: BudgetOverlay,
+  chipColors: Required<BudgetChipColors>
+): string {
+  const withinBudget = budget.verdict?.withinBudget;
+  const varianceR$ = hasAmount(budget.verdict?.variance)
+    ? formatBRLDelta(budget.verdict.variance)
+    : DASH;
+  const pct = computeDeltaPct(
+    budget.projected?.amount ?? null,
+    budget.target?.amount ?? null
+  );
+  const pctTxt = pct == null ? DASH : formatDeltaPct(pct);
+  const varianceLabel =
+    varianceR$ === DASH && pctTxt === DASH
+      ? ''
+      : `<span class="myio-budget__variance" style="font-weight:700;margin-left:8px;color:var(--gc-muted, #64748b);">${varianceR$} · ${pctTxt}</span>`;
+
+  // ── DEC-6: only a strict boolean yields a conclusion. `null`/anything → withheld.
+  if (withinBudget === true) {
+    return (
+      `<span data-budget-verdict="within" style="background:${chipColors.withinBg};color:${chipColors.withinText};${CHIP_BASE}">` +
+      `<span aria-hidden="true">✓</span>Dentro do orçamento</span>${varianceLabel}`
+    );
+  }
+  if (withinBudget === false) {
+    return (
+      `<span data-budget-verdict="over" style="background:${chipColors.overBg};color:${chipColors.overText};${CHIP_BASE}">` +
+      `<span aria-hidden="true">▲</span>Acima do orçamento</span>${varianceLabel}`
+    );
+  }
+  // Withheld — coverage incomplete. No in/over-budget word (DEC-6).
+  return (
+    `<span data-budget-verdict="withheld" style="background:${chipColors.neutralBg};color:${chipColors.neutralText};${CHIP_BASE}">` +
+    `<span aria-hidden="true">⏳</span>Veredito indisponível — cobertura incompleta</span>`
+  );
+}
+
+/**
+ * Build the budget view body (Target/Projected figures + verdict) as an HTML
+ * **string** (pure — no DOM, no callbacks, no A4 deferral). Directly testable for
+ * the DEC-6 verdict-withholding invariant and the wording contract.
+ */
+export function buildBudgetHTML(
+  budget: BudgetOverlay,
+  chipColors: Required<BudgetChipColors> = DEFAULT_CHIP,
+  valueColors: Required<BudgetValueColors> = DEFAULT_VALUE_COLORS
+): string {
+  const figures =
+    `<div style="font:600 12px Nunito,sans-serif;color:var(--gc-muted, #64748b);display:flex;align-items:center;gap:14px;flex-wrap:wrap;min-width:0;">` +
+    `<span aria-hidden="true">🎯</span>` +
+    figureHTML('Meta (orçamento)', budget.target?.amount, valueColors.target) +
+    figureHTML('Projeção', budget.projected?.amount, valueColors.projected) +
+    `</div>`;
+  return (
+    `<div class="myio-budget__row" data-budget-row="1" style="display:flex;align-items:center;justify-content:space-between;gap:10px;flex-wrap:wrap;">` +
+    figures +
+    `<span class="myio-budget__verdict-wrap" style="display:inline-flex;align-items:center;">` +
+    buildVerdictHTML(budget, chipColors) +
+    `</span>` +
+    `</div>` +
+    `<div class="myio-budget__note" style="font:600 10px Nunito,sans-serif;color:var(--gc-muted, #94a3b8);margin-top:4px;">Orçamento nativo em R$ · Projeção estimada</div>`
+  );
+}
+
+/** The empty-state HTML when no native budget exists (no error, no R$ 0). */
+function emptyStateHTML(): string {
+  return (
+    `<div class="myio-budget__empty" role="status" style="font:600 12px Nunito,sans-serif;color:var(--gc-muted, #94a3b8);display:flex;align-items:center;gap:6px;">` +
+    `<span aria-hidden="true">💸</span>Nenhum orçamento em R$ definido.` +
+    `</div>`
+  );
+}
+
+/**
+ * Render the native CURRENCY budget view for a shopping/portfolio as a live DOM
+ * element — or `null` when there is no overlay (money off).
+ *
+ * - No overlay → `null` (caller appends nothing).
+ * - No `budget` block → empty state (`data-budget-state="empty"`).
+ * - `budget` present → Target/Projected + verdict (`data-budget-state="budget"`).
+ *   When the verdict is withheld AND `coverageComplete:false`, the A4
+ *   {@link renderCoverageView} element is appended for the *why*.
+ */
+export function renderBudgetView(options: BudgetViewOptions): HTMLElement | null {
+  const overlay = options?.overlay;
+  // Gate: no overlay (money source not configured / not resolved) → no budget view.
+  if (!overlay || typeof (overlay as { state?: unknown }).state !== 'string') {
+    return null;
+  }
+
+  const doc =
+    options.document || (typeof document !== 'undefined' ? document : undefined);
+  if (!doc) {
+    throw new Error(
+      'renderBudgetView requires a document (pass options.document in non-DOM envs).'
+    );
+  }
+
+  const budget = resolveBudget(overlay);
+  const root = doc.createElement('div');
+  root.className = 'myio-budget';
+
+  // No native budget → honest empty state (never an error, never R$ 0).
+  if (!budget) {
+    root.setAttribute('data-budget-state', 'empty');
+    root.innerHTML = emptyStateHTML();
+    return root;
+  }
+
+  const chipColors: Required<BudgetChipColors> = { ...DEFAULT_CHIP, ...options.chipColors };
+  const valueColors: Required<BudgetValueColors> = {
+    ...DEFAULT_VALUE_COLORS,
+    ...options.valueColors,
+  };
+
+  root.setAttribute('data-budget-state', 'budget');
+  root.innerHTML = buildBudgetHTML(budget, chipColors, valueColors);
+
+  // DEC-6: when the verdict is withheld because coverage is incomplete, defer to A4
+  // for the *why* (uncategorized devices / tariff gaps). We never fabricate a verdict.
+  const withheld = budget.verdict?.withinBudget !== true && budget.verdict?.withinBudget !== false;
+  if (
+    withheld &&
+    overlay.state === 'available' &&
+    overlay.coverageComplete !== true
+  ) {
+    const coverageOpts: CoverageViewOptions = {
+      onCategorizeDevice: options.onCategorizeDevice,
+      onManageCategories: options.onManageCategories,
+      document: doc,
+    };
+    const why = renderCoverageView(overlay, coverageOpts);
+    why.setAttribute('data-budget-why', '1');
+    root.appendChild(why);
+  }
+
+  // Optional stub edit affordance — the host wires it to `putBudget` (F0). A3 does
+  // NOT build a full editor; it fires a best-effort annual echo of the current target.
+  if (typeof options.onSaveBudget === 'function') {
+    const cb = options.onSaveBudget;
+    const btn = doc.createElement('button');
+    btn.type = 'button';
+    btn.className = 'myio-budget__edit';
+    btn.setAttribute('data-budget-edit', '1');
+    btn.textContent = 'Editar orçamento';
+    btn.setAttribute(
+      'style',
+      'align-self:flex-start;margin-top:8px;padding:6px 12px;border:1px solid #7c3aed;border-radius:8px;background:transparent;color:#7c3aed;font:800 12px Nunito,sans-serif;cursor:pointer;'
+    );
+    btn.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      // Best-effort echo: hand back the current annual target as a write tree. The
+      // amount is a decimal string; the wire (§5.4) carries a number, so the host's
+      // real editor owns any re-shaping. This is a stub, not the editor.
+      const tree: GoalTreeNode = hasAmount(budget.target?.amount)
+        ? { annual: { value: Number(budget.target.amount) } }
+        : {};
+      cb(tree);
+    });
+    root.appendChild(btn);
+  }
+
+  return root;
+}

--- a/src/components/financial-goals/coverageStyles.ts
+++ b/src/components/financial-goals/coverageStyles.ts
@@ -1,0 +1,257 @@
+/**
+ * RFC-0228 A4 — Honest coverage UI styles.
+ *
+ * Idempotent injection: {@link injectCoverageStyles} appends the stylesheet once
+ * per document (guarded by the style element id), mirroring the pricing-panel
+ * idiom (`injectPricingPanelStyles`). Colors read `--myio-*` custom properties so
+ * the panel follows the host dashboard palette; a `prefers-color-scheme: dark`
+ * block re-points those vars for standalone/dark rendering so the component is
+ * theme-aware even without a host theme. Font is Nunito, matching the house style.
+ */
+
+export const COVERAGE_STYLE_ID = 'myio-fin-coverage-styles';
+
+const COVERAGE_CSS = `
+  .myio-cov {
+    --_cov-bg: var(--myio-bg, #ffffff);
+    --_cov-card: var(--myio-card, #f8fafc);
+    --_cov-text: var(--myio-text, #1f2937);
+    --_cov-muted: var(--myio-text-muted, #6b7280);
+    --_cov-border: var(--myio-border, #e5e7eb);
+    --_cov-brand: var(--myio-brand-700, #5b2c9d);
+    --_cov-warn-bg: #fffbeb;
+    --_cov-warn-border: #fde68a;
+    --_cov-warn-text: #92400e;
+    --_cov-ok-bg: #ecfdf5;
+    --_cov-ok-border: #a7f3d0;
+    --_cov-ok-text: #065f46;
+    --_cov-info-bg: #eff6ff;
+    --_cov-info-border: #bfdbfe;
+    --_cov-info-text: #1e40af;
+    font-family: 'Nunito', system-ui, -apple-system, sans-serif;
+    color: var(--_cov-text);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    font-size: 13px;
+    line-height: 1.45;
+  }
+
+  /* ---- Unavailable panel (money view withheld — not an error, not R$ 0) ---- */
+  .myio-cov__panel {
+    border: 1px solid var(--_cov-border);
+    border-left: 3px solid var(--_cov-brand);
+    border-radius: 10px;
+    background: var(--_cov-card);
+    padding: 14px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .myio-cov__panel-title {
+    font-weight: 800;
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .myio-cov__panel-msg {
+    color: var(--_cov-muted);
+    margin: 0;
+  }
+
+  /* ---- Complete: quiet, non-intrusive affordance ---- */
+  .myio-cov__complete {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    align-self: flex-start;
+    padding: 3px 10px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 700;
+    background: var(--_cov-ok-bg);
+    color: var(--_cov-ok-text);
+    border: 1px solid var(--_cov-ok-border);
+  }
+
+  /* ---- Incomplete badge + covered fraction ---- */
+  .myio-cov__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    align-self: flex-start;
+    padding: 4px 12px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 800;
+    background: var(--_cov-warn-bg);
+    color: var(--_cov-warn-text);
+    border: 1px solid var(--_cov-warn-border);
+  }
+  .myio-cov__badge-pct {
+    font-variant-numeric: tabular-nums;
+    font-weight: 800;
+  }
+  .myio-cov__hours {
+    color: var(--_cov-muted);
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+  }
+  .myio-cov__note {
+    margin: 0;
+    color: var(--_cov-muted);
+    font-size: 12px;
+    font-style: italic;
+  }
+
+  /* ---- Uncategorized devices: each a deep-link click affordance to A5a ---- */
+  .myio-cov__section-title {
+    font-weight: 700;
+    font-size: 12px;
+    color: var(--_cov-text);
+    margin: 4px 0 0;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+  }
+  .myio-cov__devices {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .myio-cov__device {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    width: 100%;
+    text-align: left;
+    padding: 9px 12px;
+    border: 1px solid var(--_cov-border);
+    border-radius: 8px;
+    background: var(--_cov-bg);
+    color: var(--_cov-text);
+    font-family: inherit;
+    font-size: 13px;
+    cursor: pointer;
+    transition: border-color 0.15s ease, background 0.15s ease;
+  }
+  .myio-cov__device:hover,
+  .myio-cov__device:focus-visible {
+    border-color: var(--_cov-brand);
+    background: var(--_cov-card);
+    outline: none;
+  }
+  .myio-cov__device-label {
+    font-weight: 700;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .myio-cov__device-code {
+    color: var(--_cov-muted);
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+  }
+  .myio-cov__device-cta {
+    color: var(--_cov-brand);
+    font-weight: 800;
+    font-size: 12px;
+    white-space: nowrap;
+  }
+
+  /* ---- Tariff coverage gaps summary ---- */
+  .myio-cov__gaps {
+    border: 1px solid var(--_cov-info-border);
+    background: var(--_cov-info-bg);
+    color: var(--_cov-info-text);
+    border-radius: 8px;
+    padding: 9px 12px;
+    font-size: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .myio-cov__gaps-truncated {
+    opacity: 0.85;
+    font-style: italic;
+  }
+
+  /* ---- Deep-link (unavailable state, generic manage-categories) ---- */
+  .myio-cov__deeplink {
+    align-self: flex-start;
+    margin-top: 4px;
+    padding: 7px 14px;
+    border: 1px solid var(--_cov-brand);
+    border-radius: 8px;
+    background: transparent;
+    color: var(--_cov-brand);
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 800;
+    cursor: pointer;
+    transition: background 0.15s ease;
+  }
+  .myio-cov__deeplink:hover,
+  .myio-cov__deeplink:focus-visible {
+    background: var(--_cov-card);
+    outline: none;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .myio-cov {
+      --_cov-bg: var(--myio-bg, #0f172a);
+      --_cov-card: var(--myio-card, #1e293b);
+      --_cov-text: var(--myio-text, #e2e8f0);
+      --_cov-muted: var(--myio-text-muted, #94a3b8);
+      --_cov-border: var(--myio-border, #334155);
+      --_cov-brand: var(--myio-brand-700, #a78bfa);
+      --_cov-warn-bg: #3a2e0a;
+      --_cov-warn-border: #7c5e12;
+      --_cov-warn-text: #fcd34d;
+      --_cov-ok-bg: #08312a;
+      --_cov-ok-border: #14654f;
+      --_cov-ok-text: #6ee7b7;
+      --_cov-info-bg: #0e2748;
+      --_cov-info-border: #1e4a86;
+      --_cov-info-text: #93c5fd;
+    }
+  }
+  /* Host theme toggle wins in both directions. */
+  :root[data-theme="dark"] .myio-cov {
+    --_cov-bg: var(--myio-bg, #0f172a);
+    --_cov-card: var(--myio-card, #1e293b);
+    --_cov-text: var(--myio-text, #e2e8f0);
+    --_cov-muted: var(--myio-text-muted, #94a3b8);
+    --_cov-border: var(--myio-border, #334155);
+    --_cov-brand: var(--myio-brand-700, #a78bfa);
+    --_cov-warn-bg: #3a2e0a; --_cov-warn-border: #7c5e12; --_cov-warn-text: #fcd34d;
+    --_cov-ok-bg: #08312a; --_cov-ok-border: #14654f; --_cov-ok-text: #6ee7b7;
+    --_cov-info-bg: #0e2748; --_cov-info-border: #1e4a86; --_cov-info-text: #93c5fd;
+  }
+  :root[data-theme="light"] .myio-cov {
+    --_cov-bg: var(--myio-bg, #ffffff);
+    --_cov-card: var(--myio-card, #f8fafc);
+    --_cov-text: var(--myio-text, #1f2937);
+    --_cov-muted: var(--myio-text-muted, #6b7280);
+    --_cov-border: var(--myio-border, #e5e7eb);
+    --_cov-brand: var(--myio-brand-700, #5b2c9d);
+    --_cov-warn-bg: #fffbeb; --_cov-warn-border: #fde68a; --_cov-warn-text: #92400e;
+    --_cov-ok-bg: #ecfdf5; --_cov-ok-border: #a7f3d0; --_cov-ok-text: #065f46;
+    --_cov-info-bg: #eff6ff; --_cov-info-border: #bfdbfe; --_cov-info-text: #1e40af;
+  }
+`;
+
+/** Inject the coverage stylesheet once per document (id-guarded, idempotent). */
+export function injectCoverageStyles(doc: Document): void {
+  if (!doc || !doc.head) return;
+  if (doc.getElementById(COVERAGE_STYLE_ID)) return;
+  const style = doc.createElement('style');
+  style.id = COVERAGE_STYLE_ID;
+  style.textContent = COVERAGE_CSS;
+  doc.head.appendChild(style);
+}

--- a/src/components/financial-goals/coverageView.ts
+++ b/src/components/financial-goals/coverageView.ts
@@ -1,0 +1,280 @@
+/**
+ * RFC-0228 A4 — Honest coverage UI (reusable renderer for A2a / A3).
+ *
+ * A pure, framework-agnostic renderer that takes a normalized {@link MoneyOverlay}
+ * (from F0, `moneyTypes.ts`) and honestly describes the R$ coverage state. It is
+ * the UX face of the backend's honesty discipline (GCDR RFC-0054 DEC-6; API guide
+ * §4.2): coverage states are 200-body outcomes, **never errors and never R$ 0**.
+ *
+ * States rendered:
+ *  1. `unavailable` (reason `MONEY_REQUIRES_DEVICE_GRANULARITY`) — a clear panel:
+ *     the money view needs a device-granular goal with a tariff category. Offers a
+ *     generic deep-link to the categorization UI (A5a) when a callback is given.
+ *  2. `available` + `coverageComplete:true` — a quiet "cobertura completa" chip so
+ *     the caller can show the R$ with confidence. No uncategorized/gaps noise.
+ *  3. `available` + `coverageComplete:false` — the key honest state: an "incomplete"
+ *     badge with the covered fraction (`pricedHours`/`totalHours` DEVICE-hours as a
+ *     %), the `uncategorizedDevices` list (each a click affordance firing
+ *     `onCategorizeDevice(deviceId)` — the A5a deep-link), the `tariffCoverageGaps`
+ *     summary, and wording that the R$ is a partial covered sum, never a total.
+ *
+ * ── WORDING CONTRACT (RFC-0228 feedback §8) — DO NOT DRIFT ──────────────────────
+ * This is coverage/estimation UX, not billing. ALLOWED: "Projeção",
+ * "Estimativa em R$", "Cobertura incompleta". FORBIDDEN (never emit): "Fatura",
+ * "Faturamento", "Valor final", "Total a pagar". Any future edit that introduces a
+ * billing-grade word breaks the honesty contract and the wording tests.
+ * ───────────────────────────────────────────────────────────────────────────────
+ *
+ * Design rules (mirroring the F0/A1 modules on this branch):
+ *  - **Pure component.** DOM/HTML output + callbacks only. No `fetch`, no
+ *    ThingsBoard, no API calls. It receives a `MoneyOverlay`; it never fetches one.
+ *  - **Never render `NaN`/`R$ 0`.** The covered percent is guarded (missing/zero
+ *    denominator → `—`); no money amount is fabricated here.
+ *  - Theme-aware (light/dark), Nunito, id-guarded CSS-in-JS injection.
+ */
+
+import type { MoneyOverlay, UncategorizedDevice, TariffCoverageGaps } from './moneyTypes';
+import { MONEY_REQUIRES_DEVICE_GRANULARITY } from './moneyTypes';
+import { DASH } from './moneyFormat';
+import { injectCoverageStyles } from './coverageStyles';
+
+/** Options for {@link renderCoverageView}. */
+export interface CoverageViewOptions {
+  /**
+   * Deep-link to A5a — fired when the user clicks an uncategorized device in the
+   * `coverageComplete:false` state. A4 does NOT implement categorization; it only
+   * surfaces the affordance and hands back the `deviceId`.
+   */
+  onCategorizeDevice?: (deviceId: string) => void;
+  /**
+   * Generic deep-link for the `unavailable` state (no specific device to point at).
+   * When provided, an "Gerenciar categorias de tarifa" button is offered so the
+   * user can reach the A5a categorization UI. Kept separate from
+   * {@link onCategorizeDevice} so the per-device contract stays a clean `(id)`.
+   */
+  onManageCategories?: () => void;
+  /** Document to build in (defaults to the ambient `document`). */
+  document?: Document;
+}
+
+/** ---- pt-BR helpers (pure strings; no float round-trips for money) ---- */
+
+/** Group an integer with pt-BR thousands dots: `61320` → `"61.320"`. */
+function groupInt(n: number): string {
+  return String(Math.trunc(Math.abs(n))).replace(/\B(?=(\d{3})+(?!\d))/g, '.');
+}
+
+/**
+ * Covered fraction as a pt-BR percent string, or {@link DASH} when it cannot be
+ * computed honestly (missing or non-positive denominator). Never `NaN`.
+ */
+export function coveragePercentLabel(
+  pricedHours: number | undefined,
+  totalHours: number | undefined
+): string {
+  if (
+    typeof pricedHours !== 'number' ||
+    typeof totalHours !== 'number' ||
+    !Number.isFinite(pricedHours) ||
+    !Number.isFinite(totalHours) ||
+    totalHours <= 0
+  ) {
+    return DASH;
+  }
+  const pct = (pricedHours / totalHours) * 100;
+  if (!Number.isFinite(pct)) return DASH;
+  const rounded = Math.round(pct * 10) / 10;
+  // Drop a trailing ",0" for whole percentages.
+  const txt = Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1).replace('.', ',');
+  return `${txt}%`;
+}
+
+/** Escape untrusted device label/code text for safe HTML interpolation. */
+function esc(s: unknown): string {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/** Human display name for a device: label → code → id, all escaped. */
+function deviceDisplayName(d: UncategorizedDevice): string {
+  return esc(d.label || d.code || d.deviceId || 'Dispositivo');
+}
+
+/** ---- HTML builders (pure; no callbacks, no DOM) ---- */
+
+function unavailableHTML(reason: string, offerDeepLink: boolean): string {
+  // Only the device-granularity reason gets the tailored copy; any other reason
+  // still renders honestly (no error, no R$ 0) with the generic message.
+  const isGranularity = reason === MONEY_REQUIRES_DEVICE_GRANULARITY;
+  const msg = isGranularity
+    ? 'A meta precisa ser por dispositivo (device-granular) com categoria de tarifa.'
+    : 'Visão em R$ não disponível para esta meta.';
+  const deepLink = offerDeepLink
+    ? `<button type="button" class="myio-cov__deeplink" data-cov-manage="1">Gerenciar categorias de tarifa</button>`
+    : '';
+  return (
+    `<div class="myio-cov__panel" role="status">` +
+    `<div class="myio-cov__panel-title"><span aria-hidden="true">💸</span>Visão em R$ indisponível</div>` +
+    `<p class="myio-cov__panel-msg">${msg}</p>` +
+    deepLink +
+    `</div>`
+  );
+}
+
+function completeHTML(): string {
+  return (
+    `<span class="myio-cov__complete" role="status">` +
+    `<span aria-hidden="true">✓</span>Cobertura completa` +
+    `</span>`
+  );
+}
+
+function devicesHTML(devices: UncategorizedDevice[]): string {
+  if (!devices.length) return '';
+  const items = devices
+    .map((d) => {
+      const name = deviceDisplayName(d);
+      const code = d.code ? `<span class="myio-cov__device-code">${esc(d.code)}</span>` : '';
+      return (
+        `<li>` +
+        `<button type="button" class="myio-cov__device" data-cov-device="${esc(d.deviceId)}">` +
+        `<span class="myio-cov__device-label">${name}</span>` +
+        code +
+        `<span class="myio-cov__device-cta">Categorizar →</span>` +
+        `</button>` +
+        `</li>`
+      );
+    })
+    .join('');
+  return (
+    `<div class="myio-cov__section-title">Dispositivos sem categoria de tarifa</div>` +
+    `<ul class="myio-cov__devices">${items}</ul>`
+  );
+}
+
+function gapsHTML(gaps: TariffCoverageGaps | undefined): string {
+  if (!gaps) return '';
+  const hours =
+    typeof gaps.missingHours === 'number' && Number.isFinite(gaps.missingHours)
+      ? groupInt(gaps.missingHours)
+      : DASH;
+  const truncated = gaps.truncated
+    ? `<span class="myio-cov__gaps-truncated">Lista de horas resumida (truncada).</span>`
+    : '';
+  return (
+    `<div class="myio-cov__gaps" role="status">` +
+    `<span><strong>${hours}</strong> horas-dispositivo sem tarifa.</span>` +
+    truncated +
+    `</div>`
+  );
+}
+
+function incompleteHTML(
+  overlay: Extract<MoneyOverlay, { state: 'available' }>
+): string {
+  const pctLabel = coveragePercentLabel(overlay.pricedHours, overlay.totalHours);
+  const hoursDetail =
+    typeof overlay.pricedHours === 'number' && typeof overlay.totalHours === 'number'
+      ? `<span class="myio-cov__hours">${groupInt(overlay.pricedHours)} / ${groupInt(
+          overlay.totalHours
+        )} horas-dispositivo cobertas</span>`
+      : '';
+  return (
+    `<span class="myio-cov__badge" role="status">` +
+    `<span aria-hidden="true">⚠️</span>Cobertura incompleta` +
+    `<span class="myio-cov__badge-pct">${pctLabel}</span>` +
+    `</span>` +
+    hoursDetail +
+    `<p class="myio-cov__note">A Estimativa em R$ é uma soma parcial coberta, não um total.</p>` +
+    devicesHTML(overlay.uncategorizedDevices) +
+    gapsHTML(overlay.tariffCoverageGaps)
+  );
+}
+
+/**
+ * Build the coverage UI as an HTML **string** (pure — no DOM, no callbacks). Used
+ * internally by {@link renderCoverageView} and directly testable for wording.
+ * `offerDeepLink` only affects the `unavailable` state's generic manage button.
+ */
+export function buildCoverageHTML(
+  overlay: MoneyOverlay,
+  offerDeepLink = false
+): string {
+  if (!overlay || (overlay as { state?: string }).state == null) {
+    // Defensive: an absent overlay is treated as unavailable, never an error.
+    return unavailableHTML(MONEY_REQUIRES_DEVICE_GRANULARITY, offerDeepLink);
+  }
+  if (overlay.state === 'unavailable') {
+    return unavailableHTML(overlay.reason, offerDeepLink);
+  }
+  // available
+  if (overlay.coverageComplete) {
+    return completeHTML();
+  }
+  return incompleteHTML(overlay);
+}
+
+/**
+ * Render the honest coverage UI for a {@link MoneyOverlay} as a live DOM element,
+ * wiring the A5a deep-link callbacks. Injects the (id-guarded) stylesheet.
+ *
+ * The returned element carries a `data-cov-state` attribute (`available-complete`
+ * | `available-incomplete` | `unavailable`) for callers/tests.
+ */
+export function renderCoverageView(
+  overlay: MoneyOverlay,
+  options: CoverageViewOptions = {}
+): HTMLElement {
+  const doc = options.document || (typeof document !== 'undefined' ? document : undefined);
+  if (!doc) {
+    throw new Error('renderCoverageView requires a document (pass options.document in non-DOM envs).');
+  }
+  injectCoverageStyles(doc);
+
+  const offerDeepLink =
+    (!overlay || overlay.state === 'unavailable') && typeof options.onManageCategories === 'function';
+
+  const root = doc.createElement('div');
+  root.className = 'myio-cov';
+  root.setAttribute(
+    'data-cov-state',
+    !overlay || overlay.state === 'unavailable'
+      ? 'unavailable'
+      : overlay.coverageComplete
+      ? 'available-complete'
+      : 'available-incomplete'
+  );
+  root.innerHTML = buildCoverageHTML(overlay, offerDeepLink);
+
+  // Wire per-device deep-links (A5a). A4 only fires the callback with the id.
+  if (typeof options.onCategorizeDevice === 'function') {
+    const cb = options.onCategorizeDevice;
+    root.querySelectorAll<HTMLElement>('[data-cov-device]').forEach((btn) => {
+      btn.addEventListener('click', (ev) => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        const id = btn.getAttribute('data-cov-device') || '';
+        cb(id);
+      });
+    });
+  }
+
+  // Wire the generic manage-categories deep-link (unavailable state).
+  if (offerDeepLink && typeof options.onManageCategories === 'function') {
+    const mcb = options.onManageCategories;
+    const manageBtn = root.querySelector<HTMLElement>('[data-cov-manage]');
+    if (manageBtn) {
+      manageBtn.addEventListener('click', (ev) => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        mcb();
+      });
+    }
+  }
+
+  return root;
+}

--- a/src/components/financial-goals/deviceCategoryPanel.ts
+++ b/src/components/financial-goals/deviceCategoryPanel.ts
@@ -1,0 +1,518 @@
+/**
+ * RFC-0228 A5a — device tariff-category **management UI**.
+ *
+ * A premium modal that lists a customer's devices and lets an operator view,
+ * filter, and edit each device's explicit `tariffCategory`
+ * (`COMMON_AREA` / `SPECIFIC` / — none —), individually or in bulk.
+ *
+ * ── THE UI DEPENDS ONLY ON A SEAM (RFC-0228 feedback §5) ──────────────────────
+ * This component NEVER talks to a concrete device HTTP API. It depends solely on
+ * an injected {@link DeviceCategoryPort}. The GCDR device-tariffCategory contract
+ * is item **B6** (gcdr repo) and is not built yet; the port is exactly what B6
+ * will implement later. Tests/demo inject `createFakeDeviceCategoryPort`, so the
+ * whole UI runs with zero live host calls and can ship before B6.
+ *
+ * ── EXPLICIT CLASSIFICATION ONLY (RFC-0207 discipline) ────────────────────────
+ * A device's category is read from and written to the **explicit** attribute and
+ * nothing else. The UI NEVER infers a category from a device's name/label — a
+ * device labeled "Loja 12" with `tariffCategory: null` stays uncategorized until a
+ * human sets it. The label is display-only; it is never a classification input.
+ *
+ * ── CATEGORY TERM MAPPING REUSES A1 (no duplicate string-matching) ────────────
+ * The value set is exactly `COMMON_AREA | SPECIFIC | null`. Its mapping to the
+ * pricing panel's `area_comum`/`lojas` terms is A1's centralized map
+ * (`tariffApiAdapter.ts`: `wireCategoryToPanel`/`panelCategoryToWire`). This file
+ * imports that map and never re-matches these tokens itself.
+ *
+ * ── WORDING (RFC-0228 §8) ─────────────────────────────────────────────────────
+ * Categorization/coverage UX, never billing. No "Fatura"/"Faturamento"/"Total a
+ * pagar" strings here.
+ */
+
+import {
+  wireCategoryToPanel,
+  panelCategoryToWire,
+} from '../pricing-panel/tariffApiAdapter';
+import type { PricingCategory } from '../pricing-panel/types';
+import type { DeviceCategory, DeviceCategoryPort, DeviceCategoryRow } from './deviceCategoryPort';
+import { DeviceCategoryConflictError } from './deviceCategoryPort';
+import { injectDeviceCategoryStyles } from './deviceCategoryStyles';
+
+/** Category filter for the toolbar. `uncategorized` = the A4 deep-link entry. */
+export type DeviceCategoryFilter = 'all' | 'uncategorized' | 'COMMON_AREA' | 'SPECIFIC';
+
+/** pt-BR display labels, keyed by the A1 **panel** term (single source below). */
+const PANEL_TERM_LABEL: Record<PricingCategory, string> = {
+  lojas: 'Lojas',
+  area_comum: 'Área Comum',
+};
+
+/** Label for the "no category" value — the honest uncategorized state. */
+const NONE_LABEL = '— Sem categoria —';
+
+/**
+ * pt-BR label for a device category. Delegates the token→panel-term step to A1's
+ * centralized `wireCategoryToPanel` map (RFC-0228 A1) — this function adds only the
+ * final term→text lookup, never a second copy of the COMMON_AREA/SPECIFIC mapping.
+ */
+export function deviceCategoryLabel(cat: DeviceCategory): string {
+  if (cat == null) return NONE_LABEL;
+  return PANEL_TERM_LABEL[wireCategoryToPanel(cat)];
+}
+
+/** The A1 panel term for a device category (or `null` when uncategorized). */
+export function deviceCategoryToPanelTerm(cat: DeviceCategory): PricingCategory | null {
+  return cat == null ? null : wireCategoryToPanel(cat);
+}
+
+/** A device category from an A1 panel term (or `null`). Inverse of the above. */
+export function panelTermToDeviceCategory(term: PricingCategory | null): DeviceCategory {
+  return term == null ? null : panelCategoryToWire(term);
+}
+
+export interface OpenDeviceCategoryPanelParams {
+  /** The injected SEAM. Tests/demo pass `createFakeDeviceCategoryPort(...)`. */
+  port: DeviceCategoryPort;
+  /** Customer whose devices to list/edit. */
+  customerId: string;
+  /** Optional money domain scope. */
+  domain?: 'ENERGY' | 'WATER';
+  /** Device to scroll to + highlight on open (from A4's `onCategorizeDevice`). */
+  focusDeviceId?: string;
+  /** Initial category filter (A4's uncategorized deep-link passes `uncategorized`). */
+  initialFilter?: DeviceCategoryFilter;
+  /** Theme CSS var overrides applied to the modal root (`--myio-*`). */
+  theme?: Record<string, string>;
+  /** Called after the panel closes. */
+  onClose?: () => void;
+  /** Document to build in (defaults to ambient `document`). */
+  document?: Document;
+}
+
+/** Live handle to an open panel (also the test/introspection surface). */
+export interface DeviceCategoryPanelHandle {
+  /** Resolves once the initial device list has loaded and rendered. */
+  ready: Promise<void>;
+  /** Close and remove the panel. */
+  close(): void;
+  /** The modal root element. */
+  getRoot(): HTMLElement;
+  /** Re-fetch the device list from the port and re-render. */
+  refresh(): Promise<void>;
+  /** Current in-memory device model (post-edits). */
+  getRows(): DeviceCategoryRow[];
+  /** Device ids currently passing search + category filter (render order). */
+  getVisibleDeviceIds(): string[];
+  /** Set the free-text search (label/code) and re-render. */
+  setSearch(text: string): void;
+  /** Set the category filter and re-render. */
+  setCategoryFilter(filter: DeviceCategoryFilter): void;
+}
+
+/** Escape untrusted text for safe HTML interpolation. */
+function esc(s: unknown): string {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/** Category `<option>`s: none + the two explicit tokens (labels via A1 map). */
+function categoryOptionsHTML(selected: DeviceCategory): string {
+  const opt = (value: string, label: string, isSel: boolean): string =>
+    `<option value="${value}"${isSel ? ' selected' : ''}>${esc(label)}</option>`;
+  return (
+    opt('', NONE_LABEL, selected == null) +
+    opt('COMMON_AREA', deviceCategoryLabel('COMMON_AREA'), selected === 'COMMON_AREA') +
+    opt('SPECIFIC', deviceCategoryLabel('SPECIFIC'), selected === 'SPECIFIC')
+  );
+}
+
+/**
+ * Open the device tariff-category management panel. Returns a
+ * {@link DeviceCategoryPanelHandle}. Explicit-only, seam-driven — see file header.
+ */
+export function openDeviceCategoryPanel(
+  params: OpenDeviceCategoryPanelParams
+): DeviceCategoryPanelHandle {
+  const doc =
+    params.document || (typeof document !== 'undefined' ? document : undefined);
+  if (!doc) {
+    throw new Error(
+      'openDeviceCategoryPanel requires a document (pass params.document in non-DOM envs).'
+    );
+  }
+  injectDeviceCategoryStyles(doc);
+
+  const { port, customerId } = params;
+
+  // --- model ---------------------------------------------------------------
+  let rows: DeviceCategoryRow[] = [];
+  let search = '';
+  let filter: DeviceCategoryFilter = params.initialFilter || 'all';
+  const selected = new Set<string>();
+
+  // --- shell ---------------------------------------------------------------
+  const root = doc.createElement('div');
+  root.className = 'myio-devcat';
+  root.setAttribute('data-devcat', '1');
+  if (params.theme) {
+    for (const [k, v] of Object.entries(params.theme)) {
+      if (k.startsWith('--') && typeof v === 'string') root.style.setProperty(k, v);
+    }
+  }
+  root.innerHTML = `
+    <div class="myio-devcat__overlay" data-devcat-overlay="1"></div>
+    <div class="myio-devcat__card" role="dialog" aria-modal="true" aria-label="Categorias de tarifa por dispositivo">
+      <div class="myio-devcat__header">
+        <h3 class="myio-devcat__title"><span aria-hidden="true">🏷️</span>Categorias de tarifa por dispositivo</h3>
+        <button type="button" class="myio-devcat__close" data-devcat-close="1" aria-label="Fechar">&times;</button>
+      </div>
+      <div class="myio-devcat__toolbar">
+        <input type="search" class="myio-devcat__search" data-devcat-search="1"
+               placeholder="Buscar por nome ou código…" aria-label="Buscar dispositivo" />
+        <select class="myio-devcat__filter" data-devcat-filter="1" aria-label="Filtrar por categoria">
+          <option value="all">Todas as categorias</option>
+          <option value="uncategorized">Sem categoria</option>
+          <option value="COMMON_AREA">${esc(deviceCategoryLabel('COMMON_AREA'))}</option>
+          <option value="SPECIFIC">${esc(deviceCategoryLabel('SPECIFIC'))}</option>
+        </select>
+        <label class="myio-devcat__filter" style="display:flex;align-items:center;gap:6px;cursor:pointer;">
+          <input type="checkbox" data-devcat-selectall="1" /> Selecionar visíveis
+        </label>
+      </div>
+      <div class="myio-devcat__bulkbar" data-devcat-bulkbar="1">
+        <span data-devcat-bulkcount="1">0 selecionados</span>
+        <select data-devcat-bulkcat="1" aria-label="Categoria para os selecionados">
+          <option value="">${esc(NONE_LABEL)}</option>
+          <option value="COMMON_AREA">${esc(deviceCategoryLabel('COMMON_AREA'))}</option>
+          <option value="SPECIFIC">${esc(deviceCategoryLabel('SPECIFIC'))}</option>
+        </select>
+        <button type="button" class="myio-devcat__bulk-apply" data-devcat-bulkapply="1">Aplicar a selecionados</button>
+      </div>
+      <div class="myio-devcat__body" data-devcat-body="1"></div>
+      <div class="myio-devcat__footer">
+        <span data-devcat-count="1"></span>
+        <span>Categoria explícita — nunca inferida do nome (RFC-0207).</span>
+      </div>
+    </div>
+  `;
+
+  const body = root.querySelector<HTMLElement>('[data-devcat-body]')!;
+  const countEl = root.querySelector<HTMLElement>('[data-devcat-count]')!;
+  const bulkbar = root.querySelector<HTMLElement>('[data-devcat-bulkbar]')!;
+  const bulkCountEl = root.querySelector<HTMLElement>('[data-devcat-bulkcount]')!;
+  const selectAll = root.querySelector<HTMLInputElement>('[data-devcat-selectall]')!;
+
+  // --- filtering -----------------------------------------------------------
+  function matchesFilter(r: DeviceCategoryRow): boolean {
+    if (filter === 'all') return true;
+    if (filter === 'uncategorized') return r.tariffCategory == null;
+    return r.tariffCategory === filter;
+  }
+  function matchesSearch(r: DeviceCategoryRow): boolean {
+    if (!search) return true;
+    const hay = `${r.label || ''} ${r.code || ''}`.toLowerCase();
+    return hay.includes(search.toLowerCase());
+  }
+  function visibleRows(): DeviceCategoryRow[] {
+    return rows.filter((r) => matchesFilter(r) && matchesSearch(r));
+  }
+
+  // --- rendering -----------------------------------------------------------
+  function rowHTML(r: DeviceCategoryRow): string {
+    const name = esc(r.label || r.code || r.deviceId);
+    const code = r.code ? `<span class="myio-devcat__row-code">${esc(r.code)}</span>` : '';
+    const checked = selected.has(r.deviceId) ? ' checked' : '';
+    const focused = r.deviceId === params.focusDeviceId ? ' data-focused="1"' : '';
+    const catAttr = r.tariffCategory == null ? 'null' : r.tariffCategory;
+    return (
+      `<div class="myio-devcat__row" data-devcat-row="${esc(r.deviceId)}" data-cat="${catAttr}"${focused}>` +
+      `<input type="checkbox" class="myio-devcat__row-check" data-devcat-rowcheck="${esc(
+        r.deviceId
+      )}"${checked} aria-label="Selecionar ${name}" />` +
+      `<div class="myio-devcat__row-main">` +
+      `<span class="myio-devcat__row-label" title="${name}">${name}</span>` +
+      code +
+      `</div>` +
+      `<select class="myio-devcat__row-select" data-devcat-rowselect="${esc(
+        r.deviceId
+      )}" aria-label="Categoria de ${name}">${categoryOptionsHTML(r.tariffCategory)}</select>` +
+      `<div class="myio-devcat__row-conflict" data-devcat-conflict="${esc(r.deviceId)}"></div>` +
+      `</div>`
+    );
+  }
+
+  function render(): void {
+    const vis = visibleRows();
+    if (vis.length === 0) {
+      body.innerHTML = `<div class="myio-devcat__empty">Nenhum dispositivo encontrado.</div>`;
+    } else {
+      body.innerHTML = vis.map(rowHTML).join('');
+    }
+    countEl.textContent = `${vis.length} de ${rows.length} dispositivo(s)`;
+    wireRows();
+    updateBulkBar();
+    // Focus/scroll the deep-linked device (guard: jsdom lacks scrollIntoView).
+    if (params.focusDeviceId) {
+      const el = body.querySelector<HTMLElement>(
+        `[data-devcat-row="${cssEscape(params.focusDeviceId)}"]`
+      );
+      if (el && typeof (el as HTMLElement).scrollIntoView === 'function') {
+        el.scrollIntoView({ block: 'center' });
+      }
+    }
+  }
+
+  function updateBulkBar(): void {
+    const n = selected.size;
+    bulkCountEl.textContent = `${n} selecionado(s)`;
+    bulkbar.classList.toggle('show', n > 0);
+  }
+
+  // --- per-row wiring ------------------------------------------------------
+  function wireRows(): void {
+    body.querySelectorAll<HTMLSelectElement>('[data-devcat-rowselect]').forEach((sel) => {
+      sel.addEventListener('change', () => {
+        const id = sel.getAttribute('data-devcat-rowselect')!;
+        const value = sel.value; // '' | 'COMMON_AREA' | 'SPECIFIC'
+        const category: DeviceCategory = value === '' ? null : (value as DeviceCategory);
+        void applySingle(id, category);
+      });
+    });
+    body.querySelectorAll<HTMLInputElement>('[data-devcat-rowcheck]').forEach((cb) => {
+      cb.addEventListener('change', () => {
+        const id = cb.getAttribute('data-devcat-rowcheck')!;
+        if (cb.checked) selected.add(id);
+        else selected.delete(id);
+        updateBulkBar();
+      });
+    });
+  }
+
+  function showConflict(deviceId: string, message: string): void {
+    const rowEl = body.querySelector<HTMLElement>(
+      `[data-devcat-row="${cssEscape(deviceId)}"]`
+    );
+    const banner = body.querySelector<HTMLElement>(
+      `[data-devcat-conflict="${cssEscape(deviceId)}"]`
+    );
+    if (rowEl) rowEl.setAttribute('data-conflict', '1');
+    if (banner) banner.textContent = message;
+  }
+  function clearConflict(deviceId: string): void {
+    const rowEl = body.querySelector<HTMLElement>(
+      `[data-devcat-row="${cssEscape(deviceId)}"]`
+    );
+    const banner = body.querySelector<HTMLElement>(
+      `[data-devcat-conflict="${cssEscape(deviceId)}"]`
+    );
+    if (rowEl) rowEl.removeAttribute('data-conflict');
+    if (banner) banner.textContent = '';
+  }
+
+  /**
+   * Write one device's category through the port with its `expectedVersion`. On
+   * success the model row is updated in place. On a version conflict the row shows
+   * a banner and keeps the user's chosen value — crucially, OTHER rows' pending or
+   * committed edits are untouched (each row is independent).
+   */
+  async function applySingle(deviceId: string, category: DeviceCategory): Promise<void> {
+    const row = rows.find((r) => r.deviceId === deviceId);
+    if (!row) return;
+    clearConflict(deviceId);
+    try {
+      const updated = await port.setCategory({
+        deviceId,
+        category,
+        expectedVersion: row.version,
+      });
+      row.tariffCategory = updated.tariffCategory;
+      row.version = updated.version;
+      // Reflect the committed category on the row (attribute drives styling).
+      const rowEl = body.querySelector<HTMLElement>(
+        `[data-devcat-row="${cssEscape(deviceId)}"]`
+      );
+      if (rowEl) rowEl.setAttribute('data-cat', updated.tariffCategory == null ? 'null' : updated.tariffCategory);
+    } catch (err) {
+      const isConflict =
+        err instanceof DeviceCategoryConflictError ||
+        (err as { code?: string })?.code === 'DEVICE_CATEGORY_VERSION_CONFLICT';
+      showConflict(
+        deviceId,
+        isConflict
+          ? 'Este dispositivo foi alterado por outra pessoa. Recarregue para ver a versão atual e reaplique.'
+          : `Não foi possível salvar: ${(err as Error)?.message || 'erro desconhecido'}`
+      );
+    }
+  }
+
+  /** Bulk-apply to the current selection: one `setCategoryBulk` if the port has it,
+   *  else N `setCategory` calls. Selection is preserved on conflict/failure. */
+  async function applyBulk(category: DeviceCategory): Promise<void> {
+    const ids = [...selected];
+    if (ids.length === 0) return;
+    if (typeof port.setCategoryBulk === 'function') {
+      const res = await port.setCategoryBulk({ deviceIds: ids, category });
+      const failedIds = new Set(res.failed.map((f) => f.deviceId));
+      for (const id of ids) {
+        const row = rows.find((r) => r.deviceId === id);
+        if (row && !failedIds.has(id)) {
+          row.tariffCategory = category;
+          if (row.version != null) row.version = String((Number(row.version) || 0) + 1);
+        }
+      }
+      for (const f of res.failed) showConflict(f.deviceId, `Falha: ${f.reason}`);
+    } else {
+      // Fallback: N independent single writes (each carries its own version).
+      await Promise.all(ids.map((id) => applySingle(id, category)));
+    }
+    render();
+  }
+
+  // --- toolbar wiring ------------------------------------------------------
+  const searchEl = root.querySelector<HTMLInputElement>('[data-devcat-search]')!;
+  const filterEl = root.querySelector<HTMLSelectElement>('[data-devcat-filter]')!;
+  filterEl.value = filter;
+  searchEl.addEventListener('input', () => {
+    search = searchEl.value;
+    render();
+  });
+  filterEl.addEventListener('change', () => {
+    filter = filterEl.value as DeviceCategoryFilter;
+    render();
+  });
+  selectAll.addEventListener('change', () => {
+    const vis = visibleRows();
+    if (selectAll.checked) vis.forEach((r) => selected.add(r.deviceId));
+    else vis.forEach((r) => selected.delete(r.deviceId));
+    render();
+  });
+  root
+    .querySelector<HTMLButtonElement>('[data-devcat-bulkapply]')!
+    .addEventListener('click', () => {
+      const bulkCat = root.querySelector<HTMLSelectElement>('[data-devcat-bulkcat]')!.value;
+      const category: DeviceCategory = bulkCat === '' ? null : (bulkCat as DeviceCategory);
+      void applyBulk(category);
+    });
+
+  // --- close ---------------------------------------------------------------
+  let closed = false;
+  function close(): void {
+    if (closed) return;
+    closed = true;
+    root.classList.remove('show');
+    doc.removeEventListener('keydown', escHandler);
+    const remove = (): void => {
+      if (root.parentNode) root.parentNode.removeChild(root);
+    };
+    if (typeof setTimeout === 'function') setTimeout(remove, 180);
+    else remove();
+    params.onClose?.();
+  }
+  function escHandler(e: KeyboardEvent): void {
+    if (e.key === 'Escape') close();
+  }
+  root.querySelector('[data-devcat-close]')?.addEventListener('click', close);
+  root.querySelector('[data-devcat-overlay]')?.addEventListener('click', close);
+  doc.addEventListener('keydown', escHandler);
+
+  // --- mount + initial load ------------------------------------------------
+  (doc.body || doc.documentElement).appendChild(root);
+  if (typeof requestAnimationFrame === 'function') {
+    requestAnimationFrame(() => root.classList.add('show'));
+  } else {
+    root.classList.add('show');
+  }
+
+  async function load(): Promise<void> {
+    body.innerHTML = `<div class="myio-devcat__empty">Carregando dispositivos…</div>`;
+    try {
+      rows = await port.listDevices({ customerId, domain: params.domain });
+    } catch (err) {
+      rows = [];
+      body.innerHTML = `<div class="myio-devcat__empty">Não foi possível carregar os dispositivos: ${esc(
+        (err as Error)?.message || 'erro'
+      )}</div>`;
+      countEl.textContent = '';
+      return;
+    }
+    render();
+  }
+
+  const ready = load();
+
+  return {
+    ready,
+    close,
+    getRoot: () => root,
+    refresh: () => load(),
+    getRows: () => rows.map((r) => ({ ...r })),
+    getVisibleDeviceIds: () => visibleRows().map((r) => r.deviceId),
+    setSearch: (text: string) => {
+      search = text;
+      searchEl.value = text;
+      render();
+    },
+    setCategoryFilter: (f: DeviceCategoryFilter) => {
+      filter = f;
+      filterEl.value = f;
+      render();
+    },
+  };
+}
+
+/**
+ * Wire A4's coverage deep-links to this panel. A4 (`renderCoverageView`) fires
+ * `onCategorizeDevice(deviceId)` per uncategorized device and `onManageCategories()`
+ * for the generic case; this helper turns both into an open of the A5a panel with
+ * the right `focusDeviceId`/filter, so the caller never re-implements the wiring.
+ *
+ * Documented usage (NOT a controller edit — just how a host composes A4 + A5a):
+ * ```ts
+ * import { renderCoverageView } from './coverageView';
+ * import { createCoverageDeepLink } from './deviceCategoryPanel';
+ * const links = createCoverageDeepLink({ port, customerId, domain: 'ENERGY' });
+ * overlay.appendChild(renderCoverageView(moneyOverlay, links));
+ * ```
+ */
+export function createCoverageDeepLink(config: {
+  port: DeviceCategoryPort;
+  customerId: string;
+  domain?: 'ENERGY' | 'WATER';
+  theme?: Record<string, string>;
+  document?: Document;
+}): {
+  onCategorizeDevice: (deviceId: string) => DeviceCategoryPanelHandle;
+  onManageCategories: () => DeviceCategoryPanelHandle;
+} {
+  const open = (
+    focusDeviceId?: string,
+    initialFilter?: DeviceCategoryFilter
+  ): DeviceCategoryPanelHandle =>
+    openDeviceCategoryPanel({
+      port: config.port,
+      customerId: config.customerId,
+      domain: config.domain,
+      focusDeviceId,
+      initialFilter,
+      theme: config.theme,
+      document: config.document,
+    });
+  return {
+    // Deep-link from one uncategorized device → open focused on it.
+    onCategorizeDevice: (deviceId: string) => open(deviceId),
+    // Generic "manage categories" → open pre-filtered to the uncategorized set.
+    onManageCategories: () => open(undefined, 'uncategorized'),
+  };
+}
+
+/** Minimal CSS.escape fallback for attribute selectors (device ids). */
+function cssEscape(s: string): string {
+  if (typeof (globalThis as { CSS?: { escape?: (v: string) => string } }).CSS?.escape === 'function') {
+    return (globalThis as { CSS: { escape: (v: string) => string } }).CSS.escape(s);
+  }
+  return String(s).replace(/["\\\]#.:>~+*^$|()[{}]/g, '\\$&');
+}

--- a/src/components/financial-goals/deviceCategoryPort.ts
+++ b/src/components/financial-goals/deviceCategoryPort.ts
@@ -1,0 +1,279 @@
+/**
+ * RFC-0228 A5a — the **device-category port** (the SEAM), plus test/demo fakes.
+ *
+ * ── WHY A SEAM (RFC-0228 feedback §5) ─────────────────────────────────────────
+ * The management UI (`deviceCategoryPanel.ts`) must NOT be coded against a
+ * presumed concrete device HTTP API. The GCDR device `tariffCategory` contract is
+ * item **B6** in the RFC-0228 index — it is *not built yet* (other repo). If A5a
+ * hard-wired a guessed request/response shape, it would rot the moment B6 lands.
+ *
+ * So the UI depends only on this small **injectable interface**. B6 later supplies
+ * a real implementation (`createHttpDeviceCategoryPort` below is a marked stub that
+ * *awaits* the B6 contract). Tests and the showcase use
+ * {@link createFakeDeviceCategoryPort} — an in-memory port with the same surface —
+ * so the whole component is exercised with **zero** live host calls.
+ *
+ * ── EXPLICIT CLASSIFICATION (RFC-0207 discipline) ─────────────────────────────
+ * A device's category is the **explicit** `tariffCategory` attribute and nothing
+ * else. The port never infers a category from a device's name/label, and neither
+ * does the UI. A device labeled "Loja 12" with `tariffCategory: null` is
+ * **uncategorized** until a human sets the attribute — never auto-`SPECIFIC`.
+ *
+ * ── VALUE SET ─────────────────────────────────────────────────────────────────
+ * The category value is exactly `COMMON_AREA | SPECIFIC | null` (GCDR
+ * API-Financial-Goals §6). It maps to the pricing panel's `area_comum`/`lojas`
+ * terms through A1's centralized map (`tariffApiAdapter.ts`) — the UI reuses that
+ * map and never re-string-matches these tokens.
+ *
+ * Pure & framework-agnostic: no DOM, no ThingsBoard.
+ */
+
+import type { WireCategory } from '../pricing-panel/tariffApiClient';
+
+/**
+ * The device tariff category — the explicit attribute B6 stores per device.
+ * `COMMON_AREA`/`SPECIFIC` reuse the frozen WIRE category tokens (RFC-0054);
+ * `null` means **uncategorized** (excluded from money sums until set).
+ */
+export type DeviceCategory = WireCategory | null;
+
+/** One device row as the port exposes it to the UI. */
+export interface DeviceCategoryRow {
+  /** Stable device identifier (GCDR device id). */
+  deviceId: string;
+  /** Short human code/identifier (e.g. `"SCP-041"`), optional. */
+  code?: string;
+  /** Human label (e.g. `"Loja 12 — Piso L2"`), optional. Display only — NEVER a
+   *  classification input (RFC-0207: category comes from `tariffCategory`, not name). */
+  label?: string;
+  /** The EXPLICIT category attribute. `null` = uncategorized. */
+  tariffCategory: DeviceCategory;
+  /** Optimistic-concurrency token echoed back on writes as `expectedVersion`. */
+  version?: string;
+}
+
+/**
+ * The SEAM the UI depends on. B6 (gcdr) implements this over HTTP; tests/demo use
+ * {@link createFakeDeviceCategoryPort}. Keeping the interface tiny is deliberate —
+ * it is the *entire* contract B6 must satisfy, nothing more.
+ */
+export interface DeviceCategoryPort {
+  /** List a customer's devices (optionally scoped to one money domain). */
+  listDevices(args: {
+    customerId: string;
+    domain?: 'ENERGY' | 'WATER';
+  }): Promise<DeviceCategoryRow[]>;
+
+  /**
+   * Set (or clear, with `null`) one device's explicit category. `expectedVersion`
+   * carries the row's last-seen version for optimistic concurrency; a stale write
+   * MUST reject (the UI surfaces the conflict without losing other edits).
+   * Returns the updated row (new `version`).
+   */
+  setCategory(args: {
+    deviceId: string;
+    category: DeviceCategory;
+    expectedVersion?: string;
+  }): Promise<DeviceCategoryRow>;
+
+  /**
+   * OPTIONAL bulk write. When absent, the UI falls back to N {@link setCategory}
+   * calls. Returns a per-device outcome so partial failures surface honestly.
+   */
+  setCategoryBulk?(args: {
+    deviceIds: string[];
+    category: DeviceCategory;
+  }): Promise<{ updated: number; failed: Array<{ deviceId: string; reason: string }> }>;
+}
+
+/** Error a port throws (or resolves-as-failure) on an optimistic-concurrency clash. */
+export class DeviceCategoryConflictError extends Error {
+  readonly deviceId: string;
+  readonly code = 'DEVICE_CATEGORY_VERSION_CONFLICT';
+  constructor(deviceId: string, message?: string) {
+    super(message || `Version conflict for device ${deviceId}`);
+    this.name = 'DeviceCategoryConflictError';
+    this.deviceId = deviceId;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// In-memory fake — the ONLY port tests/demo rely on. No HTTP, no host.
+// ---------------------------------------------------------------------------
+
+/** Seed row for {@link createFakeDeviceCategoryPort}. */
+export interface FakeDeviceSeed {
+  deviceId: string;
+  code?: string;
+  label?: string;
+  tariffCategory?: DeviceCategory;
+  version?: string;
+  /** Optional domain tag so `listDevices({domain})` can filter the fake. */
+  domain?: 'ENERGY' | 'WATER';
+}
+
+export interface FakeDeviceCategoryPortOptions {
+  /**
+   * If `true`, the fake exposes `setCategoryBulk`. If `false`/omitted, the bulk
+   * method is absent so the UI's N-call fallback path is exercised. Default `true`.
+   */
+  supportsBulk?: boolean;
+  /**
+   * Optional latency (ms) injected before each resolve, to exercise loading UX.
+   * Default `0` (synchronous microtask).
+   */
+  latencyMs?: number;
+}
+
+interface FakeInternalRow extends DeviceCategoryRow {
+  domain?: 'ENERGY' | 'WATER';
+  _v: number;
+}
+
+/**
+ * Build an in-memory {@link DeviceCategoryPort}. Versions are monotonic integers
+ * stringified; a `setCategory` whose `expectedVersion` no longer matches rejects
+ * with {@link DeviceCategoryConflictError}. Bump a row's version out-of-band via
+ * {@link FakeDeviceCategoryPortHandle.bumpVersion} to simulate a concurrent edit.
+ */
+export interface FakeDeviceCategoryPortHandle extends DeviceCategoryPort {
+  /** Read the current in-memory rows (deep-ish copy). */
+  snapshot(): DeviceCategoryRow[];
+  /** Force a version bump on a device (simulates someone else editing it). */
+  bumpVersion(deviceId: string): void;
+}
+
+export function createFakeDeviceCategoryPort(
+  seed: FakeDeviceSeed[] = [],
+  options: FakeDeviceCategoryPortOptions = {}
+): FakeDeviceCategoryPortHandle {
+  const supportsBulk = options.supportsBulk !== false;
+  const latency = Math.max(0, options.latencyMs || 0);
+
+  const rows = new Map<string, FakeInternalRow>();
+  for (const s of seed) {
+    const v = s.version != null ? Number(s.version) || 0 : 0;
+    rows.set(s.deviceId, {
+      deviceId: s.deviceId,
+      code: s.code,
+      label: s.label,
+      tariffCategory: s.tariffCategory ?? null,
+      version: String(v),
+      domain: s.domain,
+      _v: v,
+    });
+  }
+
+  const delay = <T>(value: T): Promise<T> =>
+    latency > 0
+      ? new Promise((res) => setTimeout(() => res(value), latency))
+      : Promise.resolve(value);
+
+  const toRow = (r: FakeInternalRow): DeviceCategoryRow => ({
+    deviceId: r.deviceId,
+    code: r.code,
+    label: r.label,
+    tariffCategory: r.tariffCategory,
+    version: r.version,
+  });
+
+  const port: FakeDeviceCategoryPortHandle = {
+    listDevices(args) {
+      const list = [...rows.values()]
+        .filter((r) => !args.domain || !r.domain || r.domain === args.domain)
+        .map(toRow);
+      return delay(list);
+    },
+
+    setCategory(args) {
+      const r = rows.get(args.deviceId);
+      if (!r) {
+        return Promise.reject(new Error(`Unknown device ${args.deviceId}`));
+      }
+      if (args.expectedVersion != null && args.expectedVersion !== r.version) {
+        return Promise.reject(
+          new DeviceCategoryConflictError(
+            args.deviceId,
+            `Version conflict: expected ${args.expectedVersion}, current ${r.version}`
+          )
+        );
+      }
+      r.tariffCategory = args.category;
+      r._v += 1;
+      r.version = String(r._v);
+      return delay(toRow(r));
+    },
+
+    snapshot() {
+      return [...rows.values()].map(toRow);
+    },
+
+    bumpVersion(deviceId) {
+      const r = rows.get(deviceId);
+      if (!r) return;
+      r._v += 1;
+      r.version = String(r._v);
+    },
+  };
+
+  if (supportsBulk) {
+    port.setCategoryBulk = (args) => {
+      const failed: Array<{ deviceId: string; reason: string }> = [];
+      let updated = 0;
+      for (const id of args.deviceIds) {
+        const r = rows.get(id);
+        if (!r) {
+          failed.push({ deviceId: id, reason: 'UNKNOWN_DEVICE' });
+          continue;
+        }
+        r.tariffCategory = args.category;
+        r._v += 1;
+        r.version = String(r._v);
+        updated += 1;
+      }
+      return delay({ updated, failed });
+    };
+  }
+
+  return port;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP stub — AWAITS THE B6 CONTRACT. Not used by tests. Not a real client.
+// ---------------------------------------------------------------------------
+
+/** Config the future B6-backed HTTP port will need. Shape is provisional. */
+export interface HttpDeviceCategoryPortConfig {
+  baseUrl: string;
+  apiKey?: string;
+  jwt?: string;
+  tenantId?: string;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * ⚠️ **AWAITS B6 CONTRACT — DO NOT RELY ON THIS.** This is a placeholder so callers
+ * can see where the real GCDR device-tariffCategory client will plug in. The exact
+ * endpoints, RBAC, auditing and bulk semantics are defined by RFC-0228 **B6**
+ * (gcdr repo) and are NOT settled here. Until B6 lands, every method throws. Tests
+ * and the showcase MUST use {@link createFakeDeviceCategoryPort} instead.
+ */
+export function createHttpDeviceCategoryPort(
+  config: HttpDeviceCategoryPortConfig
+): DeviceCategoryPort {
+  void config;
+  // Reject (don't sync-throw) so consumers awaiting the port see a normal
+  // rejection — the interface is Promise-returning end to end.
+  const notReady = <T>(): Promise<T> =>
+    Promise.reject(
+      new Error(
+        'createHttpDeviceCategoryPort: the GCDR device tariffCategory API (RFC-0228 B6) ' +
+          'is not implemented yet. Inject createFakeDeviceCategoryPort for now, or a real ' +
+          'DeviceCategoryPort once B6 ships.'
+      )
+    );
+  return {
+    listDevices: () => notReady<DeviceCategoryRow[]>(),
+    setCategory: () => notReady<DeviceCategoryRow>(),
+  };
+}

--- a/src/components/financial-goals/deviceCategoryStyles.ts
+++ b/src/components/financial-goals/deviceCategoryStyles.ts
@@ -1,0 +1,274 @@
+/**
+ * RFC-0228 A5a — device tariff-category management panel styles.
+ *
+ * Idempotent, id-guarded injection (mirrors `injectCoverageStyles` and the
+ * pricing-panel idiom). Premium modal shell: overlay + centered card, Nunito,
+ * theme-aware via `--myio-*` custom properties with a `prefers-color-scheme: dark`
+ * fallback and host `data-theme` overrides that win in both directions.
+ */
+
+export const DEVICE_CATEGORY_STYLE_ID = 'myio-fin-device-category-styles';
+
+const DEVICE_CATEGORY_CSS = `
+  .myio-devcat {
+    --_dc-bg: var(--myio-bg, #ffffff);
+    --_dc-card: var(--myio-card, #f8fafc);
+    --_dc-text: var(--myio-text, #1f2937);
+    --_dc-muted: var(--myio-text-muted, #6b7280);
+    --_dc-border: var(--myio-border, #e5e7eb);
+    --_dc-brand: var(--myio-brand-700, #5b2c9d);
+    --_dc-brand-soft: var(--myio-brand-100, #efe7fb);
+    --_dc-danger-bg: #fef2f2;
+    --_dc-danger-border: #fecaca;
+    --_dc-danger-text: #991b1b;
+    --_dc-focus-bg: #fffbeb;
+    --_dc-focus-border: #f59e0b;
+    position: fixed;
+    inset: 0;
+    z-index: 2147483000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: 'Nunito', system-ui, -apple-system, sans-serif;
+    color: var(--_dc-text);
+    opacity: 0;
+    transition: opacity 0.18s ease;
+  }
+  .myio-devcat.show { opacity: 1; }
+
+  .myio-devcat__overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.55);
+    backdrop-filter: blur(2px);
+  }
+
+  .myio-devcat__card {
+    position: relative;
+    width: min(760px, 94vw);
+    max-height: 90vh;
+    display: flex;
+    flex-direction: column;
+    background: var(--_dc-bg);
+    border: 1px solid var(--_dc-border);
+    border-radius: 16px;
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.35);
+    overflow: hidden;
+  }
+
+  .myio-devcat__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--_dc-border);
+    background: var(--_dc-card);
+  }
+  .myio-devcat__title {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: 800;
+    font-size: 16px;
+    margin: 0;
+  }
+  .myio-devcat__close {
+    border: none;
+    background: transparent;
+    color: var(--_dc-muted);
+    font-size: 22px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 8px;
+  }
+  .myio-devcat__close:hover { background: var(--_dc-border); color: var(--_dc-text); }
+
+  .myio-devcat__toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+    padding: 12px 20px;
+    border-bottom: 1px solid var(--_dc-border);
+  }
+  .myio-devcat__search {
+    flex: 1 1 200px;
+    min-width: 140px;
+    padding: 8px 12px;
+    border: 1px solid var(--_dc-border);
+    border-radius: 8px;
+    background: var(--_dc-bg);
+    color: var(--_dc-text);
+    font-family: inherit;
+    font-size: 13px;
+  }
+  .myio-devcat__filter {
+    padding: 8px 12px;
+    border: 1px solid var(--_dc-border);
+    border-radius: 8px;
+    background: var(--_dc-bg);
+    color: var(--_dc-text);
+    font-family: inherit;
+    font-size: 13px;
+    cursor: pointer;
+  }
+
+  .myio-devcat__bulkbar {
+    display: none;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 10px;
+    padding: 10px 20px;
+    background: var(--_dc-brand-soft);
+    border-bottom: 1px solid var(--_dc-border);
+    font-size: 13px;
+    font-weight: 700;
+  }
+  .myio-devcat__bulkbar.show { display: flex; }
+  .myio-devcat__bulkbar select {
+    padding: 6px 10px;
+    border: 1px solid var(--_dc-border);
+    border-radius: 8px;
+    background: var(--_dc-bg);
+    color: var(--_dc-text);
+    font-family: inherit;
+    font-size: 13px;
+  }
+  .myio-devcat__bulk-apply {
+    padding: 6px 14px;
+    border: none;
+    border-radius: 8px;
+    background: var(--_dc-brand);
+    color: #fff;
+    font-family: inherit;
+    font-weight: 800;
+    font-size: 13px;
+    cursor: pointer;
+  }
+  .myio-devcat__bulk-apply:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  .myio-devcat__body {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    padding: 6px 0;
+  }
+  .myio-devcat__empty {
+    padding: 40px 20px;
+    text-align: center;
+    color: var(--_dc-muted);
+    font-size: 14px;
+  }
+
+  .myio-devcat__row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 20px;
+    border-bottom: 1px solid var(--_dc-border);
+  }
+  .myio-devcat__row[data-focused="1"] {
+    background: var(--_dc-focus-bg);
+    box-shadow: inset 3px 0 0 var(--_dc-focus-border);
+  }
+  .myio-devcat__row-check { flex: 0 0 auto; width: 16px; height: 16px; cursor: pointer; }
+  .myio-devcat__row-main { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+  .myio-devcat__row-label {
+    font-weight: 700;
+    font-size: 14px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .myio-devcat__row-code {
+    font-size: 12px;
+    color: var(--_dc-muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .myio-devcat__row-select {
+    flex: 0 0 auto;
+    padding: 7px 10px;
+    border: 1px solid var(--_dc-border);
+    border-radius: 8px;
+    background: var(--_dc-bg);
+    color: var(--_dc-text);
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 700;
+    cursor: pointer;
+  }
+  .myio-devcat__row[data-cat="null"] .myio-devcat__row-select { color: var(--_dc-muted); }
+  .myio-devcat__row-conflict {
+    display: none;
+    flex: 1 1 100%;
+    margin-top: 6px;
+    padding: 7px 12px;
+    border-radius: 8px;
+    background: var(--_dc-danger-bg);
+    border: 1px solid var(--_dc-danger-border);
+    color: var(--_dc-danger-text);
+    font-size: 12px;
+    font-weight: 700;
+  }
+  .myio-devcat__row[data-conflict="1"] { flex-wrap: wrap; }
+  .myio-devcat__row[data-conflict="1"] .myio-devcat__row-conflict { display: block; }
+
+  .myio-devcat__footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px 20px;
+    border-top: 1px solid var(--_dc-border);
+    background: var(--_dc-card);
+    font-size: 12px;
+    color: var(--_dc-muted);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .myio-devcat {
+      --_dc-bg: var(--myio-bg, #0f172a);
+      --_dc-card: var(--myio-card, #1e293b);
+      --_dc-text: var(--myio-text, #e2e8f0);
+      --_dc-muted: var(--myio-text-muted, #94a3b8);
+      --_dc-border: var(--myio-border, #334155);
+      --_dc-brand: var(--myio-brand-700, #a78bfa);
+      --_dc-brand-soft: var(--myio-brand-100, #2a2350);
+      --_dc-danger-bg: #3a1414; --_dc-danger-border: #7f1d1d; --_dc-danger-text: #fca5a5;
+      --_dc-focus-bg: #3a2e0a; --_dc-focus-border: #b45309;
+    }
+  }
+  :root[data-theme="dark"] .myio-devcat {
+    --_dc-bg: var(--myio-bg, #0f172a);
+    --_dc-card: var(--myio-card, #1e293b);
+    --_dc-text: var(--myio-text, #e2e8f0);
+    --_dc-muted: var(--myio-text-muted, #94a3b8);
+    --_dc-border: var(--myio-border, #334155);
+    --_dc-brand: var(--myio-brand-700, #a78bfa);
+    --_dc-brand-soft: var(--myio-brand-100, #2a2350);
+    --_dc-danger-bg: #3a1414; --_dc-danger-border: #7f1d1d; --_dc-danger-text: #fca5a5;
+    --_dc-focus-bg: #3a2e0a; --_dc-focus-border: #b45309;
+  }
+  :root[data-theme="light"] .myio-devcat {
+    --_dc-bg: var(--myio-bg, #ffffff);
+    --_dc-card: var(--myio-card, #f8fafc);
+    --_dc-text: var(--myio-text, #1f2937);
+    --_dc-muted: var(--myio-text-muted, #6b7280);
+    --_dc-border: var(--myio-border, #e5e7eb);
+    --_dc-brand: var(--myio-brand-700, #5b2c9d);
+    --_dc-brand-soft: var(--myio-brand-100, #efe7fb);
+    --_dc-danger-bg: #fef2f2; --_dc-danger-border: #fecaca; --_dc-danger-text: #991b1b;
+    --_dc-focus-bg: #fffbeb; --_dc-focus-border: #f59e0b;
+  }
+`;
+
+/** Inject the panel stylesheet once per document (id-guarded, idempotent). */
+export function injectDeviceCategoryStyles(doc: Document): void {
+  if (!doc || !doc.head) return;
+  if (doc.getElementById(DEVICE_CATEGORY_STYLE_ID)) return;
+  const style = doc.createElement('style');
+  style.id = DEVICE_CATEGORY_STYLE_ID;
+  style.textContent = DEVICE_CATEGORY_CSS;
+  doc.head.appendChild(style);
+}

--- a/src/components/financial-goals/financialIndicators.ts
+++ b/src/components/financial-goals/financialIndicators.ts
@@ -1,0 +1,340 @@
+/**
+ * RFC-0228 A2a — The R$ money overlay row for one shopping card (pilot).
+ *
+ * Given the existing **quantity** KPIs of a Metas × Consumo card (A-1 / Realizado
+ * / Orçado / Meta in kWh/m³) and a normalized {@link MoneyOverlay} (F0,
+ * `moneyTypes.ts`), this renderer produces the **parallel R$ view** for that one
+ * card:
+ *
+ *  - When money coverage is honest and complete (`available` +
+ *    `coverageComplete:true`): a **R$ row** — Realizado / Orçado / Meta em R$
+ *    (decimal strings via {@link formatBRL}) — plus a **deviation chip in R$**
+ *    (Realizado vs Meta, falling back to vs A-1), signed/coloured exactly like the
+ *    card's kWh/m³ deviation chip (↑ over = red, ↓ under = green, ≈ = grey).
+ *  - When coverage is `unavailable` **or** `coverageComplete:false`: it **defers to
+ *    A4** ({@link renderCoverageView}) and shows the honest coverage state instead
+ *    of any R$ number. It **never invents `R$ 0`** and **never prints a total** over
+ *    a partial projection (GCDR RFC-0054 DEC-6; API guide §4.2).
+ *  - When there is **no overlay** (money source not configured / gate off): it
+ *    returns `null` — the caller appends nothing and the card stays byte-identical
+ *    to the kWh-only view.
+ *
+ * The A5a deep-link callbacks (`onCategorizeDevice`, `onManageCategories`) are
+ * passed straight through to A4.
+ *
+ * ── WORDING CONTRACT (RFC-0228 feedback §8) ─────────────────────────────────────
+ * This is coverage/estimation UX, not billing. The R$ row labels itself
+ * "Estimativa em R$"; the incomplete/unavailable states reuse A4, which already
+ * enforces the no-"fatura"/"faturamento"/"valor final" wording. Do not introduce a
+ * billing-grade word here.
+ * ───────────────────────────────────────────────────────────────────────────────
+ *
+ * Design rules (mirroring F0/A4 on this branch):
+ *  - **Pure component.** DOM/HTML output + inputs/callbacks only. No `fetch`, no
+ *    ThingsBoard, no API calls. It receives a `MoneyOverlay`; it never fetches one.
+ *  - **Amounts are decimal STRINGS.** The only `Number()` is inside the deviation
+ *    percent (reused from F0 `computeDeltaPct`) — a derived display metric. The R$
+ *    row amounts are formatted string-in / string-out ({@link formatBRL}),
+ *    never round-tripped through a float.
+ *  - **Never `R$ 0`, never `NaN`.** A missing amount renders `—` (F0 `DASH`).
+ */
+
+import type { MoneyOverlay } from './moneyTypes';
+import { renderCoverageView, type CoverageViewOptions } from './coverageView';
+import {
+  DASH,
+  formatBRL,
+  formatBRLDelta,
+  formatDeltaPct,
+  computeDeltaPct,
+} from './moneyFormat';
+
+/**
+ * The R$ amounts for a card's money row, each a **decimal string** (`"223000.00"`)
+ * or `null`/absent when unknown. Sourced from the overlay's `monetaryValue`s /
+ * `money`/`budget` block by the caller (or derived by
+ * {@link resolveMoneyRowValues}). A missing value renders `—`, never `R$ 0`.
+ */
+export interface FinancialMoneyValues {
+  /** Realizado em R$ (realized consumption priced). Optional — goal overlays may not carry it. */
+  realized?: string | null;
+  /** Orçado em R$. Defaults to `overlay.budget.projected.amount` when omitted. */
+  orcado?: string | null;
+  /** Meta em R$ (native CURRENCY target). Defaults to `overlay.budget.target.amount` when omitted. */
+  meta?: string | null;
+  /** A-1 em R$ (previous-year realized priced). Optional. */
+  prevYear?: string | null;
+}
+
+/** Per-role chip palette (defaults mirror the Metas × Consumo `devChip`). */
+export interface FinancialChipColors {
+  /** Realizado > reference (spending over): red by default. */
+  overBg?: string;
+  overText?: string;
+  /** Realizado < reference (spending under): green by default. */
+  underBg?: string;
+  underText?: string;
+  /** ~equal / no data: grey by default. */
+  neutralBg?: string;
+  neutralText?: string;
+}
+
+/** Per-role value colours for the three R$ figures (label/number tint). */
+export interface FinancialValueColors {
+  realized?: string;
+  orcado?: string;
+  meta?: string;
+  prevYear?: string;
+}
+
+/** Options for {@link renderFinancialIndicators}. */
+export interface FinancialIndicatorsOptions {
+  /**
+   * The normalized money overlay for this card (F0). Drives the gate:
+   *  - `null`/`undefined` → renderer returns `null` (money off → no R$ row).
+   *  - `unavailable` / `available`+`coverageComplete:false` → A4 coverage view.
+   *  - `available`+`coverageComplete:true` → the R$ row.
+   */
+  overlay: MoneyOverlay | null | undefined;
+  /**
+   * Explicit R$ amounts (decimal strings). When omitted for `orcado`/`meta`, they
+   * are derived from `overlay.budget`. `realized`/`prevYear` are only shown when
+   * given (a goal `withMoney` read does not carry realized R$).
+   */
+  money?: FinancialMoneyValues;
+  /**
+   * Deviation-chip reference: `'meta'` (default; falls back to `'prevYear'` when
+   * Meta em R$ is absent) or `'prevYear'`.
+   */
+  chipBaseline?: 'meta' | 'prevYear';
+  /** Chip palette override (defaults mirror the card's kWh chip). */
+  chipColors?: FinancialChipColors;
+  /** Value-figure colour override (defaults: Realizado blue, Orçado orange, Meta purple). */
+  valueColors?: FinancialValueColors;
+  /** A5a per-device deep-link, passed through to A4 in the incomplete state. */
+  onCategorizeDevice?: (deviceId: string) => void;
+  /** A5a generic deep-link, passed through to A4 in the unavailable state. */
+  onManageCategories?: () => void;
+  /** Document to build in (defaults to the ambient `document`). */
+  document?: Document;
+}
+
+/** Default chip palette — identical hues to the Metas × Consumo `devChip`. */
+const DEFAULT_CHIP: Required<FinancialChipColors> = {
+  overBg: '#fee2e2',
+  overText: '#b91c1c',
+  underBg: '#dcfce7',
+  underText: '#15803d',
+  neutralBg: '#f1f5f9',
+  neutralText: '#64748b',
+};
+
+/** Default value hues — Realizado blue, Orçado orange, Meta purple, A-1 grey. */
+const DEFAULT_VALUE_COLORS: Required<FinancialValueColors> = {
+  realized: '#2563eb',
+  orcado: '#f59e0b',
+  meta: '#7c3aed',
+  prevYear: '#94a3b8',
+};
+
+/** |pct| below this reads as "≈" (neutral) — parallel to the kWh chip. */
+const APPROX_PCT = 1;
+
+/** A decimal string is "present" when it is a non-empty, non-null string. */
+function hasAmount(s: string | null | undefined): s is string {
+  return typeof s === 'string' && s.trim() !== '';
+}
+
+/**
+ * Resolve the three R$ figures for the row: explicit `money.*` wins; otherwise
+ * `orcado` ← `overlay.budget.projected.amount` and `meta` ← `overlay.budget.target.amount`.
+ * `realized`/`prevYear` come only from `money` (a goal overlay carries no realized R$).
+ * Pure — decimal strings pass through verbatim, never `Number()`-ed.
+ */
+export function resolveMoneyRowValues(
+  overlay: MoneyOverlay | null | undefined,
+  money?: FinancialMoneyValues
+): Required<FinancialMoneyValues> {
+  const budget =
+    overlay && overlay.state === 'available' ? overlay.budget : undefined;
+  const orcado = hasAmount(money?.orcado)
+    ? (money!.orcado as string)
+    : hasAmount(budget?.projected?.amount)
+    ? (budget!.projected.amount as string)
+    : null;
+  const meta = hasAmount(money?.meta)
+    ? (money!.meta as string)
+    : hasAmount(budget?.target?.amount)
+    ? (budget!.target!.amount as string)
+    : null;
+  return {
+    realized: hasAmount(money?.realized) ? (money!.realized as string) : null,
+    orcado,
+    meta,
+    prevYear: hasAmount(money?.prevYear) ? (money!.prevYear as string) : null,
+  };
+}
+
+const CHIP_BASE =
+  'border-radius:999px;padding:2px 10px;font:700 11px Nunito,sans-serif;white-space:nowrap;';
+
+/**
+ * Build the deviation chip (Realizado vs reference) from two R$ decimal strings.
+ * Arrow + percent, coloured by sign exactly like the card's kWh chip: ↑ over = red,
+ * ↓ under = green, ≈ (|pct|<1) / missing = grey. The signed R$ delta rides in the
+ * `title`. Returns an HTML string. `computeDeltaPct` is the single allowed
+ * `Number()` (a display metric); the R$ amounts stay strings.
+ */
+function chipHTML(
+  realized: string | null,
+  reference: string | null,
+  colors: Required<FinancialChipColors>
+): string {
+  const pct = computeDeltaPct(realized, reference);
+  if (pct == null) {
+    return `<span data-fin-chip="none" style="background:${colors.neutralBg};color:${colors.neutralText};${CHIP_BASE}">${DASH}</span>`;
+  }
+  const deltaAmount =
+    hasAmount(realized) && hasAmount(reference)
+      ? formatBRLDelta(subtractDecimals(realized, reference))
+      : DASH;
+  const pctTxt = formatDeltaPct(pct);
+  if (Math.abs(pct) < APPROX_PCT) {
+    return `<span data-fin-chip="approx" title="${deltaAmount}" style="background:${colors.neutralBg};color:${colors.neutralText};${CHIP_BASE}">&#8776; ${pctTxt}</span>`;
+  }
+  if (pct > 0) {
+    return `<span data-fin-chip="over" title="${deltaAmount}" style="background:${colors.overBg};color:${colors.overText};${CHIP_BASE}">&#8593; ${pctTxt}</span>`;
+  }
+  return `<span data-fin-chip="under" title="${deltaAmount}" style="background:${colors.underBg};color:${colors.underText};${CHIP_BASE}">&#8595; ${pctTxt}</span>`;
+}
+
+/** Parse a decimal string into integer cents (half-up on the 3rd digit), or null. */
+function parseCents(s: string | null | undefined): number | null {
+  if (!hasAmount(s)) return null;
+  const m = /^([+-]?)(\d+)(?:\.(\d+))?$/.exec(s.trim());
+  if (!m) return null;
+  const sign = m[1] === '-' ? -1 : 1;
+  const whole = Number(m[2]);
+  const frac = (m[3] || '').padEnd(3, '0');
+  let cents = Number(frac.slice(0, 2));
+  if (frac.charAt(2) >= '5') cents += 1;
+  const total = whole * 100 + cents;
+  return Number.isFinite(total) ? sign * total : null;
+}
+
+/**
+ * Subtract two decimal strings and return a decimal string (`"1234.56"`), used only
+ * for the chip's title/tooltip R$ delta. Pure cents math (2dp, sign preserved) —
+ * no float round-trip on the amounts. Returns `null` on invalid input.
+ */
+export function subtractDecimals(
+  a: string | null | undefined,
+  b: string | null | undefined
+): string | null {
+  const pa = parseCents(a);
+  const pb = parseCents(b);
+  if (pa == null || pb == null) return null;
+  const diff = pa - pb; // BRL cents for a panel sum are well within MAX_SAFE_INTEGER
+  const neg = diff < 0;
+  const abs = Math.abs(diff);
+  const intPart = Math.trunc(abs / 100);
+  const cents = String(abs % 100).padStart(2, '0');
+  return `${neg ? '-' : ''}${intPart}.${cents}`;
+}
+
+/** One R$ figure cell: coloured label + formatted amount (or `—`). */
+function figureHTML(label: string, amount: string | null, color: string): string {
+  return (
+    `<span style="display:inline-flex;align-items:center;gap:4px;white-space:nowrap;">` +
+    `<span style="color:${color};font-weight:700;">${label}</span>` +
+    `<b style="color:var(--gc-text2, #334155);font-weight:700;">${formatBRL(amount)}</b>` +
+    `</span>`
+  );
+}
+
+/**
+ * Build the R$ row (available + complete state) as an HTML **string** (pure — no
+ * DOM). Realizado / Orçado / Meta em R$ + the deviation chip. Directly testable.
+ */
+export function buildFinancialRowHTML(
+  values: Required<FinancialMoneyValues>,
+  chipBaseline: 'meta' | 'prevYear',
+  chipColors: Required<FinancialChipColors>,
+  valueColors: Required<FinancialValueColors>
+): string {
+  const reference =
+    chipBaseline === 'prevYear'
+      ? values.prevYear
+      : hasAmount(values.meta)
+      ? values.meta
+      : values.prevYear;
+  const figures = [
+    figureHTML('Realizado', values.realized, valueColors.realized),
+    figureHTML('Orçado', values.orcado, valueColors.orcado),
+    figureHTML('Meta', values.meta, valueColors.meta),
+  ].join('');
+  return (
+    `<div class="myio-fin__row" data-fin-row="1" style="display:flex;align-items:center;justify-content:space-between;gap:8px;">` +
+    `<div style="font:600 11px Nunito,sans-serif;color:var(--gc-muted, #64748b);display:flex;align-items:center;gap:8px;flex-wrap:wrap;min-width:0;">` +
+    `<span aria-hidden="true">💰</span>` +
+    figures +
+    `</div>` +
+    chipHTML(values.realized, reference, chipColors) +
+    `</div>` +
+    `<div class="myio-fin__note" style="font:600 10px Nunito,sans-serif;color:var(--gc-muted, #94a3b8);margin-top:2px;">Estimativa em R$</div>`
+  );
+}
+
+/**
+ * Render the R$ money view for one shopping card as a live DOM element — or `null`
+ * when there is no overlay (money off).
+ *
+ * - No overlay → `null` (caller appends nothing; card unchanged).
+ * - `unavailable` / `available`+`coverageComplete:false` → **A4**
+ *   {@link renderCoverageView} (honest coverage; never R$ numbers, never R$ 0).
+ * - `available`+`coverageComplete:true` → the R$ row (Realizado/Orçado/Meta em R$
+ *   + deviation chip). The element carries `data-fin-state="available-money"`.
+ */
+export function renderFinancialIndicators(
+  options: FinancialIndicatorsOptions
+): HTMLElement | null {
+  const overlay = options?.overlay;
+  // Gate: no overlay (money source not configured / not resolved) → no R$ row.
+  if (!overlay || typeof (overlay as { state?: unknown }).state !== 'string') {
+    return null;
+  }
+
+  const doc =
+    options.document || (typeof document !== 'undefined' ? document : undefined);
+  if (!doc) {
+    throw new Error(
+      'renderFinancialIndicators requires a document (pass options.document in non-DOM envs).'
+    );
+  }
+
+  const coverageOpts: CoverageViewOptions = {
+    onCategorizeDevice: options.onCategorizeDevice,
+    onManageCategories: options.onManageCategories,
+    document: doc,
+  };
+
+  // Defer to A4 for every non-confident state — unavailable OR partial coverage.
+  if (overlay.state === 'unavailable' || overlay.coverageComplete !== true) {
+    return renderCoverageView(overlay, coverageOpts);
+  }
+
+  // available + coverageComplete: the R$ row.
+  const values = resolveMoneyRowValues(overlay, options.money);
+  const chipColors: Required<FinancialChipColors> = { ...DEFAULT_CHIP, ...options.chipColors };
+  const valueColors: Required<FinancialValueColors> = {
+    ...DEFAULT_VALUE_COLORS,
+    ...options.valueColors,
+  };
+  const chipBaseline = options.chipBaseline === 'prevYear' ? 'prevYear' : 'meta';
+
+  const root = doc.createElement('div');
+  root.className = 'myio-fin';
+  root.setAttribute('data-fin-state', 'available-money');
+  root.innerHTML = buildFinancialRowHTML(values, chipBaseline, chipColors, valueColors);
+  return root;
+}

--- a/src/components/financial-goals/goalsMoneyClient.ts
+++ b/src/components/financial-goals/goalsMoneyClient.ts
@@ -1,0 +1,325 @@
+/**
+ * RFC-0228 F0 — Thin, typed client for the **money side of goals** (GCDR
+ * RFC-0054; contract in `gcdr.git/docs/api/API-Financial-Goals.md`, frozen).
+ *
+ * Sits beside the A1 tariff client and mirrors its style exactly:
+ *   GET    /customers/:id/goals?domain=&year=&granularity=&withMoney=true   (money overlay)
+ *   GET    /customers/:id/goals?domain=&year=&measure=CURRENCY              (native budget read)
+ *   PUT    /customers/:id/goals?domain=&year=&measure=CURRENCY              (set budget)
+ *   DELETE /customers/:id/goals?domain=&year=&measure=CURRENCY              (delete budget)
+ *
+ * Design rules (identical to `tariffApiClient` on this branch):
+ *  - **Pure / framework-agnostic.** No DOM, no ThingsBoard. `fetch` is injected
+ *    (defaults to `globalThis.fetch`) so it is unit-testable with a mock.
+ *  - **Never converts money to `Number`.** `monetaryValue`, `amount`, and the
+ *    budget tree ride as decimal strings, preserved verbatim (`"223000.00"`).
+ *  - **Coverage is a value, not an error.** The money overlay is run through
+ *    `normalizeMoneyBlock`; `unavailable`/`coverageComplete:false` are normal
+ *    200-body outcomes, never thrown (API guide §7).
+ *  - **Optimistic concurrency.** Writes send the guard via `If-Match: "<v>"`
+ *    AND body `expectedVersion` (equal values); `409 GOAL_VERSION_CONFLICT`
+ *    surfaces `currentVersion` instead of being swallowed.
+ *  - **Errors surface the stable `code`, never the message** (§7 taxonomy).
+ */
+
+import {
+  type MoneyDomain,
+  type MonetaryProjection,
+  type GoalTreeNode,
+  type RawMoneyBlock,
+  type RawBudgetBlock,
+  normalizeMoneyBlock,
+} from './moneyTypes';
+
+/** Goal money granularity for reads. `month` is a common overlay grain. */
+export type GoalGranularity = 'year' | 'month' | 'day' | 'hour';
+
+/** Selects a single money-capable goal `(customer × domain × year)`. */
+export interface GoalSelector {
+  customerId: string;
+  domain: MoneyDomain;
+  year: number;
+}
+
+/** A native CURRENCY budget read (the R$ target goal, `measure=CURRENCY`). */
+export interface CurrencyBudgetResponse {
+  customerId: string;
+  domain: MoneyDomain;
+  year: number;
+  measure: 'CURRENCY';
+  currency?: string;
+  /** Optimistic-concurrency counter (`0` = never set). */
+  version: number;
+  /**
+   * The R$ budget tree exactly as returned. Amounts are preserved verbatim —
+   * the client never `Number()`s them (the contract keeps money as strings).
+   */
+  tree: GoalTreeNode;
+}
+
+/**
+ * Client configuration. Auth is `apiKey` (X-API-Key) OR `jwt` (Bearer).
+ * Identical shape to `TariffApiClientConfig`.
+ */
+export interface GoalsMoneyClientConfig {
+  /** API origin, e.g. `https://gcdr-api.a.myio-bas.com`. `/api/v1` is appended. */
+  baseUrl: string;
+  /** Customer API Key (`gcdr_cust_…`) → `X-API-Key`. */
+  apiKey?: string;
+  /** JWT → `Authorization: Bearer`. */
+  jwt?: string;
+  /** Optional tenant hint forwarded as `X-Tenant-Id`. */
+  tenantId?: string;
+  /** Injectable fetch (defaults to `globalThis.fetch`). */
+  fetchImpl?: typeof fetch;
+  /** Base path segment. Defaults to `api/v1`. */
+  basePath?: string;
+}
+
+/**
+ * Structured goals-money API failure. Callers switch on `.code` (stable), never
+ * on the human message. `currentVersion` is lifted from `details` for 409s so a
+ * `GOAL_VERSION_CONFLICT` is surfaced without digging.
+ */
+export class GoalsMoneyApiError extends Error {
+  readonly code: string;
+  readonly status: number;
+  readonly details?: Record<string, unknown>;
+  readonly currentVersion?: number;
+
+  constructor(
+    code: string,
+    status: number,
+    message?: string,
+    details?: Record<string, unknown>
+  ) {
+    super(message || code);
+    this.name = 'GoalsMoneyApiError';
+    this.code = code;
+    this.status = status;
+    this.details = details;
+    const cv = details && (details as { currentVersion?: unknown }).currentVersion;
+    this.currentVersion = typeof cv === 'number' ? cv : undefined;
+  }
+}
+
+function joinUrl(baseUrl: string, basePath: string, path: string): string {
+  const b = baseUrl.replace(/\/+$/, '');
+  const bp = basePath ? `/${basePath.replace(/^\/+|\/+$/g, '')}` : '';
+  const p = path.startsWith('/') ? path : `/${path}`;
+  return `${b}${bp}${p}`;
+}
+
+/** Parse a strong ETag (`"5"`) into a number, if present. */
+function parseETagVersion(headers: Headers): number | undefined {
+  const raw = headers.get('ETag') || headers.get('etag');
+  if (!raw) return undefined;
+  const m = /"?(-?\d+)"?/.exec(raw);
+  return m ? Number(m[1]) : undefined;
+}
+
+/** Body fragment carrying the optimistic-concurrency guard. */
+function guardBody(expectedVersion?: number): { expectedVersion?: number } {
+  return typeof expectedVersion === 'number' ? { expectedVersion } : {};
+}
+
+export class GoalsMoneyClient {
+  private readonly cfg: GoalsMoneyClientConfig;
+  private readonly fetchImpl: typeof fetch;
+  private readonly basePath: string;
+
+  constructor(config: GoalsMoneyClientConfig) {
+    if (!config || !config.baseUrl) {
+      throw new Error('GoalsMoneyClient requires a baseUrl.');
+    }
+    this.cfg = config;
+    const injected = config.fetchImpl || (globalThis.fetch as typeof fetch | undefined);
+    if (typeof injected !== 'function') {
+      throw new Error('GoalsMoneyClient requires a fetch implementation.');
+    }
+    // Preserve the correct `this` when calling a global fetch.
+    this.fetchImpl = config.fetchImpl ? config.fetchImpl : injected.bind(globalThis);
+    this.basePath = config.basePath ?? 'api/v1';
+  }
+
+  private authHeaders(): Record<string, string> {
+    const h: Record<string, string> = {};
+    if (this.cfg.apiKey) h['X-API-Key'] = this.cfg.apiKey;
+    if (this.cfg.jwt) h['Authorization'] = `Bearer ${this.cfg.jwt}`;
+    if (this.cfg.tenantId) h['X-Tenant-Id'] = this.cfg.tenantId;
+    return h;
+  }
+
+  private goalsPath(sel: GoalSelector): string {
+    return `/customers/${encodeURIComponent(sel.customerId)}/goals`;
+  }
+
+  /**
+   * Read a quantity goal **in money** (`?withMoney=true`). Returns the quantity
+   * tree (values are quantities, `monetaryValue`s are decimal strings), plus the
+   * normalized money overlay (`available` | `unavailable`) and, when a CURRENCY
+   * goal exists, the folded budget verdict. Coverage states are NOT thrown.
+   */
+  async getGoalWithMoney(
+    args: GoalSelector & { granularity?: GoalGranularity }
+  ): Promise<MonetaryProjection> {
+    const qs = new URLSearchParams();
+    qs.set('domain', args.domain);
+    qs.set('year', String(args.year));
+    if (args.granularity) qs.set('granularity', args.granularity);
+    qs.set('withMoney', 'true');
+    const url = joinUrl(this.cfg.baseUrl, this.basePath, `${this.goalsPath(args)}?${qs.toString()}`);
+
+    const res = await this.fetchImpl(url, {
+      method: 'GET',
+      headers: { Accept: 'application/json', ...this.authHeaders() },
+    });
+    const body = await this.readBody(res);
+    if (!res.ok) throw this.toError(res, body);
+
+    const etagVersion = parseETagVersion(res.headers);
+    const parsed = (body || {}) as {
+      measure?: string;
+      version?: number;
+      unit?: string;
+      tree?: GoalTreeNode;
+      money?: RawMoneyBlock;
+      budget?: RawBudgetBlock;
+    };
+    const version =
+      typeof parsed.version === 'number' ? parsed.version : etagVersion ?? 0;
+    const measure = parsed.measure === 'CURRENCY' ? 'CURRENCY' : 'QUANTITY';
+
+    return {
+      customerId: args.customerId,
+      domain: args.domain,
+      year: args.year,
+      measure,
+      version,
+      goal: {
+        domain: args.domain,
+        unit: typeof parsed.unit === 'string' ? parsed.unit : '',
+        // Tree is passed through verbatim — amounts/monetaryValues stay strings.
+        tree: parsed.tree || {},
+        version,
+      },
+      money: normalizeMoneyBlock(parsed.money, parsed.budget),
+    };
+  }
+
+  /** Read the native CURRENCY budget goal (R$ target tree). */
+  async getBudget(sel: GoalSelector): Promise<CurrencyBudgetResponse> {
+    const qs = new URLSearchParams();
+    qs.set('domain', sel.domain);
+    qs.set('year', String(sel.year));
+    qs.set('measure', 'CURRENCY');
+    const url = joinUrl(this.cfg.baseUrl, this.basePath, `${this.goalsPath(sel)}?${qs.toString()}`);
+
+    const res = await this.fetchImpl(url, {
+      method: 'GET',
+      headers: { Accept: 'application/json', ...this.authHeaders() },
+    });
+    const body = await this.readBody(res);
+    if (!res.ok) throw this.toError(res, body);
+
+    const etagVersion = parseETagVersion(res.headers);
+    const parsed = (body || {}) as Partial<CurrencyBudgetResponse>;
+    return {
+      customerId: sel.customerId,
+      domain: sel.domain,
+      year: sel.year,
+      measure: 'CURRENCY',
+      currency: parsed.currency,
+      version: typeof parsed.version === 'number' ? parsed.version : etagVersion ?? 0,
+      tree: parsed.tree || {},
+    };
+  }
+
+  /**
+   * Set the native CURRENCY budget (PUT replace). The `tree` is sent **verbatim**
+   * (`{ annual: { value: "120000.00" } }` or `{ monthly: {…} }`) — the client
+   * does not coerce amounts, keeping the decimal-string contract end to end.
+   * The optimistic guard rides both `If-Match` and body `expectedVersion`.
+   */
+  async putBudget(
+    args: GoalSelector & { tree: GoalTreeNode; expectedVersion?: number }
+  ): Promise<{ version: number }> {
+    const qs = new URLSearchParams();
+    qs.set('domain', args.domain);
+    qs.set('year', String(args.year));
+    qs.set('measure', 'CURRENCY');
+    const url = joinUrl(this.cfg.baseUrl, this.basePath, `${this.goalsPath(args)}?${qs.toString()}`);
+
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      ...this.authHeaders(),
+    };
+    if (typeof args.expectedVersion === 'number') {
+      headers['If-Match'] = `"${args.expectedVersion}"`;
+    }
+    const res = await this.fetchImpl(url, {
+      method: 'PUT',
+      headers,
+      body: JSON.stringify({ ...args.tree, ...guardBody(args.expectedVersion) }),
+    });
+    const parsed = await this.readBody(res);
+    if (!res.ok) throw this.toError(res, parsed);
+    const etagVersion = parseETagVersion(res.headers);
+    const v = (parsed && (parsed as { version?: unknown }).version) ?? etagVersion;
+    return { version: typeof v === 'number' ? v : (args.expectedVersion ?? 0) + 1 };
+  }
+
+  /**
+   * Delete the native CURRENCY budget. Whole-year delete is idempotent (204).
+   * The optimistic guard rides both `If-Match` and body `expectedVersion`.
+   */
+  async deleteBudget(
+    args: GoalSelector & { expectedVersion?: number }
+  ): Promise<{ version?: number }> {
+    const qs = new URLSearchParams();
+    qs.set('domain', args.domain);
+    qs.set('year', String(args.year));
+    qs.set('measure', 'CURRENCY');
+    const url = joinUrl(this.cfg.baseUrl, this.basePath, `${this.goalsPath(args)}?${qs.toString()}`);
+
+    const headers: Record<string, string> = { Accept: 'application/json', ...this.authHeaders() };
+    const init: RequestInit = { method: 'DELETE', headers };
+    if (typeof args.expectedVersion === 'number') {
+      headers['If-Match'] = `"${args.expectedVersion}"`;
+      headers['Content-Type'] = 'application/json';
+      init.body = JSON.stringify(guardBody(args.expectedVersion));
+    }
+    const res = await this.fetchImpl(url, init);
+    if (res.status === 204) return {};
+    const body = await this.readBody(res);
+    if (!res.ok) throw this.toError(res, body);
+    const etagVersion = parseETagVersion(res.headers);
+    const v = (body && (body as { version?: unknown }).version) ?? etagVersion;
+    return typeof v === 'number' ? { version: v } : {};
+  }
+
+  private async readBody(res: Response): Promise<unknown> {
+    try {
+      const text = await res.text();
+      if (!text) return null;
+      return JSON.parse(text);
+    } catch {
+      return null;
+    }
+  }
+
+  private toError(res: Response, body: unknown): GoalsMoneyApiError {
+    const err = body && (body as { error?: unknown }).error;
+    if (err && typeof err === 'object') {
+      const e = err as { code?: string; message?: string; details?: Record<string, unknown> };
+      return new GoalsMoneyApiError(e.code || `HTTP_${res.status}`, res.status, e.message, e.details);
+    }
+    return new GoalsMoneyApiError(`HTTP_${res.status}`, res.status, res.statusText);
+  }
+}
+
+/** Convenience factory (mirrors `createTariffApiClient`). */
+export function createGoalsMoneyClient(config: GoalsMoneyClientConfig): GoalsMoneyClient {
+  return new GoalsMoneyClient(config);
+}

--- a/src/components/financial-goals/index.ts
+++ b/src/components/financial-goals/index.ts
@@ -64,3 +64,18 @@ export type {
   FinancialChipColors,
   FinancialValueColors,
 } from './financialIndicators';
+
+// A3 — Native CURRENCY budget view (Target/Projected + DEC-6 verdict). Renders the
+// native R$ budget beside the A2a R$ row; withholds the verdict while coverage is
+// incomplete (defers to A4 for the why).
+export {
+  renderBudgetView,
+  buildBudgetHTML,
+  buildVerdictHTML,
+  resolveBudget,
+} from './budgetView';
+export type {
+  BudgetViewOptions,
+  BudgetValueColors,
+  BudgetChipColors,
+} from './budgetView';

--- a/src/components/financial-goals/index.ts
+++ b/src/components/financial-goals/index.ts
@@ -113,3 +113,20 @@ export {
   injectDeviceCategoryStyles,
   DEVICE_CATEGORY_STYLE_ID,
 } from './deviceCategoryStyles';
+
+// A6 — R$ money column for aggregate report rows/totals (AllReportModal + energy
+// summaries). Reuses A2a/F0 formatting + A4 coverage under the DEC-8 rounding
+// contract; a null config yields a disabled (byte-identical-when-off) column.
+export {
+  createReportMoneyColumn,
+  isMoneyColumnConfident,
+  sumMoneyDecimals,
+  decimalStringToCents,
+  centsToDecimalString,
+  REPORT_MONEY_HEADER,
+} from './reportMoneyColumn';
+export type {
+  ReportMoneyColumnConfig,
+  ReportMoneyColumn,
+  ReportMoneyTotal,
+} from './reportMoneyColumn';

--- a/src/components/financial-goals/index.ts
+++ b/src/components/financial-goals/index.ts
@@ -130,3 +130,30 @@ export type {
   ReportMoneyColumn,
   ReportMoneyTotal,
 } from './reportMoneyColumn';
+
+// A7 — per-consumer realized-vs-goal variance in R$ (RFC-0182 rows / RFC-0217 card).
+// Reuses A2a's `subtractDecimals` + A6's `decimalStringToCents`; honors DEC-6
+// withholding (indeterminate/incomplete → "Variação indisponível", never green/red).
+// Naming bridge: `monetaryProjection` (realized R$) vs `currencyBudget` (goal R$) —
+// never the quantity `budget` prop.
+export {
+  computeMoneyVariance,
+  buildMoneyVarianceHTML,
+  renderMoneyVariance,
+  createMoneyVarianceColumn,
+  resolveGoalAmount,
+  overlayWithholdsVerdict,
+  VARIANCE_LABEL_ABOVE,
+  VARIANCE_LABEL_BELOW,
+  VARIANCE_LABEL_ONTARGET,
+  VARIANCE_LABEL_WITHHELD,
+  MONEY_VARIANCE_HEADER,
+} from './moneyVariance';
+export type {
+  MoneyVarianceInput,
+  MoneyVarianceResult,
+  MoneyVarianceVerdict,
+  MoneyVarianceOptions,
+  MoneyVarianceColumn,
+  MoneyVarianceColumnConfig,
+} from './moneyVariance';

--- a/src/components/financial-goals/index.ts
+++ b/src/components/financial-goals/index.ts
@@ -157,3 +157,24 @@ export type {
   MoneyVarianceColumn,
   MoneyVarianceColumnConfig,
 } from './moneyVariance';
+
+// A2b — broad-rollout gate: the per-customer eligibility layer that decides whether
+// the money overlay turns on. Composes with (never duplicates) A2a's feature gate:
+// AND of (feature available) × (customer explicitly curated/allowlisted) × (coverage
+// sane). Defaults OFF for the whole production base; base-wide flip is blocked on
+// GCDR B1. Ineligible/coverage-gap routes to A4 honest coverage, never money.
+export {
+  resolveMoneyRollout,
+  routeMoneyRender,
+  renderGatedMoney,
+} from './moneyRolloutGate';
+export type {
+  MoneyRolloutReason,
+  MoneyRolloutDecision,
+  MoneyRolloutAllowlist,
+  MoneyRolloutSettings,
+  MoneyRolloutParams,
+  MoneyRenderAction,
+  MoneyRenderRouting,
+  GatedMoneyRenderers,
+} from './moneyRolloutGate';

--- a/src/components/financial-goals/index.ts
+++ b/src/components/financial-goals/index.ts
@@ -40,3 +40,12 @@ export {
   computeDeltaPct,
   signOf,
 } from './moneyFormat';
+
+// A4 — Honest coverage UI (reusable renderer consumed by A2a/A3).
+export {
+  renderCoverageView,
+  buildCoverageHTML,
+  coveragePercentLabel,
+} from './coverageView';
+export type { CoverageViewOptions } from './coverageView';
+export { injectCoverageStyles, COVERAGE_STYLE_ID } from './coverageStyles';

--- a/src/components/financial-goals/index.ts
+++ b/src/components/financial-goals/index.ts
@@ -1,0 +1,42 @@
+// RFC-0228 F0 — Financial Goals money foundation. Barrel export.
+// Pure types/client/formatters (no UI); the shared spine A4/A2a/A3 consume.
+
+// Naming bridge + normalized money types (resolves the 3-way `budget` collision).
+export {
+  MONEY_REQUIRES_DEVICE_GRANULARITY,
+  normalizeMoneyBlock,
+  normalizeBudgetBlock,
+} from './moneyTypes';
+export type {
+  MoneyDomain,
+  QuantityGoal,
+  GoalTreeNode,
+  MonetaryProjection,
+  CurrencyBudget,
+  BudgetVerdict,
+  BudgetOverlay,
+  MoneyOverlay,
+  UncategorizedDevice,
+  TariffCoverageGaps,
+  RawMoneyBlock,
+  RawBudgetBlock,
+} from './moneyTypes';
+
+// Goals-money API client (mirrors the A1 tariff client).
+export { GoalsMoneyClient, GoalsMoneyApiError, createGoalsMoneyClient } from './goalsMoneyClient';
+export type {
+  GoalsMoneyClientConfig,
+  GoalSelector,
+  GoalGranularity,
+  CurrencyBudgetResponse,
+} from './goalsMoneyClient';
+
+// Money display formatting (decimal-string in, pt-BR BRL out).
+export {
+  DASH,
+  formatBRL as formatMoneyBRL,
+  formatBRLDelta,
+  formatDeltaPct,
+  computeDeltaPct,
+  signOf,
+} from './moneyFormat';

--- a/src/components/financial-goals/index.ts
+++ b/src/components/financial-goals/index.ts
@@ -49,3 +49,18 @@ export {
 } from './coverageView';
 export type { CoverageViewOptions } from './coverageView';
 export { injectCoverageStyles, COVERAGE_STYLE_ID } from './coverageStyles';
+
+// A2a — R$ money overlay row for one Metas × Consumo card (pilot). Renders the R$
+// row when coverage is complete; defers to A4 (`renderCoverageView`) otherwise.
+export {
+  renderFinancialIndicators,
+  buildFinancialRowHTML,
+  resolveMoneyRowValues,
+  subtractDecimals,
+} from './financialIndicators';
+export type {
+  FinancialIndicatorsOptions,
+  FinancialMoneyValues,
+  FinancialChipColors,
+  FinancialValueColors,
+} from './financialIndicators';

--- a/src/components/financial-goals/index.ts
+++ b/src/components/financial-goals/index.ts
@@ -79,3 +79,37 @@ export type {
   BudgetValueColors,
   BudgetChipColors,
 } from './budgetView';
+
+// A5a — Device tariff-category management UI. Depends only on the injectable
+// DeviceCategoryPort SEAM (B6 implements it later); never on a concrete device
+// HTTP shape. Reuses A1's category map (tariffApiAdapter) for panel-term display.
+export {
+  createFakeDeviceCategoryPort,
+  createHttpDeviceCategoryPort,
+  DeviceCategoryConflictError,
+} from './deviceCategoryPort';
+export type {
+  DeviceCategory,
+  DeviceCategoryRow,
+  DeviceCategoryPort,
+  FakeDeviceSeed,
+  FakeDeviceCategoryPortOptions,
+  FakeDeviceCategoryPortHandle,
+  HttpDeviceCategoryPortConfig,
+} from './deviceCategoryPort';
+export {
+  openDeviceCategoryPanel,
+  createCoverageDeepLink,
+  deviceCategoryLabel,
+  deviceCategoryToPanelTerm,
+  panelTermToDeviceCategory,
+} from './deviceCategoryPanel';
+export type {
+  OpenDeviceCategoryPanelParams,
+  DeviceCategoryPanelHandle,
+  DeviceCategoryFilter,
+} from './deviceCategoryPanel';
+export {
+  injectDeviceCategoryStyles,
+  DEVICE_CATEGORY_STYLE_ID,
+} from './deviceCategoryStyles';

--- a/src/components/financial-goals/moneyFormat.ts
+++ b/src/components/financial-goals/moneyFormat.ts
@@ -1,0 +1,145 @@
+/**
+ * RFC-0228 F0 — Money **display** formatting for the financial-goals frontend.
+ *
+ * The canonical money representation is a decimal **string** (`"1234.56"`); these
+ * helpers parse it **for display only** and never round-trip through a float.
+ * The BRL formatter is fully string-based (group-by-thousands, comma decimal), so
+ * arbitrarily large amounts group correctly and there is no float artifact. The
+ * only `Number()` in this module is inside percent math for the deviation chip —
+ * a derived display value, never written back to a canonical amount.
+ *
+ * Honest-empty rule: a missing/`null`/invalid amount renders {@link DASH} (`—`),
+ * **never** `NaN` or a misleading `R$ 0` (RFC-0228 F0 constraint).
+ */
+
+/** The em-dash rendered for a missing/unknown money value. */
+export const DASH = '—';
+
+/** A decimal string split into sign + integer + (already-2dp) fraction. */
+interface DecimalParts {
+  negative: boolean;
+  intDigits: string;
+  frac2: string;
+}
+
+/**
+ * Parse a decimal string into sign / integer / 2-decimal fraction using pure
+ * string ops (half-up rounding on the third fraction digit). Returns `null` for
+ * anything that is not a finite decimal string — the caller renders {@link DASH}.
+ */
+function toDecimalParts(input: string): DecimalParts | null {
+  const s = input.trim();
+  if (!s) return null;
+  // Accept an optional leading sign then digits with an optional single dot.
+  const m = /^([+-]?)(\d+)(?:\.(\d+))?$/.exec(s);
+  if (!m) return null;
+
+  const negative = m[1] === '-';
+  let intDigits = m[2].replace(/^0+(?=\d)/, ''); // strip leading zeros, keep one
+  const frac = m[3] || '';
+
+  // Round to 2 decimals, half-up, using string carry (no float).
+  let cents = frac.slice(0, 2).padEnd(2, '0');
+  const roundDigit = frac.charAt(2);
+  if (roundDigit && roundDigit >= '5') {
+    const bumped = String(Number(cents) + 1).padStart(2, '0'); // 0..99 only — safe
+    if (bumped.length > 2) {
+      // 99 -> 100: carry into the integer part via string increment.
+      cents = '00';
+      intDigits = incrementDigits(intDigits);
+    } else {
+      cents = bumped;
+    }
+  }
+  return { negative, intDigits, frac2: cents };
+}
+
+/** Increment a non-negative integer given as a digit string (no float). */
+function incrementDigits(digits: string): string {
+  const arr = digits.split('');
+  let i = arr.length - 1;
+  for (; i >= 0; i--) {
+    if (arr[i] === '9') {
+      arr[i] = '0';
+    } else {
+      arr[i] = String(Number(arr[i]) + 1);
+      return arr.join('');
+    }
+  }
+  return '1' + arr.join('');
+}
+
+/** Group an integer digit-string in threes with pt-BR dots: `1234567` → `1.234.567`. */
+function groupThousands(intDigits: string): string {
+  return intDigits.replace(/\B(?=(\d{3})+(?!\d))/g, '.');
+}
+
+/**
+ * Format a decimal **string** amount as pt-BR BRL: `"1234.56"` → `"R$ 1.234,56"`.
+ * `null`/`undefined`/empty/invalid → {@link DASH}. Never returns `NaN` or a
+ * spurious `R$ 0`. The amount is grouped from the string (safe for large values);
+ * no numeric addition is performed, so string inputs like `"0.10"` and `"0.20"`
+ * are formatted independently and never summed as floats.
+ */
+export function formatBRL(amount: string | null | undefined): string {
+  if (amount == null) return DASH;
+  const parts = toDecimalParts(String(amount));
+  if (!parts) return DASH;
+  const grouped = groupThousands(parts.intDigits);
+  const sign = parts.negative && !(parts.intDigits === '0' && parts.frac2 === '00') ? '-' : '';
+  return `R$ ${sign}${grouped},${parts.frac2}`;
+}
+
+/**
+ * Sign glyph for a numeric delta: positive → `"+"`, negative → `"−"` (true minus),
+ * zero/`null`/`NaN` → `""`. Parallels the kWh deviation chips.
+ */
+export function signOf(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value) || value === 0) return '';
+  return value > 0 ? '+' : '−';
+}
+
+/**
+ * Compute a signed deviation percentage between two decimal-string amounts:
+ * `(current − baseline) / |baseline| × 100`. Returns `null` when either input is
+ * invalid or the baseline is zero (avoids divide-by-zero / `Infinity`). This is
+ * the one place a `Number()` is used — for a derived display metric only; the
+ * canonical amounts remain strings.
+ */
+export function computeDeltaPct(
+  current: string | null | undefined,
+  baseline: string | null | undefined
+): number | null {
+  if (current == null || baseline == null) return null;
+  const c = Number(String(current).trim());
+  const b = Number(String(baseline).trim());
+  if (!Number.isFinite(c) || !Number.isFinite(b) || b === 0) return null;
+  return ((c - b) / Math.abs(b)) * 100;
+}
+
+/**
+ * Format a percentage for the R$ deviation chip: `3.2` → `"+3,2%"`,
+ * `-1.5` → `"−1,5%"`, `0` → `"0,0%"`, `null` → {@link DASH}. `digits` controls the
+ * fraction length (default 1). Uses the true minus sign to match the kWh chips.
+ */
+export function formatDeltaPct(pct: number | null | undefined, digits = 1): string {
+  if (pct == null || !Number.isFinite(pct)) return DASH;
+  const abs = Math.abs(pct).toFixed(digits).replace('.', ',');
+  const sign = pct > 0 ? '+' : pct < 0 ? '−' : '';
+  return `${sign}${abs}%`;
+}
+
+/**
+ * Format a signed R$ deviation for the chip label: `"1234.56"` → `"+R$ 1.234,56"`,
+ * `"-50.00"` → `"−R$ 50,00"`. `null`/invalid → {@link DASH}. Keeps the amount a
+ * string; only the sign is derived (from the leading `-`).
+ */
+export function formatBRLDelta(amount: string | null | undefined): string {
+  if (amount == null) return DASH;
+  const parts = toDecimalParts(String(amount));
+  if (!parts) return DASH;
+  const isZero = parts.intDigits === '0' && parts.frac2 === '00';
+  const sign = isZero ? '' : parts.negative ? '−' : '+';
+  const grouped = groupThousands(parts.intDigits);
+  return `${sign}R$ ${grouped},${parts.frac2}`;
+}

--- a/src/components/financial-goals/moneyRolloutGate.ts
+++ b/src/components/financial-goals/moneyRolloutGate.ts
@@ -1,0 +1,305 @@
+/**
+ * RFC-0228 A2b — Broad-rollout gate for the R$ money overlay.
+ *
+ * A2a (`financialIndicators.ts` + the controller `_moneyGate`) answers **one**
+ * question: *is the money feature available at all?* — i.e. the operator configured
+ * `settings.goalsMoneyApi` AND the library exposes the money symbols
+ * (`createGoalsMoneyClient` / `renderFinancialIndicators`). That gate is a single
+ * global on/off axis for the whole dashboard.
+ *
+ * A2b adds the **second axis, per customer**: *is THIS customer eligible for the
+ * broad overlay?* The two compose as an **AND**, never a replacement:
+ *
+ *     money renders  ⇔  (A2a feature available)          ← global, A2a owns it
+ *                    ∧  (customer explicitly eligible)   ← A2b layer (b)
+ *                    ∧  (coverage is sane, not broken)   ← A2b layer (c)
+ *
+ * This module owns only the 2nd/3rd axes. It **reuses** A2a's flag (layer (a)) and
+ * never re-implements A2a's runtime symbol check — that half is enforced by the
+ * caller's existing `_moneyGate` seam (the wiring only reaches A2b once `_moneyGate`
+ * already passed). See `routeMoneyRender` / `renderGatedMoney` for the composition.
+ *
+ * ── WHY THE PRODUCTION BASE DEFAULTS OFF (the "sem B1" reality made safe) ─────────
+ * RFC-0228 index §Track B: without GCDR **B1** (money for *customer-granular* goals),
+ * `?withMoney=true` requires a **device-granular** goal, and the majority of the
+ * production base is customer-granular → the overlay would resolve to
+ * `MONEY_REQUIRES_DEVICE_GRANULARITY` / `coverageComplete:false` for most customers.
+ * So enabling money **base-wide today would show "sem cobertura" to the majority.**
+ *
+ * A2b makes that safe by defaulting eligibility **OFF for everyone**: only customers
+ * an operator has **explicitly** curated (device-granular, allowlisted) turn on. The
+ * pilot (A2a) stays valid for those curated customers; the broad base stays dark and
+ * honest until curated — never a broken overlay, never fabricated R$.
+ *
+ * ── B1 / B2 DEPENDENCY (backend, GCDR repo — NOT built here) ─────────────────────
+ * Broad, base-wide enablement is blocked on the **GCDR B1 fork decision** (default a
+ * per-customer `tariff_category` × curate goals to device-granular × hybrid), which
+ * itself waits on **B2** (measuring how many production goals are device-granular).
+ * Both are GCDR deliverables. Until B1 lands, eligibility here is **allowlist/curated
+ * only**. When B1 ships, flipping to base-wide is a **one-line policy change**:
+ * set `settings.goalsMoneyRolloutBaseWide = true` (or put `'*'` in the allowlist) —
+ * see {@link isCustomerEligible}. Nothing else in this module changes.
+ *
+ * Design rules (mirroring F0/A2a/A4 on this branch):
+ *  - **Pure / declarative.** No `fetch`, no ThingsBoard, no `window`, no DOM here
+ *    (the element convenience `renderGatedMoney` only *invokes* injected renderers).
+ *  - **Eligibility is injected, never inferred.** The allowlist/curated source comes
+ *    from an explicit param or a settings attribute — never derived from the
+ *    customer's name, domain, or size (RFC-0207 explicit-only discipline).
+ *  - **Ineligible / coverage-gap ⇒ A4 honest coverage**, never money, never R$ 0.
+ */
+
+import type { MoneyOverlay } from './moneyTypes';
+import { MONEY_REQUIRES_DEVICE_GRANULARITY } from './moneyTypes';
+
+/**
+ * Why the overlay is (not) enabled for a customer:
+ *  - `disabled`     — layer (a): the money feature is off globally (A2a gate false).
+ *  - `not-eligible` — layer (b): feature on, but the customer is NOT allowlisted /
+ *                     curated. **This is the base-wide default** (no inference).
+ *  - `coverage-gap` — layer (c): feature on + eligible, but the sampled overlay is
+ *                     `unavailable` (no device-granular coverage — the no-B1 case).
+ *  - `eligible`     — all three layers pass: render the R$ overlay.
+ */
+export type MoneyRolloutReason =
+  | 'disabled'
+  | 'not-eligible'
+  | 'coverage-gap'
+  | 'eligible';
+
+/** The gate decision — `enabled` is `true` only when `reason === 'eligible'`. */
+export interface MoneyRolloutDecision {
+  enabled: boolean;
+  reason: MoneyRolloutReason;
+}
+
+/**
+ * Curated/allowlisted customer ids. Explicit ids only, never inferred. The sentinel
+ * `'*'` (or {@link MoneyRolloutSettings.goalsMoneyRolloutBaseWide}) flips to base-wide
+ * — reserved for **after** GCDR B1 lands.
+ */
+export type MoneyRolloutAllowlist = string[] | Set<string> | null | undefined;
+
+/**
+ * The (small) slice of dashboard `settings` A2b reads. A superset-safe subset of the
+ * settings A2a already consumes — passing the whole settings object is fine.
+ */
+export interface MoneyRolloutSettings {
+  /**
+   * Layer (a): A2a's global money feature flag (`settings.goalsMoneyApi`). Truthy =
+   * the money data source is configured. A2b **reuses** this; it never reinvents it.
+   */
+  goalsMoneyApi?: unknown;
+  /**
+   * Layer (b) source: curated/allowlisted customers eligible for the R$ overlay.
+   * Explicit ids only. `'*'` = base-wide (post-B1). An explicit `params.allowlist`
+   * overrides this.
+   */
+  goalsMoneyRolloutAllowlist?: MoneyRolloutAllowlist;
+  /**
+   * The **one-line base-wide flip**, blocked on GCDR **B1**. `true` = every customer
+   * is eligible (subject to layers (a) and (c)). Defaults falsy → allowlist-only.
+   * **Do not set `true` until B1 ships** or the majority will hit `coverage-gap`.
+   */
+  goalsMoneyRolloutBaseWide?: boolean;
+  [k: string]: unknown;
+}
+
+/** Inputs to {@link resolveMoneyRollout} / {@link routeMoneyRender}. */
+export interface MoneyRolloutParams {
+  /** GCDR customer id under evaluation. Missing/empty → never eligible (unverifiable). */
+  customerId?: string | number | null;
+  /** Dashboard settings — A2a's `goalsMoneyApi` + A2b's allowlist / base-wide flags. */
+  settings?: MoneyRolloutSettings | null;
+  /**
+   * The **composed A2a gate** result, when the caller already computed `_moneyGate`.
+   * When a boolean is supplied it **is** layer (a) and takes precedence over
+   * `settings.goalsMoneyApi` — this is how A2b composes with (never duplicates or
+   * weakens) A2a's runtime gate. Omit to fall back to the settings flag.
+   */
+  featureAvailable?: boolean;
+  /** Explicit allowlist override (wins over `settings`). Never inferred. */
+  allowlist?: MoneyRolloutAllowlist;
+  /**
+   * A representative money overlay for this customer (F0 {@link MoneyOverlay}). When
+   * it is `unavailable` (e.g. `MONEY_REQUIRES_DEVICE_GRANULARITY` — the no-B1
+   * reality), layer (c) fails with `coverage-gap`: never surface a broken overlay.
+   * Absent → coverage sanity is deferred to per-card A2a/A4 at render time.
+   */
+  overlaySample?: MoneyOverlay | null;
+}
+
+/** Normalize any allowlist shape into a `Set<string>` of trimmed, non-empty ids. */
+function normalizeAllowlist(list: MoneyRolloutAllowlist): Set<string> {
+  const out = new Set<string>();
+  if (!list) return out;
+  const iter: Iterable<unknown> = list instanceof Set ? list : Array.isArray(list) ? list : [];
+  for (const raw of iter) {
+    const id = String(raw ?? '').trim();
+    if (id) out.add(id);
+  }
+  return out;
+}
+
+/** A customer id as a trimmed string, or `''` when absent/blank (→ unverifiable). */
+function normalizeId(customerId: string | number | null | undefined): string {
+  return customerId == null ? '' : String(customerId).trim();
+}
+
+/** An overlay is "broken" for rollout purposes when it is explicitly `unavailable`. */
+function isBrokenOverlay(overlay: MoneyOverlay | null | undefined): boolean {
+  return !!overlay && overlay.state === 'unavailable';
+}
+
+/**
+ * Layer (b) — **explicit** customer eligibility, defaulting OFF for the whole base.
+ *
+ * A customer is eligible **only** when one of these explicit operator actions holds:
+ *  1. `settings.goalsMoneyRolloutBaseWide === true` — the post-B1 base-wide flip.
+ *  2. the allowlist contains the base-wide sentinel `'*'`.
+ *  3. the allowlist (param override, else `settings.goalsMoneyRolloutAllowlist`)
+ *     contains the customer's id.
+ *
+ * Everyone else is **not eligible** — including customers with no id (unverifiable →
+ * OFF). No customer is ever eligible by inference (name/domain/size): RFC-0207
+ * explicit-only discipline. This is the single line that keeps the production base
+ * dark until curated, and the single place the base-wide flip lives once B1 lands.
+ */
+function isCustomerEligible(
+  params: MoneyRolloutParams,
+  settings: MoneyRolloutSettings | null
+): boolean {
+  // (1) The one-line base-wide flip (blocked on GCDR B1 today).
+  if (settings && settings.goalsMoneyRolloutBaseWide === true) return true;
+
+  const set = normalizeAllowlist(params.allowlist ?? settings?.goalsMoneyRolloutAllowlist);
+  // (2) Base-wide sentinel in the allowlist.
+  if (set.has('*')) return true;
+
+  // (3) Explicit membership. No id → cannot verify → OFF (never inferred).
+  const id = normalizeId(params.customerId);
+  if (!id) return false;
+  return set.has(id);
+}
+
+/**
+ * A2b decision: is the R$ money overlay enabled for this customer?
+ *
+ * The three layers are AND-ed and short-circuit in order so the `reason` names the
+ * **first** failing layer:
+ *   (a) feature available (A2a) — else `disabled`;
+ *   (b) customer eligible (explicit allowlist/curated, default OFF) — else `not-eligible`;
+ *   (c) coverage sane (sampled overlay not `unavailable`) — else `coverage-gap`.
+ * Only when all three pass: `{ enabled: true, reason: 'eligible' }`.
+ */
+export function resolveMoneyRollout(params: MoneyRolloutParams): MoneyRolloutDecision {
+  const p = params || ({} as MoneyRolloutParams);
+  const settings = p.settings ?? null;
+
+  // Layer (a) — global feature flag. The composed A2a gate wins when provided;
+  // otherwise the settings half (`goalsMoneyApi`). We deliberately do NOT re-check
+  // the MyIOLibrary symbols here — that runtime half is A2a's, enforced by the
+  // caller's `_moneyGate` seam. Composition, not duplication.
+  const featureAvailable =
+    typeof p.featureAvailable === 'boolean'
+      ? p.featureAvailable
+      : !!(settings && settings.goalsMoneyApi);
+  if (!featureAvailable) return { enabled: false, reason: 'disabled' };
+
+  // Layer (b) — explicit customer eligibility. Default OFF for the whole base.
+  if (!isCustomerEligible(p, settings)) {
+    return { enabled: false, reason: 'not-eligible' };
+  }
+
+  // Layer (c) — coverage sanity. A sampled `unavailable` overlay (the no-B1 case)
+  // must never surface a broken R$ overlay; route it to the honest A4 path.
+  if (isBrokenOverlay(p.overlaySample)) {
+    return { enabled: false, reason: 'coverage-gap' };
+  }
+
+  return { enabled: true, reason: 'eligible' };
+}
+
+/** What a gated money surface should render, from the A2b decision. */
+export type MoneyRenderAction = 'render-money' | 'render-coverage' | 'render-nothing';
+
+/** The routing produced by {@link routeMoneyRender}: decision + what to render. */
+export interface MoneyRenderRouting {
+  decision: MoneyRolloutDecision;
+  action: MoneyRenderAction;
+  /**
+   * The overlay A4 should render when `action === 'render-coverage'`. Always an
+   * `unavailable` overlay — the honest coverage state, never a fabricated/partial R$.
+   */
+  coverageOverlay?: MoneyOverlay;
+}
+
+/**
+ * The **wiring helper**: turn an A2b decision into a render action for any money
+ * surface (indicators / report column / variance / budget view). Pure — no DOM.
+ *
+ *  - `disabled`     → `render-nothing`. **Byte-identical to pre-A2b**: when the
+ *                     feature is off there was no money and no coverage panel, so A2b
+ *                     adds nothing either.
+ *  - `eligible`     → `render-money` (call the A2a/A3/A6/A7 renderer).
+ *  - `not-eligible` /
+ *    `coverage-gap` → `render-coverage` with an `unavailable` overlay — route to A4's
+ *                     honest coverage state. The sampled overlay is reused when it is
+ *                     already `unavailable`; otherwise a canonical
+ *                     `MONEY_REQUIRES_DEVICE_GRANULARITY` overlay is synthesized.
+ */
+export function routeMoneyRender(params: MoneyRolloutParams): MoneyRenderRouting {
+  const decision = resolveMoneyRollout(params);
+
+  // Feature off → render nothing at all (byte-identical to the pre-A2b surface).
+  if (decision.reason === 'disabled') {
+    return { decision, action: 'render-nothing' };
+  }
+
+  if (decision.enabled) {
+    return { decision, action: 'render-money' };
+  }
+
+  // not-eligible | coverage-gap → honest A4 coverage. Never a fabricated overlay.
+  const sample = params?.overlaySample;
+  const coverageOverlay: MoneyOverlay =
+    sample && sample.state === 'unavailable'
+      ? sample
+      : { state: 'unavailable', reason: MONEY_REQUIRES_DEVICE_GRANULARITY };
+  return { decision, action: 'render-coverage', coverageOverlay };
+}
+
+/** Injected renderers for {@link renderGatedMoney} — A2a money + A4 coverage. */
+export interface GatedMoneyRenderers {
+  /**
+   * The money renderer (A2a `renderFinancialIndicators`, or A3/A6/A7 equivalents).
+   * Called **only** when the decision is `eligible`. Receives the real overlay sample.
+   */
+  renderMoney: (overlay: MoneyOverlay | null | undefined) => HTMLElement | null;
+  /**
+   * The A4 honest-coverage renderer (`renderCoverageView`). Called for `not-eligible`
+   * and `coverage-gap` with an `unavailable` overlay — never money, never R$ 0.
+   */
+  renderCoverage: (overlay: MoneyOverlay) => HTMLElement | null;
+}
+
+/**
+ * Element-level composition helper: resolve the A2b gate and dispatch to the right
+ * renderer. This is the seam money-consuming surfaces call **instead of** rendering
+ * money directly — it composes A2a and A4 without rewriting either.
+ *
+ *  - `render-nothing` → returns `null` (feature off; byte-identical to pre-A2b).
+ *  - `render-money`   → `renderers.renderMoney(overlaySample)` (A2a et al.).
+ *  - `render-coverage`→ `renderers.renderCoverage(unavailableOverlay)` (A4).
+ */
+export function renderGatedMoney(
+  params: MoneyRolloutParams,
+  renderers: GatedMoneyRenderers
+): HTMLElement | null {
+  const routing = routeMoneyRender(params);
+  if (routing.action === 'render-nothing') return null;
+  if (routing.action === 'render-money') {
+    return renderers.renderMoney(params?.overlaySample);
+  }
+  return renderers.renderCoverage(routing.coverageOverlay as MoneyOverlay);
+}

--- a/src/components/financial-goals/moneyTypes.ts
+++ b/src/components/financial-goals/moneyTypes.ts
@@ -1,0 +1,307 @@
+/**
+ * RFC-0228 F0 — Money foundation: the **naming bridge** + normalized money types.
+ *
+ * The word `budget` collides three ways across this codebase and the GCDR wire
+ * (RFC-0228 index §"Colisão de nomes `budget`"; feedback-v1 §3). This module
+ * resolves the collision **explicitly** so no downstream (A4/A2a/A3) code can
+ * conflate them:
+ *
+ *   1. {@link QuantityGoal}       — the existing kWh/m³ **Meta / Orçado** line.
+ *                                    This is what local components today call
+ *                                    `budget` (`CustomerGoalsCard/types.ts`:
+ *                                    `budget`/`budgetBreakdown`/`orcado`,
+ *                                    GCDR RFC-0052 `adjustedValue`).
+ *                                    **NOT money.** A quantity in kWh or m³.
+ *   2. {@link MonetaryProjection} — R$ **derived** from `?withMoney=true`
+ *                                    (the `money` block + per-node
+ *                                    `monetaryValue`). A projection, not a target.
+ *   3. {@link CurrencyBudget}     — the **native** `measure=CURRENCY` target
+ *                                    (GCDR RFC-0054 `budget.target`). The only
+ *                                    one that should carry the frontend name
+ *                                    `currencyBudget`.
+ *
+ * Design rules (mirroring the A1 tariff client on this branch):
+ *  - **Pure / framework-agnostic.** No DOM, no ThingsBoard.
+ *  - **Amounts are decimal STRINGS end to end** (`"223000.00"`), never JSON
+ *    numbers. Nothing here calls `Number()` — display formatting lives in
+ *    `moneyFormat.ts`.
+ *  - **Honest coverage is a first-class value, not an error.** The `unavailable`
+ *    state and `coverageComplete:false` are normal 200-body outcomes
+ *    (API guide §4.2, §7; GCDR RFC-0054 DEC-6). `withinBudget`/`variance` stay
+ *    `null` while coverage is incomplete.
+ */
+
+/** Money-capable (SUM) domain for goals overlay/budget. Mirrors WIRE domain. */
+export type MoneyDomain = 'ENERGY' | 'WATER';
+
+/**
+ * Bridge #1 — the **quantity** goal line (kWh / m³). This is the RFC-0052
+ * `adjustedValue` "Meta / Orçado" that local components already expose under the
+ * prop name `budget`. Kept here **only to name it away from money**: a
+ * `QuantityGoal` is a consumption target, never R$. Downstream code that means
+ * "the kWh/m³ goal" should reference this type, never a `budget` money field.
+ */
+export interface QuantityGoal {
+  /** SUM domain the goal belongs to. */
+  domain: MoneyDomain;
+  /** Physical unit of the target, e.g. `"kWh"` or `"m³"`. NOT a currency. */
+  unit: string;
+  /**
+   * The nested quantity tree exactly as the goals API returns it. `value`s are
+   * quantities (numbers on the wire); a `monetaryValue` sibling, when present,
+   * is the money **projection** (decimal string) — see {@link MonetaryProjection}.
+   */
+  tree: GoalTreeNode;
+  /** Optimistic-concurrency counter (`0` = never set). */
+  version: number;
+}
+
+/** One node of a goals tree (quantity `value` + optional money projection). */
+export interface GoalTreeNode {
+  /** Quantity target at this node (kWh/m³) — a number on the wire. NOT money. */
+  value?: number;
+  /**
+   * R$ projection for this node from `?withMoney=true` — a **decimal string**
+   * (`"223000.00"`). Preserved verbatim; never `Number()`-ed or summed here.
+   */
+  monetaryValue?: string;
+  annual?: GoalTreeNode;
+  monthly?: Record<string, GoalTreeNode>;
+  daily?: Record<string, GoalTreeNode>;
+  hourly?: Record<string, GoalTreeNode>;
+  [k: string]: unknown;
+}
+
+/** A device excluded from a money sum because it carries no `tariffCategory`. */
+export interface UncategorizedDevice {
+  deviceId: string;
+  code?: string;
+  label?: string;
+}
+
+/** Tariff-coverage gap detail from the `money` block (API guide §4.2). */
+export interface TariffCoverageGaps {
+  /** Missing hour refs, e.g. `["2026-03-01T00"]`. */
+  missing: string[];
+  /** `true` when the `missing` list was capped for size. */
+  truncated: boolean;
+  /** Count of device-hours with no priced tariff. */
+  missingHours: number;
+}
+
+/**
+ * Bridge #3 — the **native** R$ budget target (`measure=CURRENCY`,
+ * GCDR RFC-0054 `budget.target`). This is the ONLY concept that should carry the
+ * frontend name `currencyBudget`. Amount is a decimal string.
+ */
+export interface CurrencyBudget {
+  /** R$ target amount (decimal string). */
+  amount: string;
+  /** Provenance, e.g. `"NATIVE"`. */
+  source: string;
+}
+
+/**
+ * The budget **verdict** — projection vs. native target. Both fields are
+ * **nullable and null together** while coverage is incomplete: the UI must never
+ * declare in/over-budget over a partial projection (GCDR RFC-0054 DEC-6).
+ */
+export interface BudgetVerdict {
+  /** `true`/`false` only when fully covered; `null` while `coverageComplete:false`. */
+  withinBudget: boolean | null;
+  /** R$ variance (projection − target) as a decimal string; `null` while incomplete. */
+  variance: string | null;
+}
+
+/**
+ * The normalized budget overlay carried inside an `available` {@link MoneyOverlay}.
+ * Wraps the wire `budget` block's `variance`/`withinBudget` into a single
+ * {@link BudgetVerdict} so callers read one honest verdict, not two loose fields.
+ */
+export interface BudgetOverlay {
+  /** R$ projection derived from the overlay (may be partial). */
+  projected: { amount: string; source: string; coverageComplete: boolean };
+  /** Native R$ target, present only when a CURRENCY goal exists. */
+  target?: CurrencyBudget;
+  /** The suppressed-while-incomplete verdict (DEC-6). */
+  verdict: BudgetVerdict;
+}
+
+/**
+ * Bridge #2 — the R$ **money overlay**, normalized into a discriminated union
+ * that removes the `money:null`-vs-`money:{reason}` ambiguity the wire carries
+ * (feedback-v1 §6). Exactly two states, both first-class 200-body outcomes:
+ *
+ *  - `available`   — a device-granular goal was priced; `coverageComplete` says
+ *                    whether every device-hour was covered. Amounts are decimal
+ *                    strings. `budget` present only when a CURRENCY goal exists.
+ *  - `unavailable` — no money view (e.g. a customer-granular goal →
+ *                    `MONEY_REQUIRES_DEVICE_GRANULARITY`). NOT an error.
+ */
+export type MoneyOverlay =
+  | {
+      state: 'available';
+      currency: string;
+      coverageComplete: boolean;
+      /** Priced device-hours (numerator of coverage). */
+      pricedHours?: number;
+      /** Total device-hours (denominator of coverage). */
+      totalHours?: number;
+      tariffCoverageGaps?: TariffCoverageGaps;
+      uncategorizedDevices: UncategorizedDevice[];
+      budget?: BudgetOverlay;
+    }
+  | {
+      state: 'unavailable';
+      reason: 'MONEY_REQUIRES_DEVICE_GRANULARITY' | string;
+    };
+
+/**
+ * Bridge #2 as a standalone read — the R$ projection over a whole goal, with the
+ * normalized overlay and the (verbatim, string-amount) tree it priced. Returned
+ * by `goalsMoneyClient.getGoalWithMoney`.
+ */
+export interface MonetaryProjection {
+  customerId: string;
+  domain: MoneyDomain;
+  year: number;
+  /** Goal measure — `QUANTITY` for a withMoney overlay read. */
+  measure: 'QUANTITY' | 'CURRENCY';
+  /** Optimistic-concurrency counter. */
+  version: number;
+  /** The quantity goal that was priced (values are quantities; strings stay strings). */
+  goal: QuantityGoal;
+  /** Normalized money overlay (`available` | `unavailable`). */
+  money: MoneyOverlay;
+}
+
+/** Canonical terminal reason for a withheld money view. */
+export const MONEY_REQUIRES_DEVICE_GRANULARITY = 'MONEY_REQUIRES_DEVICE_GRANULARITY';
+
+/** The raw money block as it may arrive on the wire (either ambiguous shape). */
+export type RawMoneyBlock =
+  | null
+  | undefined
+  | {
+      reason?: string;
+      currency?: string;
+      coverageComplete?: boolean;
+      pricedHours?: number;
+      totalHours?: number;
+      tariffCoverageGaps?: TariffCoverageGaps;
+      uncategorizedDevices?: UncategorizedDevice[];
+      [k: string]: unknown;
+    };
+
+/** The raw `budget` sibling block as it arrives on the wire (API guide §4.2). */
+export type RawBudgetBlock =
+  | null
+  | undefined
+  | {
+      projected?: { amount?: string; source?: string; coverageComplete?: boolean };
+      target?: { amount?: string; source?: string } | null;
+      variance?: string | null;
+      withinBudget?: boolean | null;
+      [k: string]: unknown;
+    };
+
+/**
+ * Collapse the two backend money shapes into the single normalized
+ * {@link MoneyOverlay} discriminated union (feedback-v1 §6):
+ *
+ *  - `money: null` (the reason travels out-of-band; `null` cannot carry a field)
+ *      → `{ state: 'unavailable', reason: MONEY_REQUIRES_DEVICE_GRANULARITY }`.
+ *  - `money: { reason }` (no coverage fields)
+ *      → `{ state: 'unavailable', reason }`.
+ *  - a populated block (has `currency` or `coverageComplete`)
+ *      → `{ state: 'available', … }`, amounts kept as decimal strings.
+ *
+ * The optional `rawBudget` (the sibling `budget` block, not inside `money`) is
+ * folded into the `available` variant's `budget`, with `variance`/`withinBudget`
+ * wrapped into a {@link BudgetVerdict}. Coverage/verdict values are passed through
+ * untouched — never coerced to `true`/`false`/`0` (DEC-6 honesty).
+ */
+export function normalizeMoneyBlock(
+  raw: RawMoneyBlock,
+  rawBudget?: RawBudgetBlock
+): MoneyOverlay {
+  // Shape A: money is null/undefined — reason cannot ride on `null`, so use the
+  // canonical terminal reason. This is a coverage state, not an error.
+  if (raw == null) {
+    return { state: 'unavailable', reason: MONEY_REQUIRES_DEVICE_GRANULARITY };
+  }
+
+  const hasCoverageFields =
+    typeof raw.currency === 'string' || typeof raw.coverageComplete === 'boolean';
+
+  // Shape B: money is `{ reason }` with no coverage fields — unavailable.
+  if (!hasCoverageFields) {
+    const reason =
+      typeof raw.reason === 'string' && raw.reason
+        ? raw.reason
+        : MONEY_REQUIRES_DEVICE_GRANULARITY;
+    return { state: 'unavailable', reason };
+  }
+
+  // Shape C: a populated, available money block.
+  const overlay: Extract<MoneyOverlay, { state: 'available' }> = {
+    state: 'available',
+    currency: typeof raw.currency === 'string' ? raw.currency : 'BRL',
+    coverageComplete: raw.coverageComplete === true,
+    uncategorizedDevices: Array.isArray(raw.uncategorizedDevices)
+      ? raw.uncategorizedDevices
+      : [],
+  };
+  if (typeof raw.pricedHours === 'number') overlay.pricedHours = raw.pricedHours;
+  if (typeof raw.totalHours === 'number') overlay.totalHours = raw.totalHours;
+  if (raw.tariffCoverageGaps) overlay.tariffCoverageGaps = raw.tariffCoverageGaps;
+
+  const budget = normalizeBudgetBlock(rawBudget);
+  if (budget) overlay.budget = budget;
+
+  return overlay;
+}
+
+/**
+ * Normalize the wire `budget` sibling block into a {@link BudgetOverlay}, wrapping
+ * `variance`/`withinBudget` into one {@link BudgetVerdict}. Returns `undefined`
+ * when no budget block is present (no CURRENCY goal). Null verdict fields are
+ * preserved as `null` — never coerced (DEC-6).
+ */
+export function normalizeBudgetBlock(
+  rawBudget: RawBudgetBlock
+): BudgetOverlay | undefined {
+  if (rawBudget == null || typeof rawBudget !== 'object') return undefined;
+  const projected = rawBudget.projected;
+  if (!projected || typeof projected.amount !== 'string') return undefined;
+
+  const overlay: BudgetOverlay = {
+    projected: {
+      amount: projected.amount,
+      source: typeof projected.source === 'string' ? projected.source : 'OVERLAY',
+      coverageComplete: projected.coverageComplete === true,
+    },
+    verdict: {
+      // Explicit `null` when withheld; only pass a boolean through unchanged.
+      withinBudget:
+        typeof rawBudget.withinBudget === 'boolean' ? rawBudget.withinBudget : null,
+      // Variance stays a decimal string, or null while incomplete.
+      variance:
+        typeof rawBudget.variance === 'string' ? rawBudget.variance : null,
+    },
+  };
+  if (
+    rawBudget.target &&
+    typeof rawBudget.target === 'object' &&
+    typeof rawBudget.target.amount === 'string'
+  ) {
+    overlay.target = {
+      amount: rawBudget.target.amount,
+      source:
+        typeof rawBudget.target.source === 'string'
+          ? rawBudget.target.source
+          : 'NATIVE',
+    };
+  }
+  return overlay;
+}

--- a/src/components/financial-goals/moneyVariance.ts
+++ b/src/components/financial-goals/moneyVariance.ts
@@ -1,0 +1,374 @@
+/**
+ * RFC-0228 A7 — Realized-vs-goal **variance in R$** for consumers (RFC-0182 rows /
+ * RFC-0217 card).
+ *
+ * A2a (`financialIndicators.ts`) renders the *card-level* R$ row + deviation chip;
+ * A6 (`reportMoneyColumn.ts`) renders the *aggregate report* R$ cost column. A7 is
+ * the **per-consumer variance** variant: given one consumer's **realized R$**
+ * (`monetaryProjection`) and its **goal/budget R$** (`currencyBudget`), it produces
+ * a signed R$ variance (`realized − goal`) + a % (when the goal is non-zero) and a
+ * chip that says **Abaixo da meta (R$)** (favorable), **Acima da meta (R$)**
+ * (unfavorable), or — when the verdict is indeterminate or coverage is incomplete —
+ * **Variação indisponível** (withheld).
+ *
+ * ── NAMING BRIDGE (RFC-0228 index §"Colisão de nomes `budget`"; F0 `moneyTypes.ts`) ─
+ * A7 speaks **money** names only. `monetaryProjection` = realized R$; `currencyBudget`
+ * = the R$ goal/budget target. It NEVER reads or writes the card's existing `budget`
+ * prop, which is a **quantity** (kWh/m³) goal line, not money.
+ * ───────────────────────────────────────────────────────────────────────────────
+ *
+ * ── DEC-6 verdict-withholding (GCDR RFC-0054; A3 `budgetView.ts`) ───────────────
+ * A conclusion (favorable/unfavorable) is emitted **only** when both amounts are
+ * present AND coverage is confidently complete. When the overlay is `unavailable` /
+ * `coverageComplete !== true`, an amount is missing, or the caller passes an explicit
+ * withhold (a null {@link BudgetVerdict}), A7 returns the **withheld** verdict — no
+ * green/red judgment, no fabricated R$ number. This mirrors A3's `buildVerdictHTML`.
+ * ───────────────────────────────────────────────────────────────────────────────
+ *
+ * ── WORDING CONTRACT (RFC-0228 feedback §8) — DO NOT DRIFT ──────────────────────
+ * Management/coverage projection UX, not billing. ALLOWED: "Acima da meta (R$)",
+ * "Abaixo da meta (R$)", "Variação indisponível", "Na meta (R$)". FORBIDDEN
+ * (never emit): "Fatura", "Faturamento", "Valor final", "Total a pagar".
+ * ───────────────────────────────────────────────────────────────────────────────
+ *
+ * Design rules (mirroring F0/A2a/A6 on this branch):
+ *  - **Pure.** HTML **strings** in/out (fits both the card's innerHTML model and
+ *    `AllReportModal`'s cell splicing) + plain data. No `fetch`, no ThingsBoard.
+ *  - **Amounts are decimal STRINGS.** The signed subtraction reuses A2a's
+ *    {@link subtractDecimals} (integer-cent math, no float drift) and the sign /
+ *    zero-goal test reuses A6's {@link decimalStringToCents} (`BigInt`) — **no
+ *    `Number()` round-trip on any money amount**. The only `Number()` is F0's
+ *    {@link computeDeltaPct}, a derived display metric.
+ *  - **Gate = presence of config.** `createMoneyVarianceColumn(undefined)` yields a
+ *    disabled column whose HTML methods all return `''`, and `renderMoneyVariance`
+ *    returns `null` when there is nothing to show — so a host stays **byte-identical**
+ *    to its pre-A7 output when money is off.
+ */
+
+import type { MoneyOverlay, BudgetVerdict } from './moneyTypes';
+// A2a: the signed decimal subtraction (integer cents, no float drift). Reused, not duplicated.
+import { subtractDecimals, type FinancialChipColors } from './financialIndicators';
+// A6: BigInt cent parsing — used for the sign + zero-goal test (no Number() round-trip).
+import { decimalStringToCents } from './reportMoneyColumn';
+import { DASH, formatBRLDelta, formatDeltaPct, computeDeltaPct } from './moneyFormat';
+
+/** §8 wording — the three chip headlines. No billing word ever. */
+export const VARIANCE_LABEL_ABOVE = 'Acima da meta (R$)';
+export const VARIANCE_LABEL_BELOW = 'Abaixo da meta (R$)';
+export const VARIANCE_LABEL_ONTARGET = 'Na meta (R$)';
+export const VARIANCE_LABEL_WITHHELD = 'Variação indisponível';
+
+/** Default per-consumer variance column header (allowed §8 wording). */
+export const MONEY_VARIANCE_HEADER = 'Variação vs meta (R$)';
+
+/**
+ * Per-consumer money variance input. Uses **money** names (naming bridge): realized
+ * R$ is `monetaryProjection`, the R$ goal is `currencyBudget` — never the quantity
+ * `budget` prop. When `currencyBudget` is omitted it defaults to the overlay's native
+ * budget target (`overlay.budget.target.amount`), mirroring A2a's row resolution.
+ */
+export interface MoneyVarianceInput {
+  /** Realizado em R$ (RFC-0054 monetary projection). Decimal string. */
+  monetaryProjection?: string | null;
+  /** Meta/orçamento em R$ (RFC-0054 CURRENCY target). Decimal string. */
+  currencyBudget?: string | null;
+  /**
+   * Coverage overlay (F0) — the DEC-6 gate. `unavailable` or `coverageComplete !==
+   * true` → the variance is **withheld** (no judgment, no number). Omitted → coverage
+   * is not gating (the caller vouches the amounts are confident).
+   */
+  overlay?: MoneyOverlay | null;
+  /**
+   * Explicit withhold override — e.g. a null {@link BudgetVerdict.withinBudget} the
+   * caller already resolved. `true` forces the withheld chip regardless of amounts.
+   */
+  withheld?: boolean;
+}
+
+/** The resolved verdict for one consumer's R$ variance. */
+export type MoneyVarianceVerdict = 'below' | 'above' | 'onTarget' | 'withheld';
+
+/** The pure result of {@link computeMoneyVariance}. */
+export interface MoneyVarianceResult {
+  /** `below` (favorable) / `above` (unfavorable) / `onTarget` / `withheld` (DEC-6). */
+  verdict: MoneyVarianceVerdict;
+  /** Signed R$ variance (`realized − goal`) as a decimal string; `null` when withheld. */
+  variance: string | null;
+  /** Signed % vs the goal (`null` when the goal is zero, missing, or withheld). */
+  pct: number | null;
+}
+
+const WITHHELD_RESULT: MoneyVarianceResult = Object.freeze({
+  verdict: 'withheld',
+  variance: null,
+  pct: null,
+});
+
+/** A decimal string is "present" when it is a non-empty, non-null string. */
+function hasAmount(s: string | null | undefined): s is string {
+  return typeof s === 'string' && s.trim() !== '';
+}
+
+/**
+ * `true` when the overlay withholds the verdict per DEC-6 — i.e. it is present and
+ * NOT confidently priced (`unavailable`, or `available` but `coverageComplete !==
+ * true`). An absent overlay does not gate (returns `false`). Also honors an
+ * explicit null {@link BudgetVerdict} carried on an available overlay's budget.
+ */
+export function overlayWithholdsVerdict(overlay: MoneyOverlay | null | undefined): boolean {
+  if (!overlay || typeof (overlay as { state?: unknown }).state !== 'string') return false;
+  if (overlay.state === 'unavailable') return true;
+  if (overlay.coverageComplete !== true) return true;
+  // A native budget verdict that is explicitly withheld (null) also withholds A7.
+  const verdict: BudgetVerdict | undefined = overlay.budget?.verdict;
+  if (verdict && verdict.withinBudget !== true && verdict.withinBudget !== false) {
+    // Only treat as withheld when a budget block is actually present with a null verdict.
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Resolve the R$ goal for a consumer: explicit `currencyBudget` wins; otherwise the
+ * overlay's native budget target (`overlay.budget.target.amount`). Pure — the decimal
+ * string passes through verbatim, never `Number()`-ed.
+ */
+export function resolveGoalAmount(input: MoneyVarianceInput): string | null {
+  if (hasAmount(input.currencyBudget)) return input.currencyBudget as string;
+  const overlay = input.overlay;
+  if (overlay && overlay.state === 'available' && hasAmount(overlay.budget?.target?.amount)) {
+    return overlay.budget!.target!.amount;
+  }
+  return null;
+}
+
+/**
+ * Compute the signed R$ variance + verdict for one consumer. **DEC-6**: withholds
+ * (no number, no judgment) when the overlay is not confidently priced, when either
+ * amount is missing, when the caller forces `withheld`, or when the subtraction is
+ * not well-formed. The subtraction reuses A2a's {@link subtractDecimals} (integer
+ * cents, no float drift); the sign + zero-goal test reuse A6's
+ * {@link decimalStringToCents} (`BigInt`) — no `Number()` touches a money amount.
+ */
+export function computeMoneyVariance(input: MoneyVarianceInput): MoneyVarianceResult {
+  if (!input || input.withheld === true) return WITHHELD_RESULT;
+  if (overlayWithholdsVerdict(input.overlay)) return WITHHELD_RESULT;
+
+  const realized = hasAmount(input.monetaryProjection) ? (input.monetaryProjection as string) : null;
+  const goal = resolveGoalAmount(input);
+  if (realized == null || goal == null) return WITHHELD_RESULT;
+
+  // A2a reuse — signed variance in integer cents (drift-free), returned as a string.
+  const variance = subtractDecimals(realized, goal);
+  if (variance == null) return WITHHELD_RESULT;
+
+  // A6 reuse — sign of the variance and the zero-goal test via BigInt cents (no Number).
+  const varCents = decimalStringToCents(variance);
+  const goalCents = decimalStringToCents(goal);
+  if (varCents == null) return WITHHELD_RESULT;
+
+  // % only when the goal is a non-zero amount (avoids divide-by-zero / Infinity).
+  const pct = goalCents != null && goalCents !== 0n ? computeDeltaPct(realized, goal) : null;
+
+  const verdict: MoneyVarianceVerdict =
+    varCents > 0n ? 'above' : varCents < 0n ? 'below' : 'onTarget';
+  return { verdict, variance, pct };
+}
+
+/** Default chip palette — mirrors A2a's `DEFAULT_CHIP` (over=red, under=green, neutral=grey). */
+const DEFAULT_CHIP: Required<FinancialChipColors> = {
+  overBg: '#fee2e2',
+  overText: '#b91c1c',
+  underBg: '#dcfce7',
+  underText: '#15803d',
+  neutralBg: '#f1f5f9',
+  neutralText: '#64748b',
+};
+
+const CHIP_BASE =
+  'border-radius:999px;padding:2px 10px;font:700 11px Nunito,sans-serif;white-space:nowrap;display:inline-flex;align-items:center;gap:4px;';
+
+/**
+ * Build the variance chip for one consumer as an HTML **string** (pure — no DOM). The
+ * chip carries `data-money-variance="below|above|ontarget|withheld"` for tests.
+ *
+ * - **below** (favorable): green ↓ "Abaixo da meta (R$)" + signed R$ + %.
+ * - **above** (unfavorable): red ↑ "Acima da meta (R$)" + signed R$ + %.
+ * - **onTarget**: grey ≈ "Na meta (R$)" + R$ 0,00.
+ * - **withheld** (DEC-6): grey "Variação indisponível" — **no number, no judgment**.
+ */
+export function buildMoneyVarianceHTML(
+  input: MoneyVarianceInput,
+  chipColors: Required<FinancialChipColors> = DEFAULT_CHIP
+): string {
+  const r = computeMoneyVariance(input);
+
+  // DEC-6: withheld — never a green/red judgment, never a fabricated R$ number.
+  if (r.verdict === 'withheld') {
+    return (
+      `<span data-money-variance="withheld" style="background:${chipColors.neutralBg};color:${chipColors.neutralText};${CHIP_BASE}">` +
+      `${VARIANCE_LABEL_WITHHELD}</span>`
+    );
+  }
+
+  const amount = hasAmount(r.variance) ? formatBRLDelta(r.variance) : DASH;
+  const pctTxt = r.pct == null ? '' : ` &middot; ${formatDeltaPct(r.pct)}`;
+
+  if (r.verdict === 'above') {
+    return (
+      `<span data-money-variance="above" title="${VARIANCE_LABEL_ABOVE}" style="background:${chipColors.overBg};color:${chipColors.overText};${CHIP_BASE}">` +
+      `&#8593; ${VARIANCE_LABEL_ABOVE} ${amount}${pctTxt}</span>`
+    );
+  }
+  if (r.verdict === 'below') {
+    return (
+      `<span data-money-variance="below" title="${VARIANCE_LABEL_BELOW}" style="background:${chipColors.underBg};color:${chipColors.underText};${CHIP_BASE}">` +
+      `&#8595; ${VARIANCE_LABEL_BELOW} ${amount}${pctTxt}</span>`
+    );
+  }
+  // onTarget — neutral, still a real number (variance is exactly 0), never withheld.
+  return (
+    `<span data-money-variance="ontarget" title="${VARIANCE_LABEL_ONTARGET}" style="background:${chipColors.neutralBg};color:${chipColors.neutralText};${CHIP_BASE}">` +
+    `&#8776; ${VARIANCE_LABEL_ONTARGET} ${amount}${pctTxt}</span>`
+  );
+}
+
+/** Options for {@link renderMoneyVariance} (the RFC-0217 card readout). */
+export interface MoneyVarianceOptions extends MoneyVarianceInput {
+  /** Optional leading label, e.g. "Meta em R$". Rendered before the chip. */
+  label?: string;
+  /** Chip palette override (defaults mirror A2a's `DEFAULT_CHIP`). */
+  chipColors?: FinancialChipColors;
+  /** Document to build in (defaults to the ambient `document`). */
+  document?: Document;
+}
+
+/**
+ * Render the per-consumer R$ variance as a live DOM element for the CustomerGoalsCard
+ * (RFC-0217) — or `null` when there is nothing to show (money off), so the card stays
+ * byte-identical to its quantity-only view.
+ *
+ * Gate: returns `null` when no overlay AND no amounts AND no explicit withhold were
+ * given. Otherwise returns a `.myio-money-variance` element carrying the chip (which
+ * is `withheld` under DEC-6 when coverage/verdict is indeterminate).
+ */
+export function renderMoneyVariance(options: MoneyVarianceOptions): HTMLElement | null {
+  if (!options) return null;
+  const hasOverlay =
+    !!options.overlay && typeof (options.overlay as { state?: unknown }).state === 'string';
+  const hasAnyAmount = hasAmount(options.monetaryProjection) || hasAmount(options.currencyBudget);
+  // Gate off → nothing to append (card unchanged).
+  if (!hasOverlay && !hasAnyAmount && options.withheld !== true) return null;
+
+  const doc = options.document || (typeof document !== 'undefined' ? document : undefined);
+  if (!doc) {
+    throw new Error(
+      'renderMoneyVariance requires a document (pass options.document in non-DOM envs).'
+    );
+  }
+
+  const chipColors: Required<FinancialChipColors> = { ...DEFAULT_CHIP, ...options.chipColors };
+  const root = doc.createElement('div');
+  root.className = 'myio-money-variance';
+  root.setAttribute('data-money-variance-row', '1');
+  const label = hasAmount(options.label)
+    ? `<span class="myio-money-variance__label" style="font:600 11px Nunito,sans-serif;color:var(--gc-muted, #64748b);margin-right:6px;">${escapeText(
+        options.label as string
+      )}</span>`
+    : '';
+  root.innerHTML =
+    `<div style="display:inline-flex;align-items:center;flex-wrap:wrap;gap:4px;">` +
+    label +
+    buildMoneyVarianceHTML(options, chipColors) +
+    `</div>`;
+  return root;
+}
+
+/** Escape untrusted label text for safe HTML interpolation. */
+function escapeText(s: string): string {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/** Config for the per-consumer variance report column (mirrors A6's factory shape). */
+export interface MoneyVarianceColumnConfig {
+  /** Aggregate coverage overlay (F0) — DEC-6 gate for every row's verdict. */
+  overlay: MoneyOverlay;
+  /** Realizado R$ per device id (monetaryProjection). Same map A6 uses for its cost cell. */
+  perDeviceRealized: Record<string, string | null | undefined>;
+  /** Meta/orçamento R$ per device id (currencyBudget). Its presence enables the column. */
+  perDeviceGoal: Record<string, string | null | undefined>;
+  /** Column header label override (defaults to {@link MONEY_VARIANCE_HEADER}). */
+  headerLabel?: string;
+  /** Chip palette override. */
+  chipColors?: FinancialChipColors;
+}
+
+/** A disabled or enabled variance column, exposing pure HTML-string fragments. */
+export interface MoneyVarianceColumn {
+  /** `false` when no config was given (gate off) — every method below returns `''`. */
+  readonly enabled: boolean;
+  /** `<th>` for the variance column, or `''` when disabled. */
+  headerCellHTML(): string;
+  /** `<td>` variance chip for one device id, or `''` when disabled. */
+  bodyCellHTML(deviceId: string | null | undefined): string;
+  /** Just the chip inner (without a `<td>`), or `''` when disabled. */
+  cellValueHTML(deviceId: string | null | undefined): string;
+}
+
+const DISABLED_COLUMN: MoneyVarianceColumn = {
+  enabled: false,
+  headerCellHTML: () => '',
+  bodyCellHTML: () => '',
+  cellValueHTML: () => '',
+};
+
+/**
+ * Build the per-consumer R$ variance column from a resolved config (mirrors A6's
+ * `createReportMoneyColumn`). **Gate:** a `null`/absent config — or one with no
+ * `perDeviceGoal` map — returns {@link DISABLED_COLUMN}, whose fragments are all `''`,
+ * so a host splicing them stays byte-identical to its pre-A7 output.
+ */
+export function createMoneyVarianceColumn(
+  config?: MoneyVarianceColumnConfig | null
+): MoneyVarianceColumn {
+  if (
+    !config ||
+    typeof (config.overlay as { state?: unknown })?.state !== 'string' ||
+    !config.perDeviceGoal
+  ) {
+    return DISABLED_COLUMN;
+  }
+
+  const overlay = config.overlay;
+  const perDeviceRealized = config.perDeviceRealized || {};
+  const perDeviceGoal = config.perDeviceGoal || {};
+  const label = config.headerLabel || MONEY_VARIANCE_HEADER;
+  const chipColors: Required<FinancialChipColors> = { ...DEFAULT_CHIP, ...config.chipColors };
+
+  const chipFor = (deviceId: string | null | undefined): string => {
+    const id = hasAmount(deviceId) ? (deviceId as string) : null;
+    return buildMoneyVarianceHTML(
+      {
+        overlay,
+        monetaryProjection: id ? perDeviceRealized[id] : null,
+        currencyBudget: id ? perDeviceGoal[id] : null,
+      },
+      chipColors
+    );
+  };
+
+  return {
+    enabled: true,
+    headerCellHTML: () =>
+      `<th data-money-variance-col="1" style="text-align:right;white-space:nowrap;">${label}</th>`,
+    bodyCellHTML: (deviceId) =>
+      `<td data-money-variance-col="1" data-label="${label}" style="text-align:right;">${chipFor(
+        deviceId
+      )}</td>`,
+    cellValueHTML: (deviceId) => chipFor(deviceId),
+  };
+}

--- a/src/components/financial-goals/reportMoneyColumn.ts
+++ b/src/components/financial-goals/reportMoneyColumn.ts
@@ -1,0 +1,277 @@
+/**
+ * RFC-0228 A6 — R$ money column for **aggregate report rows/totals**.
+ *
+ * A6 is the report/summary face of the money layer: it puts an R$ figure **beside**
+ * the existing kWh/m³ column of `AllReportModal` (RFC-0182) and the energy summary,
+ * on the **DEC-8 rounding contract** (GCDR RFC-0054). It reuses A2a/F0 formatting
+ * (`formatMoneyBRL`) and A4's honest-coverage discipline (`buildCoverageHTML`) — it
+ * re-implements neither a BRL formatter nor a coverage renderer.
+ *
+ * ── DEC-8 (GCDR RFC-0054-Monetary-Goals-and-Customer-Tariffs.md §DEC-8), verbatim ──
+ *   "The server computes every R$; clients consume the decimal string and never
+ *    re-derive. Money is `numeric`, serialized as a **decimal string**, never a
+ *    JSON number."
+ *   "monetaryValue(N) = round_half_up(raw(N), 2)  [round ONCE, at this node's boundary]"
+ *   "One rounding boundary, top-down. Parent = round(Σ child full-precision raws),
+ *    NOT the sum of children's already-rounded values."
+ *   "round_half_up operates on the exact decimal value at 2 places (BRL), half away
+ *    from zero."
+ *
+ * How A6 obeys DEC-8:
+ *  1. **Never re-derive.** Per-row R$ (`perDevice[id]`) and the aggregate come from
+ *     the backend as decimal strings and are only *formatted* for display via
+ *     {@link formatMoneyBRL} — never `Number()`-round-tripped.
+ *  2. **Prefer the backend parent total.** Because "Parent = round(Σ child
+ *     full-precision raws), NOT the sum of children's already-rounded values", the
+ *     backend-authoritative aggregate (`total`) is the correct footer number; A6
+ *     shows it verbatim when provided.
+ *  3. **String-only fallback sum.** When the backend does not hand down a parent
+ *     total, A6 sums the already-2dp per-row values in **integer cents via `BigInt`**
+ *     (no float, no new rounding boundary — the rows are already `round_half_up`ed).
+ *     This is a display convenience clearly derived from the visible rows, not a
+ *     re-derivation of the priced raw.
+ *  4. **Honest coverage.** When the overlay is `unavailable` or coverage is
+ *     incomplete, the footer/summary shows A4's coverage indicator — **never** R$ 0,
+ *     NaN, or a partial sum presented as a complete total.
+ *
+ * ── WORDING CONTRACT (RFC-0228 feedback §8) — DO NOT DRIFT ──────────────────────
+ * Management projection UX, not billing. ALLOWED: "Custo projetado", "Estimado R$",
+ * "Cobertura incompleta". FORBIDDEN (never emit): "Fatura", "Faturamento",
+ * "Valor final", "Total a pagar".
+ * ───────────────────────────────────────────────────────────────────────────────
+ *
+ * Design rules (mirroring F0/A2a/A4 on this branch):
+ *  - **Pure.** HTML **strings** in/out (fits `AllReportModal`'s innerHTML model) +
+ *    plain data. No `fetch`, no ThingsBoard. It receives a resolved money config; it
+ *    never fetches one.
+ *  - **Amounts are decimal STRINGS.** The only integer math is `BigInt` cents; no
+ *    `Number()` is applied to a money string.
+ *  - **Gate = presence of config.** `createReportMoneyColumn(undefined)` yields a
+ *    disabled column whose every HTML method returns `''`, so a host that splices the
+ *    fragments in is **byte-identical** to its pre-A6 output when money is off.
+ */
+
+import type { MoneyOverlay } from './moneyTypes';
+// `formatBRL` is the string-based BRL formatter (top-level re-export: `formatMoneyBRL`).
+import { DASH, formatBRL as formatMoneyBRL, formatBRLDelta } from './moneyFormat';
+import { buildCoverageHTML } from './coverageView';
+
+/** Default R$ column header — allowed §8 wording, never a billing word. */
+export const REPORT_MONEY_HEADER = 'Custo projetado (R$)';
+
+/** Config for the R$ report column. Absent/`null` → the column is disabled (gate off). */
+export interface ReportMoneyColumnConfig {
+  /**
+   * Aggregate money overlay (F0) — drives the honest-coverage gate for the total:
+   *  - `available` + `coverageComplete:true` → a numeric R$ total is shown.
+   *  - `unavailable` / `coverageComplete:false` → A4 coverage indicator, no number.
+   */
+  overlay: MoneyOverlay;
+  /** Per-device R$ (backend `monetaryValue`, DEC-8 2dp) keyed by device id (ingestionId). */
+  perDevice: Record<string, string | null | undefined>;
+  /**
+   * Backend-authoritative aggregate R$ (DEC-8 top-down parent). **Preferred** for the
+   * footer total when present; when absent A6 falls back to a BigInt-cent row sum.
+   */
+  total?: string | null;
+  /**
+   * Optional R$ deviation vs the meta (e.g. `overlay.budget.verdict.variance`).
+   * Rendered as a small "vs Meta" note beside the total when coverage is complete.
+   * A7 owns the per-consumer variance chip — A6 only surfaces the report-total delta.
+   */
+  variance?: string | null;
+  /** Column header label override (defaults to {@link REPORT_MONEY_HEADER}). */
+  headerLabel?: string;
+}
+
+/** The resolved report/summary total: either a confident amount or a coverage state. */
+export type ReportMoneyTotal =
+  | { kind: 'amount'; amount: string; formatted: string; source: 'backend' | 'row-sum' }
+  | { kind: 'coverage'; overlay: MoneyOverlay };
+
+/** A disabled or enabled R$ column, exposing pure HTML-string fragments for a host. */
+export interface ReportMoneyColumn {
+  /** `false` when no config was given (gate off) — every method below returns `''`/`null`. */
+  readonly enabled: boolean;
+  /** `<th>` for the R$ column, or `''` when disabled. */
+  headerCellHTML(): string;
+  /** `<td>` R$ cell for one device id (formatted backend string or `—`), or `''` when disabled. */
+  bodyCellHTML(deviceId: string | null | undefined): string;
+  /** Just the formatted cell inner (`"R$ …"`/`—`) without a `<td>`, or `''` when disabled. */
+  cellValueHTML(deviceId: string | null | undefined): string;
+  /**
+   * Resolve the footer/summary total honestly. `rowValues` (aligned to the counted
+   * rows) is only used for the DEC-8 fallback row-sum when no backend total is given.
+   * Returns `null` when disabled.
+   */
+  resolveTotal(rowValues?: Array<string | null | undefined>): ReportMoneyTotal | null;
+  /**
+   * Footer/summary total as HTML: a formatted R$ (+ optional "vs Meta" note) when
+   * coverage is complete, else A4's coverage indicator. `''` when disabled.
+   */
+  totalHTML(rowValues?: Array<string | null | undefined>): string;
+}
+
+/** True when the overlay is confidently priced (available + fully covered). */
+export function isMoneyColumnConfident(overlay: MoneyOverlay | null | undefined): boolean {
+  return (
+    !!overlay &&
+    (overlay as { state?: string }).state === 'available' &&
+    (overlay as { coverageComplete?: boolean }).coverageComplete === true
+  );
+}
+
+/** A decimal string is "present" when it is a non-empty, non-null string. */
+function hasAmount(s: string | null | undefined): s is string {
+  return typeof s === 'string' && s.trim() !== '';
+}
+
+/**
+ * Parse a decimal string into **integer cents** as a `BigInt` — pure string ops, no
+ * float. Per DEC-8 the input is already `round_half_up(·,2)`; a stray 3rd digit is
+ * defensively rounded half-up (half away from zero) via BigInt carry, never `Number`.
+ * Returns `null` for anything that is not a finite decimal string.
+ */
+export function decimalStringToCents(s: string | null | undefined): bigint | null {
+  if (!hasAmount(s)) return null;
+  const m = /^([+-]?)(\d+)(?:\.(\d+))?$/.exec(s.trim());
+  if (!m) return null;
+  const negative = m[1] === '-';
+  const whole = BigInt(m[2]);
+  const frac = m[3] || '';
+  let cents = BigInt(frac.slice(0, 2).padEnd(2, '0')); // 0..99
+  // round_half_up on the 3rd fraction digit (defensive; DEC-8 rows are already 2dp).
+  if (frac.charAt(2) >= '5') cents += 1n; // may reach 100 → carries into `whole` below
+  const total = whole * 100n + cents;
+  return negative ? -total : total;
+}
+
+/** Format `BigInt` cents back to a 2dp decimal string (`-12345n` → `"-123.45"`). */
+export function centsToDecimalString(cents: bigint): string {
+  const negative = cents < 0n;
+  const abs = negative ? -cents : cents;
+  const whole = abs / 100n;
+  const rem = abs % 100n;
+  return `${negative ? '-' : ''}${whole.toString()}.${rem.toString().padStart(2, '0')}`;
+}
+
+/**
+ * Sum a set of decimal-string amounts and return a decimal string — **integer-cent
+ * `BigInt` math, never float** (so `"0.10" + "0.20"` is exactly `"0.30"`, and a long
+ * run of `x.xx` cents that would drift under `Number()` addition does not drift here).
+ *
+ * DEC-8: the rows are already `round_half_up(·,2)`; summing their 2dp cents introduces
+ * **no new rounding boundary**. Returns `null` when the input is empty or **any** value
+ * is missing/invalid — an honest "cannot total", never a silent partial sum.
+ */
+export function sumMoneyDecimals(values: Array<string | null | undefined>): string | null {
+  if (!Array.isArray(values) || values.length === 0) return null;
+  let acc = 0n;
+  for (const v of values) {
+    const c = decimalStringToCents(v);
+    if (c == null) return null; // cannot honestly total with a missing/invalid row
+    acc += c;
+  }
+  return centsToDecimalString(acc);
+}
+
+/** One R$ figure cell inner: formatted backend string, or `—` (never `R$ 0`/NaN). */
+function cellInner(value: string | null | undefined): string {
+  return `<span data-money-cell="1">${formatMoneyBRL(value ?? null)}</span>`;
+}
+
+/** The variance-vs-meta note ("vs Meta ±R$ …"), or `''` when absent. */
+function varianceNoteHTML(variance: string | null | undefined): string {
+  if (!hasAmount(variance)) return '';
+  return (
+    `<span data-money-variance="1" style="margin-left:6px;font:600 10px Nunito,sans-serif;color:var(--myio-text-muted,#94a3b8);">` +
+    `vs Meta ${formatBRLDelta(variance)}` +
+    `</span>`
+  );
+}
+
+const DISABLED_COLUMN: ReportMoneyColumn = {
+  enabled: false,
+  headerCellHTML: () => '',
+  bodyCellHTML: () => '',
+  cellValueHTML: () => '',
+  resolveTotal: () => null,
+  totalHTML: () => '',
+};
+
+/**
+ * Build the R$ report column from a resolved money config. **Gate:** a `null`/absent
+ * config returns {@link DISABLED_COLUMN} — every HTML method emits `''`, so a host
+ * that interpolates the fragments stays byte-identical to its pre-A6 output.
+ */
+export function createReportMoneyColumn(
+  config?: ReportMoneyColumnConfig | null
+): ReportMoneyColumn {
+  if (!config || typeof (config.overlay as { state?: unknown })?.state !== 'string') {
+    return DISABLED_COLUMN;
+  }
+
+  const overlay = config.overlay;
+  const perDevice = config.perDevice || {};
+  const label = config.headerLabel || REPORT_MONEY_HEADER;
+
+  const valueFor = (deviceId: string | null | undefined): string | null | undefined =>
+    hasAmount(deviceId) ? perDevice[deviceId as string] : null;
+
+  const resolveTotal = (
+    rowValues?: Array<string | null | undefined>
+  ): ReportMoneyTotal => {
+    // Honest coverage: only a confidently-priced overlay yields a number.
+    if (!isMoneyColumnConfident(overlay)) {
+      return { kind: 'coverage', overlay };
+    }
+    // DEC-8: "Parent = round(Σ child full-precision raws), NOT the sum of children's
+    // already-rounded values" — so the backend parent total is authoritative; prefer it.
+    if (hasAmount(config.total)) {
+      return {
+        kind: 'amount',
+        amount: config.total as string,
+        formatted: formatMoneyBRL(config.total as string),
+        source: 'backend',
+      };
+    }
+    // Fallback: sum the already-2dp rows in integer cents (no float, no re-rounding).
+    const summed = sumMoneyDecimals(rowValues || []);
+    if (summed == null) {
+      // Cannot honestly total (missing rows) → defer to the coverage indicator.
+      return { kind: 'coverage', overlay };
+    }
+    return {
+      kind: 'amount',
+      amount: summed,
+      formatted: formatMoneyBRL(summed),
+      source: 'row-sum',
+    };
+  };
+
+  return {
+    enabled: true,
+    headerCellHTML: () =>
+      `<th data-money-col="1" style="text-align:right;white-space:nowrap;">${label}</th>`,
+    bodyCellHTML: (deviceId) =>
+      `<td data-money-col="1" data-label="${label}" style="text-align:right;font-weight:bold;">${cellInner(
+        valueFor(deviceId)
+      )}</td>`,
+    cellValueHTML: (deviceId) => cellInner(valueFor(deviceId)),
+    resolveTotal,
+    totalHTML: (rowValues) => {
+      const total = resolveTotal(rowValues);
+      if (total.kind === 'coverage') {
+        // A4 owns the honest coverage UI — never a number, never R$ 0.
+        return `<span data-money-total="coverage">${buildCoverageHTML(total.overlay, false)}</span>`;
+      }
+      return (
+        `<span data-money-total="amount" data-money-source="${total.source}">${total.formatted}</span>` +
+        varianceNoteHTML(config.variance)
+      );
+    },
+  };
+}
+
+/** Re-export so hosts can pull the DASH sentinel without a second import. */
+export { DASH };

--- a/src/components/premium-modals/report-all/AllReportModal.ts
+++ b/src/components/premium-modals/report-all/AllReportModal.ts
@@ -20,6 +20,13 @@ import { createGranularitySelector } from '../../granularity-selector';
 import type { GranularitySelectorInstance } from '../../granularity-selector';
 import { createModalFooter } from '../footer-modal';
 import type { ModalFooterInstance } from '../footer-modal';
+// RFC-0228 A6 — R$ money column (additive + gated). `createReportMoneyColumn(undefined)`
+// yields a disabled column whose HTML methods all return '' → byte-identical when off.
+import {
+  createReportMoneyColumn,
+  type ReportMoneyColumn,
+} from '../../financial-goals/reportMoneyColumn';
+import { injectCoverageStyles } from '../../financial-goals/coverageStyles';
 
 // Domain configuration
 type Domain = 'energy' | 'water' | 'temperature';
@@ -113,6 +120,10 @@ export class AllReportModal {
   // Os botões de export vivem AQUI (removidos da toolbar).
   private modalFooter: ModalFooterInstance | null = null;
 
+  // RFC-0228 A6 — R$ money column. Disabled (all fragments '') when params.money is
+  // absent, so the table/summary stay byte-identical to the pre-A6 report.
+  private moneyColumn: ReportMoneyColumn;
+
   constructor(private params: OpenAllReportParams) {
     this.authClient = new AuthClient({
       clientId: params.api.clientId,
@@ -126,6 +137,13 @@ export class AllReportModal {
 
     // Set debug flag from params (1 = enabled, 0 = disabled)
     this.debugEnabled = params.debug === 1;
+
+    // RFC-0228 A6 — gate: no `money` config → disabled column (all HTML '' → byte-identical).
+    this.moneyColumn = createReportMoneyColumn(params.money ?? null);
+    if (this.moneyColumn.enabled && typeof document !== 'undefined') {
+      // A4 coverage indicator (incomplete/unavailable total) needs its stylesheet.
+      injectCoverageStyles(document);
+    }
 
     this.debugLog('🚀 AllReportModal initialized', {
       customerId: params.customerId,
@@ -719,7 +737,31 @@ export class AllReportModal {
       },
     ];
     if (!isTemperature) kpis.push({ value: String(zeroCount), label: 'Sem Consumo' });
+
+    // RFC-0228 A6 — additive R$ KPI (only when the money gate is on). Honest total
+    // when coverage is complete, else a coverage label — never R$ 0 / NaN.
+    const moneyKpi = this.computeMoneyKpi();
+    if (moneyKpi) kpis.push(moneyKpi);
+
     return kpis;
+  }
+
+  // RFC-0228 A6 — the "Custo projetado (R$)" summary KPI, or null when money is off.
+  // Reuses the A6 column's honest-coverage resolution: a formatted R$ total only when
+  // the overlay is confidently priced (DEC-8), otherwise a coverage state label.
+  private computeMoneyKpi(): { value: string; label: string; sub?: string } | null {
+    if (!this.moneyColumn.enabled) return null;
+    const rowValues = this.data.map((r) => (r.id ? this.params.money?.perDevice?.[r.id] : null));
+    const total = this.moneyColumn.resolveTotal(rowValues);
+    if (!total) return null;
+    const label = this.params.money?.headerLabel || 'Custo projetado (R$)';
+    if (total.kind === 'amount') {
+      return { value: total.formatted, label };
+    }
+    // Coverage state — honest label, never a number (§8-allowed wording).
+    const value =
+      total.overlay.state === 'unavailable' ? 'Indisponível' : 'Cobertura incompleta';
+    return { value, label };
   }
 
   private renderTable(): void {
@@ -747,6 +789,10 @@ export class AllReportModal {
     const grandTotal = this.calculateTotalConsumption();
     const pct = (v: number) => (grandTotal > 0 ? `${fmtPt((v / grandTotal) * 100)}%` : '—');
 
+    // RFC-0228 A6 — money fragments: '' when the gate is off (byte-identical), an
+    // extra R$ <td>/<th> when a money overlay was provided.
+    const moneyCell = (row: StoreReading): string => this.moneyColumn.bodyCellHTML(row.id);
+
     const tableRows = isGrouped
       ? this.renderGroupedRows(paginatedData, grandTotal)
       : paginatedData
@@ -756,7 +802,7 @@ export class AllReportModal {
             <td data-label="Identificador" style="font-family: monospace; font-weight: bold; text-transform: uppercase;">${row.identifier}</td>
             <td data-label="Nome"><strong>${row.name}</strong></td>
             <td data-label="${this.domainConfig.label}" style="text-align: right; font-weight: bold;">${fmtPt(row.consumption)}</td>
-            <td data-label="%" style="text-align: right; color: var(--myio-text-muted);">${pct(row.consumption)}</td>
+            ${moneyCell(row)}<td data-label="%" style="text-align: right; color: var(--myio-text-muted);">${pct(row.consumption)}</td>
           </tr>
         `
           )
@@ -809,7 +855,7 @@ export class AllReportModal {
                 ${this.domainConfig.label}
                 <span style="margin-left: 4px; opacity: ${this.getSortOpacity('consumption')};">${this.getSortIcon('consumption')}</span>
               </th>
-              <th style="text-align: right; width: 14%;">%</th>
+              ${this.moneyColumn.headerCellHTML()}<th style="text-align: right; width: 14%;">%</th>
             </tr>
           </thead>
           <tbody>${tableRows}</tbody>
@@ -894,7 +940,7 @@ export class AllReportModal {
 
         const header = `
         <tr class="rp-group-header">
-          <td colspan="4">
+          <td colspan="${this.moneyColumn.enabled ? 5 : 4}">
             ${groupLabel}
             <span class="rp-group-total">${items.length} dispositivos · ${fmtPt(groupTotal)} ${this.domainConfig.unit}</span>
           </td>
@@ -907,7 +953,7 @@ export class AllReportModal {
           <td data-label="Identificador" style="font-family: monospace; font-weight: bold; text-transform: uppercase;">${row.identifier}</td>
           <td data-label="Nome"><strong>${row.name}</strong></td>
           <td data-label="${this.domainConfig.label}" style="text-align: right; font-weight: bold;">${fmtPt(row.consumption)}</td>
-          <td data-label="%" style="text-align: right; color: var(--myio-text-muted);">${pct(row.consumption)}</td>
+          ${this.moneyColumn.bodyCellHTML(row.id)}<td data-label="%" style="text-align: right; color: var(--myio-text-muted);">${pct(row.consumption)}</td>
         </tr>`
           )
           .join('');

--- a/src/components/premium-modals/report-all/AllReportModal.ts
+++ b/src/components/premium-modals/report-all/AllReportModal.ts
@@ -26,6 +26,13 @@ import {
   createReportMoneyColumn,
   type ReportMoneyColumn,
 } from '../../financial-goals/reportMoneyColumn';
+// RFC-0228 A7 — per-consumer realized-vs-goal R$ variance chip (additive + gated).
+// `createMoneyVarianceColumn(undefined)` (or a config without `perDeviceGoal`) yields
+// a disabled column whose HTML methods all return '' → byte-identical when off.
+import {
+  createMoneyVarianceColumn,
+  type MoneyVarianceColumn,
+} from '../../financial-goals/moneyVariance';
 import { injectCoverageStyles } from '../../financial-goals/coverageStyles';
 
 // Domain configuration
@@ -124,6 +131,10 @@ export class AllReportModal {
   // absent, so the table/summary stay byte-identical to the pre-A6 report.
   private moneyColumn: ReportMoneyColumn;
 
+  // RFC-0228 A7 — per-consumer realized-vs-goal R$ variance column. Disabled (all
+  // fragments '') when params.money.perDeviceGoal is absent → byte-identical.
+  private varianceColumn: MoneyVarianceColumn;
+
   constructor(private params: OpenAllReportParams) {
     this.authClient = new AuthClient({
       clientId: params.api.clientId,
@@ -144,6 +155,19 @@ export class AllReportModal {
       // A4 coverage indicator (incomplete/unavailable total) needs its stylesheet.
       injectCoverageStyles(document);
     }
+
+    // RFC-0228 A7 — gate: no `money.perDeviceGoal` → disabled column (all HTML '').
+    // Realized R$ reuses A6's per-device map; the goal comes from perDeviceGoal.
+    this.varianceColumn = createMoneyVarianceColumn(
+      params.money && params.money.perDeviceGoal
+        ? {
+            overlay: params.money.overlay,
+            perDeviceRealized: params.money.perDevice,
+            perDeviceGoal: params.money.perDeviceGoal,
+            headerLabel: params.money.varianceHeaderLabel,
+          }
+        : null
+    );
 
     this.debugLog('🚀 AllReportModal initialized', {
       customerId: params.customerId,
@@ -802,7 +826,7 @@ export class AllReportModal {
             <td data-label="Identificador" style="font-family: monospace; font-weight: bold; text-transform: uppercase;">${row.identifier}</td>
             <td data-label="Nome"><strong>${row.name}</strong></td>
             <td data-label="${this.domainConfig.label}" style="text-align: right; font-weight: bold;">${fmtPt(row.consumption)}</td>
-            ${moneyCell(row)}<td data-label="%" style="text-align: right; color: var(--myio-text-muted);">${pct(row.consumption)}</td>
+            ${moneyCell(row)}${this.varianceColumn.bodyCellHTML(row.id)}<td data-label="%" style="text-align: right; color: var(--myio-text-muted);">${pct(row.consumption)}</td>
           </tr>
         `
           )
@@ -855,7 +879,7 @@ export class AllReportModal {
                 ${this.domainConfig.label}
                 <span style="margin-left: 4px; opacity: ${this.getSortOpacity('consumption')};">${this.getSortIcon('consumption')}</span>
               </th>
-              ${this.moneyColumn.headerCellHTML()}<th style="text-align: right; width: 14%;">%</th>
+              ${this.moneyColumn.headerCellHTML()}${this.varianceColumn.headerCellHTML()}<th style="text-align: right; width: 14%;">%</th>
             </tr>
           </thead>
           <tbody>${tableRows}</tbody>
@@ -940,7 +964,7 @@ export class AllReportModal {
 
         const header = `
         <tr class="rp-group-header">
-          <td colspan="${this.moneyColumn.enabled ? 5 : 4}">
+          <td colspan="${4 + (this.moneyColumn.enabled ? 1 : 0) + (this.varianceColumn.enabled ? 1 : 0)}">
             ${groupLabel}
             <span class="rp-group-total">${items.length} dispositivos · ${fmtPt(groupTotal)} ${this.domainConfig.unit}</span>
           </td>
@@ -953,7 +977,7 @@ export class AllReportModal {
           <td data-label="Identificador" style="font-family: monospace; font-weight: bold; text-transform: uppercase;">${row.identifier}</td>
           <td data-label="Nome"><strong>${row.name}</strong></td>
           <td data-label="${this.domainConfig.label}" style="text-align: right; font-weight: bold;">${fmtPt(row.consumption)}</td>
-          ${this.moneyColumn.bodyCellHTML(row.id)}<td data-label="%" style="text-align: right; color: var(--myio-text-muted);">${pct(row.consumption)}</td>
+          ${this.moneyColumn.bodyCellHTML(row.id)}${this.varianceColumn.bodyCellHTML(row.id)}<td data-label="%" style="text-align: right; color: var(--myio-text-muted);">${pct(row.consumption)}</td>
         </tr>`
           )
           .join('');

--- a/src/components/premium-modals/types.ts
+++ b/src/components/premium-modals/types.ts
@@ -21,6 +21,18 @@ export interface AllReportMoneyConfig {
   variance?: string | null;
   /** Column header label override (defaults to "Custo projetado (R$)"). */
   headerLabel?: string;
+  /**
+   * RFC-0228 A7 — per-consumer **goal/budget R$** keyed by device id (ingestionId),
+   * the `currencyBudget` half of the naming bridge (never the quantity `budget`). When
+   * present, an additive "Variação vs meta (R$)" column shows each consumer's
+   * realized-vs-goal variance chip: realized R$ comes from {@link perDevice}
+   * (`monetaryProjection`), the goal from here. Absent → no variance column (the
+   * A6 cost column, if any, is unaffected). Withheld per DEC-6 when coverage is
+   * incomplete / a verdict is indeterminate — never a fabricated number.
+   */
+  perDeviceGoal?: Record<string, string | null | undefined>;
+  /** A7 variance column header override (defaults to "Variação vs meta (R$)"). */
+  varianceHeaderLabel?: string;
 }
 
 export interface DateRange { 

--- a/src/components/premium-modals/types.ts
+++ b/src/components/premium-modals/types.ts
@@ -1,5 +1,27 @@
 // src/components/premium-modals/types.ts
+import type { MoneyOverlay } from '../financial-goals/moneyTypes';
+
 export type ISODate = `${number}-${number}-${number}`; // YYYY-MM-DD
+
+/**
+ * RFC-0228 A6 — optional R$ money overlay for AllReportModal (additive + gated).
+ * When **absent**, the modal renders exactly as before (byte-identical). When
+ * present, an R$ column is shown beside kWh/m³ and an honest footer total is
+ * produced on the DEC-8 rounding contract (GCDR RFC-0054). Amounts are decimal
+ * **strings**; the modal never re-derives or `Number()`-round-trips them.
+ */
+export interface AllReportMoneyConfig {
+  /** Aggregate coverage overlay (F0) — gates whether a numeric total is shown. */
+  overlay: MoneyOverlay;
+  /** Per-device R$ (backend `monetaryValue`, DEC-8 2dp), keyed by device id (ingestionId). */
+  perDevice: Record<string, string | null | undefined>;
+  /** Backend-authoritative aggregate R$ (DEC-8 top-down parent). Preferred for the total. */
+  total?: string | null;
+  /** Optional R$ deviation vs the meta for the report total (A7 owns the per-consumer chip). */
+  variance?: string | null;
+  /** Column header label override (defaults to "Custo projetado (R$)"). */
+  headerLabel?: string;
+}
 
 export interface DateRange { 
   start: ISODate; 
@@ -89,6 +111,11 @@ export interface OpenAllReportParams {
   theme?: { cssVars(): Record<string, string> } | Record<string, string>;
   /** Nome do customer/shopping exibido no footer premium da modal. */
   customerName?: string;
+  /**
+   * RFC-0228 A6 — optional R$ money overlay. Absent → byte-identical to the
+   * pre-A6 report. Present → an additive R$ column + honest DEC-8 footer total.
+   */
+  money?: AllReportMoneyConfig;
 }
 
 export interface OpenSettingsParams {

--- a/src/components/pricing-panel/index.ts
+++ b/src/components/pricing-panel/index.ts
@@ -32,4 +32,56 @@ export type {
   PricingPanelEvent,
   PricingPanelHandle,
   PricingPanelThemeSource,
+  TariffApiPanelConfig,
 } from './types';
+
+// RFC-0228 A1 — GCDR hourly-tariff client + panel↔wire adapter.
+export {
+  TariffApiClient,
+  TariffApiError,
+  createTariffApiClient,
+} from './tariffApiClient';
+export type {
+  TariffApiClientConfig,
+  TariffSelector,
+  TariffBucket,
+  TariffTreeNode,
+  TariffTreeResponse,
+  TariffGranularity,
+  WireDomain,
+  WireCategory,
+} from './tariffApiClient';
+export {
+  TariffApiAdapter,
+  createTariffApiAdapter,
+  PANEL_TO_WIRE_DOMAIN,
+  WIRE_TO_PANEL_DOMAIN,
+  PANEL_TO_WIRE_CATEGORY,
+  WIRE_TO_PANEL_CATEGORY,
+  panelDomainToWire,
+  wireDomainToPanel,
+  panelCategoryToWire,
+  wireCategoryToPanel,
+  normalizePriceString,
+  priceToNumber,
+  isLeapYear,
+  daysInMonthYear,
+  assertValidCivilDate,
+  eachDate,
+  normalizeBand,
+  bandSelector,
+  panelEntryToBand,
+  bandToPanelEntry,
+  expandDayToHourBuckets,
+  expandBandHours,
+  bandDateBounds,
+  expandBandToHourBucketsByYear,
+  collapseHoursToBands,
+  collapseTreeToBands,
+} from './tariffApiAdapter';
+export type {
+  TariffApiAdapterOptions,
+  TariffBand,
+  TariffBandInput,
+  TariffBandPeriod,
+} from './tariffApiAdapter';

--- a/src/components/pricing-panel/openPricingPanel.ts
+++ b/src/components/pricing-panel/openPricingPanel.ts
@@ -40,6 +40,8 @@ import {
   upsertEntry,
 } from './helpers';
 import { injectPricingPanelStyles } from './styles';
+import { TariffApiClient } from './tariffApiClient';
+import { TariffApiAdapter } from './tariffApiAdapter';
 
 const MODAL_ID = 'myio-pricing-panel';
 
@@ -149,11 +151,31 @@ export function openPricingPanel(params: OpenPricingPanelParams): PricingPanelHa
   const allowed = isPricingAllowed(params.currentUserEmail, isSuperAdmin());
   const customers: PricingCustomerRef[] = params.customers || [];
 
-  // Prototype state (in-memory, hydrated from localStorage + seeds).
+  // RFC-0228 A1 — when a tariff API is configured, persistence goes through the
+  // hourly-tariff adapter and localStorage is NOT the source of truth. When it is
+  // absent, the localStorage prototype path below is byte-identical (the gate).
+  const tariffApi = params.tariffApi;
+  let adapter: TariffApiAdapter | null = null;
+  if (allowed && tariffApi) {
+    const client = new TariffApiClient({
+      baseUrl: tariffApi.baseUrl,
+      apiKey: tariffApi.apiKey,
+      jwt: tariffApi.jwt,
+      tenantId: tariffApi.tenantId,
+      fetchImpl: tariffApi.fetchImpl,
+    });
+    adapter = new TariffApiAdapter(client, { year: tariffApi.year });
+  }
+
+  // Prototype state (in-memory). In the localStorage path it is hydrated from
+  // localStorage + seeds; in the tariff-API path it starts from seeds only and is
+  // (re)hydrated asynchronously from the API — localStorage is never read/written.
   let entries: PricingEntry[] = allowed
-    ? mergeEntries(loadJson<PricingEntry[]>(doc, keyEntries, []), params.initialEntries || [], author)
+    ? adapter
+      ? (params.initialEntries || []).map((e) => ({ ...e }))
+      : mergeEntries(loadJson<PricingEntry[]>(doc, keyEntries, []), params.initialEntries || [], author)
     : [];
-  let auditLog: PricingAuditRecord[] = allowed ? loadJson<PricingAuditRecord[]>(doc, keyAudit, []) : [];
+  let auditLog: PricingAuditRecord[] = allowed && !adapter ? loadJson<PricingAuditRecord[]>(doc, keyAudit, []) : [];
 
   const modal = doc.createElement('div');
   modal.id = MODAL_ID;
@@ -400,10 +422,59 @@ export function openPricingPanel(params: OpenPricingPanelParams): PricingPanelHa
       renderList();
     })
   );
+  // RFC-0228 A1 — reload the newly selected customer's tariffs from the API.
+  if (adapter) {
+    customerSel.addEventListener('change', () => {
+      void loadFromApi();
+    });
+  }
   syncPeriodFields();
   syncUnit();
 
-  const persist = (): void => {
+  type PersistChange = { kind: 'upsert' | 'remove'; entry: PricingEntry };
+
+  // Surface an adapter/API failure in the form error box. A version conflict
+  // (RFC-0054 409 TARIFF_VERSION_CONFLICT) is shown, never swallowed.
+  function surfaceApiError(err: unknown): void {
+    const code = (err as { code?: string })?.code;
+    if (code === 'TARIFF_VERSION_CONFLICT') {
+      const cv = (err as { currentVersion?: number }).currentVersion;
+      showError(
+        `Conflito de versão: a tarifa mudou no servidor${
+          cv != null ? ` (versão atual ${cv})` : ''
+        }. Reabra o painel e tente novamente.`
+      );
+      return;
+    }
+    showError(`Falha ao salvar a tarifa no servidor${code ? ` (${code})` : ''}.`);
+  }
+
+  // Reload the selected customer's tariffs from the API and merge into state.
+  async function loadFromApi(): Promise<void> {
+    if (!adapter) return;
+    const customerId = customerSel.value;
+    if (!customerId) return;
+    try {
+      const loaded = await adapter.loadEntriesForCustomer(customerId);
+      entries = entries.filter((e) => e.customerId !== customerId).concat(loaded);
+      renderList();
+    } catch (err) {
+      surfaceApiError(err);
+    }
+  }
+
+  const persist = (changed?: PersistChange): void => {
+    if (adapter) {
+      // Tariff-API path: write through the adapter; never localStorage.
+      if (changed?.kind === 'upsert') {
+        adapter.saveEntry(changed.entry.customerId, changed.entry).catch(surfaceApiError);
+      } else if (changed?.kind === 'remove') {
+        adapter.deleteEntry(changed.entry.customerId, changed.entry).catch(surfaceApiError);
+      }
+      if (typeof params.onSave === 'function') params.onSave(entries.map((e) => ({ ...e })));
+      emit('save', entries.map((e) => ({ ...e })));
+      return;
+    }
     saveJson(doc, keyEntries, entries);
     saveJson(doc, keyAudit, auditLog);
     if (typeof params.onSave === 'function') params.onSave(entries.map((e) => ({ ...e })));
@@ -451,6 +522,11 @@ export function openPricingPanel(params: OpenPricingPanelParams): PricingPanelHa
     listEl.querySelectorAll<HTMLButtonElement>('[data-remove]').forEach((btn) => {
       btn.addEventListener('click', () => {
         const [domain, category, boundsKey] = String(btn.getAttribute('data-remove')).split('|');
+        const removedEntry = entries.find((e) => {
+          if (e.customerId !== customerId || e.domain !== domain || e.category !== category) return false;
+          const b = entryBounds(e);
+          return Boolean(b && `${b.start}__${b.end}` === boundsKey);
+        });
         const result = removeEntryByBounds(
           entries,
           {
@@ -463,7 +539,7 @@ export function openPricingPanel(params: OpenPricingPanelParams): PricingPanelHa
         );
         entries = result.entries;
         pushAudit(result.audit);
-        persist();
+        persist(removedEntry ? { kind: 'remove', entry: removedEntry } : undefined);
         renderList();
         emit('remove', result.audit);
       });
@@ -512,7 +588,7 @@ export function openPricingPanel(params: OpenPricingPanelParams): PricingPanelHa
     }
     entries = result.entries;
     pushAudit(result.audit);
-    persist();
+    persist({ kind: 'upsert', entry: candidate });
     customerSel.value = candidate.customerId;
     domainSel.value = candidate.domain;
     categorySel.value = candidate.category;
@@ -617,6 +693,9 @@ export function openPricingPanel(params: OpenPricingPanelParams): PricingPanelHa
   }
 
   renderList();
+
+  // RFC-0228 A1 — initial hydration from the tariff API (localStorage path skips this).
+  if (adapter) void loadFromApi();
 
   return handle;
 }

--- a/src/components/pricing-panel/tariffApiAdapter.ts
+++ b/src/components/pricing-panel/tariffApiAdapter.ts
@@ -1,0 +1,668 @@
+/**
+ * RFC-0228 A1 — Bidirectional adapter between the pricing panel's UX shape and
+ * the GCDR **hourly tariff** contract (RFC-0054, frozen).
+ *
+ * The panel thinks in `month | range` periods, `energy|water` domains,
+ * `lojas|area_comum` categories and (legacy) numeric `pricePerKwh`. The server
+ * stores **hourly buckets** keyed by `(customer × domain × category × year)`,
+ * WIRE domains/categories, and **decimal-string** prices. This module is the
+ * ONLY place those two worlds meet:
+ *
+ *  - **Category / domain maps** — centralized here (both directions). Nothing
+ *    else in the codebase string-matches `SPECIFIC`/`COMMON_AREA`/`ENERGY`/…
+ *  - **Write (panel → PUT/PATCH):** a day price expands to its 24 hourly buckets,
+ *    a range to every hour of its days, an intraday band to exactly its hours,
+ *    a month to every hour of the month. Annual → PUT (replace year); everything
+ *    else → PATCH (sparse merge, siblings preserved). Carries `expectedVersion`.
+ *  - **Read (GET → panel):** the hourly/day tree collapses equal contiguous
+ *    hours/days back into `month|range|day|band` bands with a single price.
+ *  - **Prices are decimal strings end to end.** `pricePerKwh` (number) is accepted
+ *    only as a *legacy input alias* and normalized to the canonical string
+ *    `price`; it is never echoed back to the wire. A numeric view is derived for
+ *    rendering only, never for round-tripping.
+ *  - **Leap year** (Feb 29 exists only in leap years) and the **empty tariff**
+ *    (`version: 0` → "no entries", not an error) are handled explicitly.
+ *
+ * Pure & framework-agnostic: no DOM, no ThingsBoard. Uses `TariffApiClient`.
+ */
+
+import type { PricingCategory, PricingDomain, PricingEntry } from './types';
+import type {
+  TariffApiClient,
+  TariffBucket,
+  TariffSelector,
+  TariffTreeNode,
+  TariffTreeResponse,
+  WireCategory,
+  WireDomain,
+} from './tariffApiClient';
+
+// ---------------------------------------------------------------------------
+// Dimension maps — the single source of truth for panel↔wire translation.
+// ---------------------------------------------------------------------------
+
+/** panel domain → WIRE domain. */
+export const PANEL_TO_WIRE_DOMAIN: Record<PricingDomain, WireDomain> = {
+  energy: 'ENERGY',
+  water: 'WATER',
+};
+/** WIRE domain → panel domain. */
+export const WIRE_TO_PANEL_DOMAIN: Record<WireDomain, PricingDomain> = {
+  ENERGY: 'energy',
+  WATER: 'water',
+};
+/** panel category → WIRE category (`lojas` = tenant/SPECIFIC, `area_comum` = COMMON_AREA). */
+export const PANEL_TO_WIRE_CATEGORY: Record<PricingCategory, WireCategory> = {
+  lojas: 'SPECIFIC',
+  area_comum: 'COMMON_AREA',
+};
+/** WIRE category → panel category. */
+export const WIRE_TO_PANEL_CATEGORY: Record<WireCategory, PricingCategory> = {
+  SPECIFIC: 'lojas',
+  COMMON_AREA: 'area_comum',
+};
+
+export function panelDomainToWire(d: PricingDomain): WireDomain {
+  const w = PANEL_TO_WIRE_DOMAIN[d];
+  if (!w) throw new Error(`Unknown panel domain: ${String(d)}`);
+  return w;
+}
+export function wireDomainToPanel(w: WireDomain): PricingDomain {
+  const d = WIRE_TO_PANEL_DOMAIN[w];
+  if (!d) throw new Error(`Unknown wire domain: ${String(w)}`);
+  return d;
+}
+export function panelCategoryToWire(c: PricingCategory): WireCategory {
+  const w = PANEL_TO_WIRE_CATEGORY[c];
+  if (!w) throw new Error(`Unknown panel category: ${String(c)}`);
+  return w;
+}
+export function wireCategoryToPanel(w: WireCategory): PricingCategory {
+  const c = WIRE_TO_PANEL_CATEGORY[w];
+  if (!c) throw new Error(`Unknown wire category: ${String(w)}`);
+  return c;
+}
+
+// ---------------------------------------------------------------------------
+// Price normalization — canonical decimal string; numeric only as legacy alias.
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonicalize a price to a decimal STRING.
+ *  - A non-empty string is preserved **verbatim** (`"0.892000"` stays
+ *    `"0.892000"`; no `Number()` drift).
+ *  - A finite `pricePerKwh` (legacy numeric alias) is formatted to a string with
+ *    up to 6 decimals. It is NEVER echoed back as `pricePerKwh`.
+ * Throws if neither is usable or the value is `<= 0`.
+ */
+export function normalizePriceString(input: {
+  price?: string | number | null;
+  pricePerKwh?: number | null;
+}): string {
+  if (typeof input.price === 'string' && input.price.trim() !== '') {
+    const s = input.price.trim();
+    if (!(Number(s) > 0)) throw new Error(`Price must be > 0 (got "${s}").`);
+    return s;
+  }
+  const numeric =
+    typeof input.price === 'number'
+      ? input.price
+      : typeof input.pricePerKwh === 'number'
+        ? input.pricePerKwh
+        : NaN;
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    throw new Error('A positive price (string) or legacy numeric pricePerKwh is required.');
+  }
+  // Up to 6 decimals, trailing zeros trimmed but at least 2 kept for readability.
+  let s = numeric.toFixed(6).replace(/0+$/, '');
+  if (/\.\d?$/.test(s)) s = numeric.toFixed(2);
+  return s;
+}
+
+/** Numeric view for RENDERING ONLY — never feed this back into a write. */
+export function priceToNumber(price: string): number {
+  return Number(price);
+}
+
+// ---------------------------------------------------------------------------
+// Calendar helpers (nominal civil days; leap-year aware). No timezone math.
+// ---------------------------------------------------------------------------
+
+export function isLeapYear(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+const MONTH_DAYS = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+/** Days in `month` (1–12) of `year`, honoring Feb 29 in leap years. */
+export function daysInMonthYear(year: number, month: number): number {
+  if (month === 2 && isLeapYear(year)) return 29;
+  return MONTH_DAYS[month - 1];
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+/**
+ * Assert a `YYYY-MM-DD` is a real civil date — rejects `02-29` in a non-leap
+ * year (mirrors the backend's `TARIFF_BUCKET_INVALID`).
+ */
+export function assertValidCivilDate(date: string): void {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  if (!m) throw new Error(`Invalid date: ${date}`);
+  const y = Number(m[1]);
+  const mo = Number(m[2]);
+  const d = Number(m[3]);
+  if (mo < 1 || mo > 12) throw new Error(`Invalid month in date: ${date}`);
+  if (d < 1 || d > daysInMonthYear(y, mo)) {
+    throw new Error(`Invalid day for ${y}-${pad2(mo)} (leap=${isLeapYear(y)}): ${date}`);
+  }
+}
+
+/** Inclusive iterator of `YYYY-MM-DD` between `start` and `end` (UTC math). */
+export function* eachDate(start: string, end: string): Generator<string> {
+  const [ys, ms, ds] = start.split('-').map(Number);
+  const [ye, me, de] = end.split('-').map(Number);
+  const t1 = Date.UTC(ye, me - 1, de);
+  for (let t = Date.UTC(ys, ms - 1, ds); t <= t1; t += 86400000) {
+    const dt = new Date(t);
+    yield `${dt.getUTCFullYear()}-${pad2(dt.getUTCMonth() + 1)}-${pad2(dt.getUTCDate())}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Canonical adapter band — the shape both directions speak internally.
+// ---------------------------------------------------------------------------
+
+export type TariffBandPeriod = 'year' | 'month' | 'range' | 'day' | 'band';
+
+/**
+ * A canonical tariff band. `price` is the decimal string (authoritative).
+ * `pricePerKwh` is accepted on INPUT only (legacy alias) and never populated on
+ * adapter output.
+ */
+export interface TariffBand {
+  domain: PricingDomain;
+  category: PricingCategory;
+  periodType: TariffBandPeriod;
+  /** Explicit year for `year` bands; otherwise derived from the period. */
+  year?: number;
+  /** `YYYY-MM` for `month`. */
+  periodKey?: string;
+  /** `YYYY-MM-DD` for `range`. */
+  start?: string;
+  end?: string;
+  /** `YYYY-MM-DD` for `day` / `band`. */
+  date?: string;
+  /** Inclusive intraday hour window for `band` (0–23). */
+  startHour?: number;
+  endHour?: number;
+  /** Canonical decimal-string price. */
+  price: string;
+}
+
+/** Loose input accepted from callers (price may still be numeric/legacy). */
+export type TariffBandInput = Omit<TariffBand, 'price'> & {
+  price?: string | number | null;
+  pricePerKwh?: number | null;
+};
+
+/** Normalize a loose band: canonical decimal-string price, no legacy echo. */
+export function normalizeBand(input: TariffBandInput): TariffBand {
+  const price = normalizePriceString(input);
+  const band: TariffBand = {
+    domain: input.domain,
+    category: input.category,
+    periodType: input.periodType,
+    price,
+  };
+  if (input.year != null) band.year = input.year;
+  if (input.periodKey != null) band.periodKey = input.periodKey;
+  if (input.start != null) band.start = input.start;
+  if (input.end != null) band.end = input.end;
+  if (input.date != null) band.date = input.date;
+  if (input.startHour != null) band.startHour = input.startHour;
+  if (input.endHour != null) band.endHour = input.endHour;
+  return band;
+}
+
+/** The `(customer × domain × category × year)` key for version bookkeeping. */
+function selectorKey(sel: TariffSelector): string {
+  return `${sel.domain}|${sel.category}|${sel.year}`;
+}
+
+/** Build a WIRE selector for a band + explicit year. */
+export function bandSelector(band: TariffBand, customerId: string, year: number): TariffSelector {
+  return {
+    customerId,
+    domain: panelDomainToWire(band.domain),
+    category: panelCategoryToWire(band.category),
+    year,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Panel entry ↔ band
+// ---------------------------------------------------------------------------
+
+/** Panel `PricingEntry` (month|range) → canonical band. */
+export function panelEntryToBand(e: PricingEntry): TariffBand {
+  const price = normalizePriceString({ price: e.price, pricePerKwh: e.pricePerKwh });
+  if (e.periodType === 'month') {
+    if (!e.periodKey) throw new Error('month entry missing periodKey');
+    return { domain: e.domain, category: e.category, periodType: 'month', periodKey: e.periodKey, price };
+  }
+  if (!e.start || !e.end) throw new Error('range entry missing start/end');
+  return { domain: e.domain, category: e.category, periodType: 'range', start: e.start, end: e.end, price };
+}
+
+/**
+ * Canonical band → panel `PricingEntry` for display. The panel UI only renders
+ * `month|range`, so `year`→whole-year range, `day`/`band`→single-day range (the
+ * intraday hour window is not shown by the month/range UI — flagged in the RFC).
+ * `price` carries the authoritative decimal string; `pricePerKwh` is the derived
+ * numeric view for the existing `formatBRL` render path.
+ */
+export function bandToPanelEntry(band: TariffBand, customerId: string): PricingEntry {
+  const base = {
+    customerId,
+    domain: band.domain,
+    category: band.category,
+    currency: 'BRL' as const,
+    price: band.price,
+    pricePerKwh: priceToNumber(band.price),
+  };
+  if (band.periodType === 'month' && band.periodKey) {
+    return { ...base, periodType: 'month', periodKey: band.periodKey };
+  }
+  if (band.periodType === 'year' && band.year != null) {
+    return { ...base, periodType: 'range', start: `${band.year}-01-01`, end: `${band.year}-12-31` };
+  }
+  if (band.periodType === 'range' && band.start && band.end) {
+    return { ...base, periodType: 'range', start: band.start, end: band.end };
+  }
+  // day | band → single-day range
+  const date = band.date || band.start || '';
+  return { ...base, periodType: 'range', start: date, end: date };
+}
+
+// ---------------------------------------------------------------------------
+// WRITE — expand a band into hourly buckets, grouped by tariff year.
+// ---------------------------------------------------------------------------
+
+/** Every hour (`0..23`) of `date` at `price` → HOUR buckets. */
+export function expandDayToHourBuckets(date: string, price: string): TariffBucket[] {
+  assertValidCivilDate(date);
+  const out: TariffBucket[] = [];
+  for (let h = 0; h < 24; h++) out.push({ level: 'HOUR', ref: `${date}T${pad2(h)}`, price });
+  return out;
+}
+
+/** An intraday band `[startHour, endHour]` (inclusive) of `date` → HOUR buckets. */
+export function expandBandHours(
+  date: string,
+  startHour: number,
+  endHour: number,
+  price: string
+): TariffBucket[] {
+  assertValidCivilDate(date);
+  if (startHour < 0 || endHour > 23 || startHour > endHour) {
+    throw new Error(`Invalid hour band ${startHour}-${endHour} for ${date}`);
+  }
+  const out: TariffBucket[] = [];
+  for (let h = startHour; h <= endHour; h++) out.push({ level: 'HOUR', ref: `${date}T${pad2(h)}`, price });
+  return out;
+}
+
+/** The inclusive `[start,end]` civil-date bounds a band covers. */
+export function bandDateBounds(band: TariffBand): { start: string; end: string } {
+  switch (band.periodType) {
+    case 'month': {
+      if (!band.periodKey) throw new Error('month band missing periodKey');
+      const [y, m] = band.periodKey.split('-').map(Number);
+      return { start: `${band.periodKey}-01`, end: `${band.periodKey}-${pad2(daysInMonthYear(y, m))}` };
+    }
+    case 'range': {
+      if (!band.start || !band.end) throw new Error('range band missing start/end');
+      return { start: band.start, end: band.end };
+    }
+    case 'day':
+    case 'band': {
+      const d = band.date || band.start;
+      if (!d) throw new Error('day/band missing date');
+      return { start: d, end: d };
+    }
+    case 'year': {
+      const y = band.year;
+      if (y == null) throw new Error('year band missing year');
+      return { start: `${y}-01-01`, end: `${y}-12-31` };
+    }
+    default:
+      throw new Error(`Unsupported band periodType: ${String(band.periodType)}`);
+  }
+}
+
+/**
+ * Expand a band into HOUR buckets, grouped by tariff year (a range may cross a
+ * year boundary; each year is a separate tariff resource). `year` bands are NOT
+ * bucket-expanded — they route through PUT annual (see {@link TariffApiAdapter}).
+ */
+export function expandBandToHourBucketsByYear(band: TariffBand): Map<number, TariffBucket[]> {
+  const byYear = new Map<number, TariffBucket[]>();
+  const push = (year: number, buckets: TariffBucket[]): void => {
+    const arr = byYear.get(year) || [];
+    arr.push(...buckets);
+    byYear.set(year, arr);
+  };
+
+  if (band.periodType === 'band') {
+    const date = band.date || band.start!;
+    push(Number(date.slice(0, 4)), expandBandHours(date, band.startHour ?? 0, band.endHour ?? 23, band.price));
+    return byYear;
+  }
+
+  const { start, end } = bandDateBounds(band);
+  for (const date of eachDate(start, end)) {
+    push(Number(date.slice(0, 4)), expandDayToHourBuckets(date, band.price));
+  }
+  return byYear;
+}
+
+// ---------------------------------------------------------------------------
+// READ — collapse a tariff tree back into user-facing bands.
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge a day's hours into the fewest contiguous equal-price bands. A single
+ * band spanning `0..23` collapses to a `day`; anything narrower is a `band`.
+ * Non-contiguous or unequal-priced hours stay split.
+ */
+export function collapseHoursToBands(
+  date: string,
+  hours: Array<{ hour: number; price: string }>,
+  dims: { domain: PricingDomain; category: PricingCategory }
+): TariffBand[] {
+  const sorted = [...hours].sort((a, b) => a.hour - b.hour);
+  const runs: Array<{ startHour: number; endHour: number; price: string }> = [];
+  for (const h of sorted) {
+    const cur = runs[runs.length - 1];
+    if (cur && h.hour === cur.endHour + 1 && h.price === cur.price) {
+      cur.endHour = h.hour;
+    } else {
+      runs.push({ startHour: h.hour, endHour: h.hour, price: h.price });
+    }
+  }
+  return runs.map((r) =>
+    r.startHour === 0 && r.endHour === 23
+      ? { domain: dims.domain, category: dims.category, periodType: 'day' as const, date, price: r.price }
+      : {
+          domain: dims.domain,
+          category: dims.category,
+          periodType: 'band' as const,
+          date,
+          startHour: r.startHour,
+          endHour: r.endHour,
+          price: r.price,
+        }
+  );
+}
+
+/** Resolve a day node's 24 hours: hourly override wins, else the day price. */
+function dayNodeToHours(node: TariffTreeNode): Array<{ hour: number; price: string }> | null {
+  const dayPrice = typeof node.price === 'string' ? node.price : undefined;
+  const hourly = node.hourly || {};
+  const hourKeys = Object.keys(hourly);
+  if (hourKeys.length === 0) {
+    return dayPrice != null ? Array.from({ length: 24 }, (_, h) => ({ hour: h, price: dayPrice })) : null;
+  }
+  const out: Array<{ hour: number; price: string }> = [];
+  for (let h = 0; h < 24; h++) {
+    const ov = hourly[String(h)];
+    const price = ov && typeof ov.price === 'string' ? ov.price : dayPrice;
+    if (price != null) out.push({ hour: h, price });
+  }
+  return out.length ? out : null;
+}
+
+/** Normalize a daily-map key (`MM-DD` at day granularity or `DD` under a month) to `MM-DD`. */
+function normalizeDayKey(key: string, monthKey?: string): string {
+  if (/^\d{2}-\d{2}$/.test(key)) return key;
+  if (/^\d{2}$/.test(key) && monthKey) return `${monthKey}-${key}`;
+  return key;
+}
+
+/** Merge contiguous equal-price single-day bands into `range`/`day` bands. */
+function mergeContiguousDays(days: TariffBand[], year: number): TariffBand[] {
+  // Only merge simple full-day bands (no intraday variation).
+  const simple = days.every((d) => d.periodType === 'day' && d.date);
+  if (!simple || days.length === 0) return days;
+  const sorted = [...days].sort((a, b) => (a.date! < b.date! ? -1 : 1));
+  const out: TariffBand[] = [];
+  let run: { start: string; end: string; price: string; dims: TariffBand } | null = null;
+  const flush = (): void => {
+    if (!run) return;
+    out.push(
+      run.start === run.end
+        ? { domain: run.dims.domain, category: run.dims.category, periodType: 'day', date: run.start, price: run.price }
+        : {
+            domain: run.dims.domain,
+            category: run.dims.category,
+            periodType: 'range',
+            start: run.start,
+            end: run.end,
+            price: run.price,
+          }
+    );
+    run = null;
+  };
+  for (const d of sorted) {
+    if (run && d.price === run.price && isNextDay(run.end, d.date!)) {
+      run.end = d.date!;
+    } else {
+      flush();
+      run = { start: d.date!, end: d.date!, price: d.price, dims: d };
+    }
+  }
+  flush();
+  void year;
+  return out;
+}
+
+function isNextDay(prev: string, next: string): boolean {
+  const [py, pm, pd] = prev.split('-').map(Number);
+  const [ny, nm, nd] = next.split('-').map(Number);
+  return Date.UTC(py, pm - 1, pd) + 86400000 === Date.UTC(ny, nm - 1, nd);
+}
+
+/**
+ * Collapse a tariff tree into user-facing bands. Handles the frozen shapes:
+ * empty tree → `[]`; `annual` uniform → one `year` band; `monthly`/`daily` maps
+ * → per-day collapse (intraday variation kept as `band`s), then contiguous equal
+ * days merged into `range`s.
+ */
+export function collapseTreeToBands(
+  tree: TariffTreeNode,
+  dims: { year: number; domain: PricingDomain; category: PricingCategory }
+): TariffBand[] {
+  if (!tree || typeof tree !== 'object') return [];
+  const dimOnly = { domain: dims.domain, category: dims.category };
+
+  // Annual uniform tariff (FLAT v1 common case).
+  if (tree.annual && typeof tree.annual.price === 'string' && !tree.daily && !tree.monthly) {
+    return [{ ...dimOnly, periodType: 'year', year: dims.year, price: tree.annual.price }];
+  }
+
+  const dayBands: TariffBand[] = [];
+
+  const collectDaily = (daily: Record<string, TariffTreeNode>, monthKey?: string): void => {
+    for (const rawKey of Object.keys(daily)) {
+      const mmdd = normalizeDayKey(rawKey, monthKey);
+      const date = `${dims.year}-${mmdd}`;
+      const hours = dayNodeToHours(daily[rawKey]);
+      if (!hours) continue;
+      dayBands.push(...collapseHoursToBands(date, hours, dimOnly));
+    }
+  };
+
+  if (tree.daily) collectDaily(tree.daily);
+  if (tree.monthly) {
+    for (const mm of Object.keys(tree.monthly)) {
+      const node = tree.monthly[mm];
+      if (node.daily) {
+        collectDaily(node.daily, mm);
+      } else if (typeof node.price === 'string') {
+        // Uniform month → expand to its days as day bands (merged below).
+        const last = daysInMonthYear(dims.year, Number(mm));
+        for (let d = 1; d <= last; d++) {
+          dayBands.push({ ...dimOnly, periodType: 'day', date: `${dims.year}-${mm}-${pad2(d)}`, price: node.price });
+        }
+      }
+    }
+  }
+
+  return mergeContiguousDays(dayBands, dims.year);
+}
+
+// ---------------------------------------------------------------------------
+// The adapter — orchestrates load / save / delete against the client.
+// ---------------------------------------------------------------------------
+
+/** The four `(domain × category)` combos a customer's tariffs span. */
+const WIRE_COMBOS: Array<[WireDomain, WireCategory]> = [
+  ['ENERGY', 'SPECIFIC'],
+  ['ENERGY', 'COMMON_AREA'],
+  ['WATER', 'SPECIFIC'],
+  ['WATER', 'COMMON_AREA'],
+];
+
+export interface TariffApiAdapterOptions {
+  /** Tariff year to load (writes derive their own year from the period). */
+  year?: number;
+}
+
+export class TariffApiAdapter {
+  private readonly client: TariffApiClient;
+  private readonly year: number;
+  /** Last-seen version per `(domain|category|year)` for optimistic concurrency. */
+  private readonly versions = new Map<string, number>();
+
+  constructor(client: TariffApiClient, opts: TariffApiAdapterOptions = {}) {
+    this.client = client;
+    this.year = opts.year ?? new Date().getFullYear();
+  }
+
+  /** Default load year. */
+  getYear(): number {
+    return this.year;
+  }
+
+  /**
+   * Load every `(domain × category)` tariff for a customer and collapse each into
+   * panel entries. An empty tariff (`version: 0`) contributes no entries — it is
+   * "no entries", never an error. Read errors propagate (caller surfaces them).
+   */
+  async loadEntriesForCustomer(customerId: string, year: number = this.year): Promise<PricingEntry[]> {
+    const out: PricingEntry[] = [];
+    for (const [domain, category] of WIRE_COMBOS) {
+      const sel: TariffSelector = { customerId, domain, category, year };
+      const resp = await this.client.getTariff(sel, 'hour');
+      this.versions.set(selectorKey(sel), resp.version);
+      if (resp.version === 0) continue; // empty tariff → no entries
+      const bands = collapseTreeToBands(resp.tree, {
+        year,
+        domain: wireDomainToPanel(domain),
+        category: wireCategoryToPanel(category),
+      });
+      for (const b of bands) out.push(bandToPanelEntry(b, customerId));
+    }
+    return out;
+  }
+
+  /** Convenience: read + collapse one specific tariff. */
+  async loadBands(customerId: string, domain: PricingDomain, category: PricingCategory, year: number = this.year): Promise<{ bands: TariffBand[]; version: number }> {
+    const sel: TariffSelector = { customerId, domain: panelDomainToWire(domain), category: panelCategoryToWire(category), year };
+    const resp = await this.client.getTariff(sel, 'hour');
+    this.versions.set(selectorKey(sel), resp.version);
+    const bands = resp.version === 0 ? [] : collapseTreeToBands(resp.tree, { year, domain, category });
+    return { bands, version: resp.version };
+  }
+
+  /**
+   * Persist one panel edit. Annual bands REPLACE the year (PUT); every other
+   * period MERGES its hourly buckets (PATCH), so sibling periods survive. A range
+   * spanning a year boundary writes once per year. `expectedVersion` is carried
+   * from the last-seen version; a stale guard throws `TARIFF_VERSION_CONFLICT`
+   * (surfaced, never swallowed).
+   */
+  async saveEntry(customerId: string, entryOrBand: PricingEntry | TariffBandInput): Promise<void> {
+    const band = toBand(entryOrBand);
+
+    if (band.periodType === 'year') {
+      const year = band.year ?? this.year;
+      const sel = bandSelector(band, customerId, year);
+      const key = selectorKey(sel);
+      const res = await this.client.putTariff(sel, { annual: { price: band.price } }, this.versions.get(key));
+      this.versions.set(key, res.version);
+      return;
+    }
+
+    const byYear = expandBandToHourBucketsByYear(band);
+    for (const [year, buckets] of byYear) {
+      const sel = bandSelector(band, customerId, year);
+      const key = selectorKey(sel);
+      const res = await this.client.patchTariff(sel, buckets, this.versions.get(key));
+      this.versions.set(key, res.version);
+    }
+  }
+
+  /**
+   * Remove a panel period. The contract offers whole-year DELETE or a single
+   * sub-bucket per call, so a partial period is deleted day-by-day (`level:'DAY'`).
+   * Removing a full year deletes the whole year in one call.
+   */
+  async deleteEntry(customerId: string, entryOrBand: PricingEntry | TariffBandInput): Promise<void> {
+    const band = toBand(entryOrBand);
+
+    if (band.periodType === 'year') {
+      const year = band.year ?? this.year;
+      const sel = bandSelector(band, customerId, year);
+      const key = selectorKey(sel);
+      const res = await this.client.deleteTariff(sel, { expectedVersion: this.versions.get(key) });
+      if (typeof res.version === 'number') this.versions.set(key, res.version);
+      return;
+    }
+
+    const { start, end } = bandDateBounds(band);
+    for (const date of eachDate(start, end)) {
+      const year = Number(date.slice(0, 4));
+      const sel = bandSelector(band, customerId, year);
+      const key = selectorKey(sel);
+      const res = await this.client.deleteTariff(sel, {
+        bucket: { level: 'DAY', ref: date },
+        expectedVersion: this.versions.get(key),
+      });
+      if (typeof res.version === 'number') this.versions.set(key, res.version);
+    }
+  }
+
+  /** Seed the version cache from an out-of-band read (e.g. a raw client call). */
+  rememberVersion(resp: Pick<TariffTreeResponse, 'domain' | 'category' | 'year' | 'version'>): void {
+    this.versions.set(`${resp.domain}|${resp.category}|${resp.year}`, resp.version);
+  }
+}
+
+/** Accept a panel entry OR a loose band; always return a normalized band. */
+function toBand(entryOrBand: PricingEntry | TariffBandInput): TariffBand {
+  if ('periodType' in entryOrBand && (entryOrBand.periodType === 'month' || entryOrBand.periodType === 'range') && !('startHour' in entryOrBand)) {
+    // Could be a PricingEntry or a month/range band — normalize via the entry path
+    // when it looks like a PricingEntry (has customerId), else treat as a band.
+    if ('customerId' in entryOrBand) return panelEntryToBand(entryOrBand as PricingEntry);
+  }
+  return normalizeBand(entryOrBand as TariffBandInput);
+}
+
+/** Convenience factory. */
+export function createTariffApiAdapter(client: TariffApiClient, opts?: TariffApiAdapterOptions): TariffApiAdapter {
+  return new TariffApiAdapter(client, opts);
+}

--- a/src/components/pricing-panel/tariffApiClient.ts
+++ b/src/components/pricing-panel/tariffApiClient.ts
@@ -1,0 +1,315 @@
+/**
+ * RFC-0228 A1 — Thin, typed client for the GCDR **hourly tariff** API
+ * (RFC-0054; contract in `gcdr.git/docs/api/API-Financial-Goals.md`, frozen).
+ *
+ * Four endpoints, customer-scoped, base path `/api/v1`:
+ *   GET    /customers/:id/tariffs?domain=&category=&year=&granularity=
+ *   PUT    /customers/:id/tariffs?domain=&category=&year=      (REPLACE year)
+ *   PATCH  /customers/:id/tariffs?domain=&category=&year=      (MERGE buckets)
+ *   DELETE /customers/:id/tariffs?domain=&category=&year=      (year or sub-bucket)
+ *
+ * Design rules for this layer:
+ *  - **Pure / framework-agnostic.** No DOM, no ThingsBoard. `fetch` is injected
+ *    (defaults to `globalThis.fetch`) so it is unit-testable with a mock.
+ *  - **Speaks the wire language only** — WIRE domains (`ENERGY`/`WATER`) and WIRE
+ *    categories (`COMMON_AREA`/`SPECIFIC`). The panel↔wire mapping lives in the
+ *    adapter, never here.
+ *  - **Never converts prices to `Number`.** Prices are decimal strings end to end
+ *    (`"2.000000"`), preserved verbatim.
+ *  - **Optimistic concurrency.** Reads/writes surface `version` (body + `ETag`).
+ *    Writes send the guard via `If-Match: "<v>"` header AND body `expectedVersion`
+ *    (equal values — the contract requires equality when both are present).
+ *  - **Errors surface the stable `code`, never the message** (see §7 taxonomy).
+ */
+
+/** WIRE domain (RFC-0054 §3). */
+export type WireDomain = 'ENERGY' | 'WATER';
+/** WIRE tariff category (RFC-0054 §3). */
+export type WireCategory = 'COMMON_AREA' | 'SPECIFIC';
+/** Tariff granularity for reads. `day` is the API default. */
+export type TariffGranularity = 'year' | 'month' | 'day' | 'hour';
+
+/** One node in the returned price tree. Price is a decimal STRING. */
+export interface TariffTreeNode {
+  price?: string;
+  sourceLevel?: 'YEAR' | 'MONTH' | 'DAY' | 'HOUR';
+  derived?: boolean;
+  /** Hour override map (key = hour, e.g. `"15"`). */
+  hourly?: Record<string, TariffTreeNode>;
+  /** Day override map (key = `"MM-DD"` at day granularity, or `"DD"` when nested). */
+  daily?: Record<string, TariffTreeNode>;
+  /** Month override map (key = `"MM"`). */
+  monthly?: Record<string, TariffTreeNode>;
+  /** Annual node. */
+  annual?: TariffTreeNode;
+  value?: unknown;
+}
+
+/** Full tariff-read response (RFC-0054 §4.1). */
+export interface TariffTreeResponse {
+  customerId: string;
+  domain: WireDomain;
+  category: WireCategory;
+  year: number;
+  unit?: string;
+  currency?: string;
+  tariffModel?: string;
+  timezone?: string;
+  /** Optimistic-concurrency counter. `0` for an empty (never-set) tariff. */
+  version: number;
+  /** Nested price tree. Empty object for an empty tariff. */
+  tree: TariffTreeNode;
+}
+
+/** A sparse merge bucket for PATCH (RFC-0054 §5.2). Price is a decimal STRING. */
+export interface TariffBucket {
+  level: 'DAY' | 'HOUR';
+  /** `YYYY-MM-DD` for DAY, `YYYY-MM-DDTHH` for HOUR. */
+  ref: string;
+  price: string;
+}
+
+/** Selects a single `(customer × domain × category × year)` tariff. */
+export interface TariffSelector {
+  customerId: string;
+  domain: WireDomain;
+  category: WireCategory;
+  year: number;
+}
+
+/** Client configuration. Auth is `apiKey` (X-API-Key) OR `jwt` (Bearer). */
+export interface TariffApiClientConfig {
+  /** API origin, e.g. `https://gcdr-api.a.myio-bas.com`. `/api/v1` is appended. */
+  baseUrl: string;
+  /** Customer API Key (`gcdr_cust_…`) → `X-API-Key`. */
+  apiKey?: string;
+  /** JWT → `Authorization: Bearer`. */
+  jwt?: string;
+  /** Optional tenant hint forwarded as `X-Tenant-Id`. */
+  tenantId?: string;
+  /** Injectable fetch (defaults to `globalThis.fetch`). */
+  fetchImpl?: typeof fetch;
+  /** Base path segment. Defaults to `/api/v1`. */
+  basePath?: string;
+}
+
+/**
+ * Structured tariff API failure. Callers switch on `.code` (stable), never on
+ * the human message. `currentVersion` is lifted from `details` for 409s so a
+ * version conflict can be surfaced without digging.
+ */
+export class TariffApiError extends Error {
+  readonly code: string;
+  readonly status: number;
+  readonly details?: Record<string, unknown>;
+  readonly currentVersion?: number;
+
+  constructor(
+    code: string,
+    status: number,
+    message?: string,
+    details?: Record<string, unknown>
+  ) {
+    super(message || code);
+    this.name = 'TariffApiError';
+    this.code = code;
+    this.status = status;
+    this.details = details;
+    const cv = details && (details as { currentVersion?: unknown }).currentVersion;
+    this.currentVersion = typeof cv === 'number' ? cv : undefined;
+  }
+}
+
+function joinUrl(baseUrl: string, basePath: string, path: string): string {
+  const b = baseUrl.replace(/\/+$/, '');
+  const bp = basePath ? `/${basePath.replace(/^\/+|\/+$/g, '')}` : '';
+  const p = path.startsWith('/') ? path : `/${path}`;
+  return `${b}${bp}${p}`;
+}
+
+function tariffQuery(sel: TariffSelector, granularity?: TariffGranularity): string {
+  const qs = new URLSearchParams();
+  qs.set('domain', sel.domain);
+  qs.set('category', sel.category);
+  qs.set('year', String(sel.year));
+  if (granularity) qs.set('granularity', granularity);
+  return qs.toString();
+}
+
+/** Parse a strong ETag (`"7"`) into a number, if present. */
+function parseETagVersion(headers: Headers): number | undefined {
+  const raw = headers.get('ETag') || headers.get('etag');
+  if (!raw) return undefined;
+  const m = /"?(-?\d+)"?/.exec(raw);
+  return m ? Number(m[1]) : undefined;
+}
+
+export class TariffApiClient {
+  private readonly cfg: TariffApiClientConfig;
+  private readonly fetchImpl: typeof fetch;
+  private readonly basePath: string;
+
+  constructor(config: TariffApiClientConfig) {
+    if (!config || !config.baseUrl) {
+      throw new Error('TariffApiClient requires a baseUrl.');
+    }
+    this.cfg = config;
+    const injected = config.fetchImpl || (globalThis.fetch as typeof fetch | undefined);
+    if (typeof injected !== 'function') {
+      throw new Error('TariffApiClient requires a fetch implementation.');
+    }
+    // Preserve the correct `this` when calling a global fetch.
+    this.fetchImpl = config.fetchImpl ? config.fetchImpl : injected.bind(globalThis);
+    this.basePath = config.basePath ?? 'api/v1';
+  }
+
+  private authHeaders(): Record<string, string> {
+    const h: Record<string, string> = {};
+    if (this.cfg.apiKey) h['X-API-Key'] = this.cfg.apiKey;
+    if (this.cfg.jwt) h['Authorization'] = `Bearer ${this.cfg.jwt}`;
+    if (this.cfg.tenantId) h['X-Tenant-Id'] = this.cfg.tenantId;
+    return h;
+  }
+
+  /** Read the tariff tree. `granularity` defaults to `day` server-side. */
+  async getTariff(
+    sel: TariffSelector,
+    granularity: TariffGranularity = 'hour'
+  ): Promise<TariffTreeResponse> {
+    const url = joinUrl(
+      this.cfg.baseUrl,
+      this.basePath,
+      `/customers/${encodeURIComponent(sel.customerId)}/tariffs?${tariffQuery(sel, granularity)}`
+    );
+    const res = await this.fetchImpl(url, {
+      method: 'GET',
+      headers: { Accept: 'application/json', ...this.authHeaders() },
+    });
+    const body = await this.readBody(res);
+    if (!res.ok) throw this.toError(res, body);
+    const etagVersion = parseETagVersion(res.headers);
+    const parsed = (body || {}) as Partial<TariffTreeResponse>;
+    return {
+      customerId: sel.customerId,
+      domain: sel.domain,
+      category: sel.category,
+      year: sel.year,
+      unit: parsed.unit,
+      currency: parsed.currency,
+      tariffModel: parsed.tariffModel,
+      timezone: parsed.timezone,
+      version: typeof parsed.version === 'number' ? parsed.version : (etagVersion ?? 0),
+      tree: parsed.tree || {},
+    };
+  }
+
+  /** REPLACE the whole year with a nested price tree. */
+  async putTariff(
+    sel: TariffSelector,
+    tree: TariffTreeNode,
+    expectedVersion?: number
+  ): Promise<{ version: number }> {
+    return this.write('PUT', sel, { ...tree, ...guardBody(expectedVersion) }, expectedVersion);
+  }
+
+  /** MERGE sparse buckets into the year (finest level wins). */
+  async patchTariff(
+    sel: TariffSelector,
+    buckets: TariffBucket[],
+    expectedVersion?: number
+  ): Promise<{ version: number }> {
+    return this.write('PATCH', sel, { buckets, ...guardBody(expectedVersion) }, expectedVersion);
+  }
+
+  /**
+   * DELETE the whole year (no `bucket`) or one sub-bucket (`bucket` present).
+   * Whole-year delete is idempotent (204 even if absent).
+   */
+  async deleteTariff(
+    sel: TariffSelector,
+    opts: { bucket?: { level: 'DAY' | 'HOUR'; ref: string }; expectedVersion?: number } = {}
+  ): Promise<{ version?: number }> {
+    const hasBody = Boolean(opts.bucket) || typeof opts.expectedVersion === 'number';
+    const url = joinUrl(
+      this.cfg.baseUrl,
+      this.basePath,
+      `/customers/${encodeURIComponent(sel.customerId)}/tariffs?${tariffQuery(sel)}`
+    );
+    const headers: Record<string, string> = { Accept: 'application/json', ...this.authHeaders() };
+    if (typeof opts.expectedVersion === 'number') headers['If-Match'] = `"${opts.expectedVersion}"`;
+    const init: RequestInit = { method: 'DELETE', headers };
+    if (hasBody) {
+      headers['Content-Type'] = 'application/json';
+      init.body = JSON.stringify({
+        ...(opts.bucket ? { bucket: opts.bucket } : {}),
+        ...guardBody(opts.expectedVersion),
+      });
+    }
+    const res = await this.fetchImpl(url, init);
+    if (res.status === 204) return {};
+    const body = await this.readBody(res);
+    if (!res.ok) throw this.toError(res, body);
+    const etagVersion = parseETagVersion(res.headers);
+    const v = (body && (body as { version?: unknown }).version) ?? etagVersion;
+    return typeof v === 'number' ? { version: v } : {};
+  }
+
+  private async write(
+    method: 'PUT' | 'PATCH',
+    sel: TariffSelector,
+    body: unknown,
+    expectedVersion?: number
+  ): Promise<{ version: number }> {
+    const url = joinUrl(
+      this.cfg.baseUrl,
+      this.basePath,
+      `/customers/${encodeURIComponent(sel.customerId)}/tariffs?${tariffQuery(sel)}`
+    );
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      ...this.authHeaders(),
+    };
+    if (typeof expectedVersion === 'number') headers['If-Match'] = `"${expectedVersion}"`;
+    const res = await this.fetchImpl(url, { method, headers, body: JSON.stringify(body) });
+    const parsed = await this.readBody(res);
+    if (!res.ok) throw this.toError(res, parsed);
+    const etagVersion = parseETagVersion(res.headers);
+    const v = (parsed && (parsed as { version?: unknown }).version) ?? etagVersion;
+    return { version: typeof v === 'number' ? v : (expectedVersion ?? 0) + 1 };
+  }
+
+  private async readBody(res: Response): Promise<unknown> {
+    try {
+      const text = await res.text();
+      if (!text) return null;
+      return JSON.parse(text);
+    } catch {
+      return null;
+    }
+  }
+
+  private toError(res: Response, body: unknown): TariffApiError {
+    const err = body && (body as { error?: unknown }).error;
+    if (err && typeof err === 'object') {
+      const e = err as { code?: string; message?: string; details?: Record<string, unknown> };
+      return new TariffApiError(
+        e.code || `HTTP_${res.status}`,
+        res.status,
+        e.message,
+        e.details
+      );
+    }
+    return new TariffApiError(`HTTP_${res.status}`, res.status, res.statusText);
+  }
+}
+
+/** Body fragment carrying the optimistic-concurrency guard. */
+function guardBody(expectedVersion?: number): { expectedVersion?: number } {
+  return typeof expectedVersion === 'number' ? { expectedVersion } : {};
+}
+
+/** Convenience factory. */
+export function createTariffApiClient(config: TariffApiClientConfig): TariffApiClient {
+  return new TariffApiClient(config);
+}

--- a/src/components/pricing-panel/types.ts
+++ b/src/components/pricing-panel/types.ts
@@ -72,7 +72,20 @@ export interface PricingEntry {
   start?: string;
   /** Range end `YYYY-MM-DD` inclusive (present when periodType === 'range'). */
   end?: string;
-  /** Price per unit — kWh for energy, m³ for water — in BRL (positive number). */
+  /**
+   * Canonical price per unit as a **decimal string** (`"0.892000"`) — the
+   * authoritative value when the panel is backed by the GCDR tariff API
+   * (RFC-0228 A1). Preserved verbatim (no `Number()` drift). When absent (the
+   * localStorage prototype path), `pricePerKwh` is authoritative.
+   */
+  price?: string;
+  /**
+   * Price per unit — kWh for energy, m³ for water — in BRL (positive number).
+   *
+   * In the tariff-API path this is a **derived numeric view for rendering only**
+   * (`Number(price)`); never round-trip it back to the wire. In the localStorage
+   * prototype path it remains the source of truth.
+   */
   pricePerKwh: number;
   /** Always `'BRL'` in this prototype. */
   currency: 'BRL';
@@ -132,6 +145,32 @@ export interface OpenPricingPanelParams {
   storageKeyPrefix?: string;
   /** Seed entries (merged over anything found in localStorage). */
   initialEntries?: PricingEntry[];
+  /**
+   * RFC-0228 A1 — GCDR hourly tariff API config. **When present**, the panel
+   * loads and saves through the tariff adapter (`GET/PUT/PATCH/DELETE
+   * /customers/:id/tariffs`) and `localStorage` is NOT used as a source of truth.
+   * **When absent**, the panel keeps its byte-identical localStorage prototype.
+   */
+  tariffApi?: TariffApiPanelConfig;
+}
+
+/** Config for the RFC-0228 A1 tariff-API persistence path. */
+export interface TariffApiPanelConfig {
+  /** API origin, e.g. `https://gcdr-api.a.myio-bas.com`. `/api/v1` is appended. */
+  baseUrl: string;
+  /** Customer API Key (`gcdr_cust_…`) → `X-API-Key`. */
+  apiKey?: string;
+  /** JWT → `Authorization: Bearer`. */
+  jwt?: string;
+  /** Optional tenant hint forwarded as `X-Tenant-Id`. */
+  tenantId?: string;
+  /** Tariff year to load (default: current year). Writes derive year from the period. */
+  year?: number;
+  /**
+   * Test seam: injectable `fetch`. Not needed in production (defaults to
+   * `globalThis.fetch`); lets unit tests drive the panel with a mocked backend.
+   */
+  fetchImpl?: typeof fetch;
 }
 
 /** Events emitted by the panel handle. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1077,6 +1077,10 @@ export {
   VARIANCE_LABEL_ONTARGET,
   VARIANCE_LABEL_WITHHELD,
   MONEY_VARIANCE_HEADER,
+  // RFC-0228 A2b — broad-rollout gate (per-customer eligibility; composes with A2a).
+  resolveMoneyRollout,
+  routeMoneyRender,
+  renderGatedMoney,
 } from './components/financial-goals';
 export type {
   MoneyDomain,
@@ -1126,6 +1130,15 @@ export type {
   MoneyVarianceOptions,
   MoneyVarianceColumn,
   MoneyVarianceColumnConfig,
+  // RFC-0228 A2b — broad-rollout gate types.
+  MoneyRolloutReason,
+  MoneyRolloutDecision,
+  MoneyRolloutAllowlist,
+  MoneyRolloutSettings,
+  MoneyRolloutParams,
+  MoneyRenderAction,
+  MoneyRenderRouting,
+  GatedMoneyRenderers,
 } from './components/financial-goals';
 
 // RFC-0108: Measurement Setup Modal

--- a/src/index.ts
+++ b/src/index.ts
@@ -1037,6 +1037,11 @@ export {
   coveragePercentLabel,
   injectCoverageStyles,
   COVERAGE_STYLE_ID,
+  // RFC-0228 A2a — R$ money overlay row for one Metas × Consumo card (pilot).
+  renderFinancialIndicators,
+  buildFinancialRowHTML,
+  resolveMoneyRowValues,
+  subtractDecimals,
 } from './components/financial-goals';
 export type {
   MoneyDomain,
@@ -1056,6 +1061,10 @@ export type {
   GoalGranularity,
   CurrencyBudgetResponse,
   CoverageViewOptions,
+  FinancialIndicatorsOptions,
+  FinancialMoneyValues,
+  FinancialChipColors,
+  FinancialValueColors,
 } from './components/financial-goals';
 
 // RFC-0108: Measurement Setup Modal

--- a/src/index.ts
+++ b/src/index.ts
@@ -974,6 +974,43 @@ export type {
   PricingPanelEvent,
   PricingPanelHandle,
   PricingPanelThemeSource,
+  TariffApiPanelConfig,
+} from './components/pricing-panel';
+
+// RFC-0228 A1 — GCDR hourly-tariff API client + panel↔wire adapter (makes the
+// pricing panel persist through /customers/:id/tariffs instead of localStorage).
+export {
+  TariffApiClient,
+  TariffApiError,
+  createTariffApiClient,
+  TariffApiAdapter,
+  createTariffApiAdapter,
+  panelDomainToWire,
+  wireDomainToPanel,
+  panelCategoryToWire,
+  wireCategoryToPanel,
+  normalizePriceString,
+  isLeapYear,
+  daysInMonthYear,
+  collapseHoursToBands,
+  collapseTreeToBands,
+  expandDayToHourBuckets,
+  expandBandHours,
+  expandBandToHourBucketsByYear,
+} from './components/pricing-panel';
+export type {
+  TariffApiClientConfig,
+  TariffSelector,
+  TariffBucket,
+  TariffTreeNode,
+  TariffTreeResponse,
+  TariffGranularity,
+  WireDomain,
+  WireCategory,
+  TariffApiAdapterOptions,
+  TariffBand,
+  TariffBandInput,
+  TariffBandPeriod,
 } from './components/pricing-panel';
 
 // RFC-0108: Measurement Setup Modal

--- a/src/index.ts
+++ b/src/index.ts
@@ -1031,6 +1031,12 @@ export {
   formatDeltaPct,
   computeDeltaPct,
   signOf,
+  // RFC-0228 A4 — honest coverage UI (reusable renderer for A2a/A3).
+  renderCoverageView,
+  buildCoverageHTML,
+  coveragePercentLabel,
+  injectCoverageStyles,
+  COVERAGE_STYLE_ID,
 } from './components/financial-goals';
 export type {
   MoneyDomain,
@@ -1049,6 +1055,7 @@ export type {
   GoalSelector,
   GoalGranularity,
   CurrencyBudgetResponse,
+  CoverageViewOptions,
 } from './components/financial-goals';
 
 // RFC-0108: Measurement Setup Modal

--- a/src/index.ts
+++ b/src/index.ts
@@ -1013,6 +1013,44 @@ export type {
   TariffBandPeriod,
 } from './components/pricing-panel';
 
+// RFC-0228 F0 — Financial Goals money foundation: naming bridge (resolves the
+// 3-way `budget` collision), goals-money API client, and pt-BR BRL formatters.
+// Pure types/client/formatters — no UI (A4/A2a/A3 consume this spine).
+// `formatBRL` is re-exported as `formatMoneyBRL` (takes a decimal STRING) to
+// avoid colliding with the pricing-panel numeric `formatBRL`.
+export {
+  MONEY_REQUIRES_DEVICE_GRANULARITY,
+  normalizeMoneyBlock,
+  normalizeBudgetBlock,
+  GoalsMoneyClient,
+  GoalsMoneyApiError,
+  createGoalsMoneyClient,
+  DASH as MONEY_DASH,
+  formatMoneyBRL,
+  formatBRLDelta,
+  formatDeltaPct,
+  computeDeltaPct,
+  signOf,
+} from './components/financial-goals';
+export type {
+  MoneyDomain,
+  QuantityGoal,
+  GoalTreeNode,
+  MonetaryProjection,
+  CurrencyBudget,
+  BudgetVerdict,
+  BudgetOverlay,
+  MoneyOverlay,
+  UncategorizedDevice,
+  TariffCoverageGaps,
+  RawMoneyBlock,
+  RawBudgetBlock,
+  GoalsMoneyClientConfig,
+  GoalSelector,
+  GoalGranularity,
+  CurrencyBudgetResponse,
+} from './components/financial-goals';
+
 // RFC-0108: Measurement Setup Modal
 export { openMeasurementSetupModal } from './components/premium-modals/measurement-setup';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1047,6 +1047,17 @@ export {
   buildBudgetHTML,
   buildVerdictHTML,
   resolveBudget,
+  // RFC-0228 A5a — device tariff-category management UI (seam-driven; B6 backs it).
+  createFakeDeviceCategoryPort,
+  createHttpDeviceCategoryPort,
+  DeviceCategoryConflictError,
+  openDeviceCategoryPanel,
+  createCoverageDeepLink,
+  deviceCategoryLabel,
+  deviceCategoryToPanelTerm,
+  panelTermToDeviceCategory,
+  injectDeviceCategoryStyles,
+  DEVICE_CATEGORY_STYLE_ID,
 } from './components/financial-goals';
 export type {
   MoneyDomain,
@@ -1073,6 +1084,18 @@ export type {
   BudgetViewOptions,
   BudgetValueColors,
   BudgetChipColors,
+  // RFC-0228 A5a — device tariff-category management UI.
+  // Aliased: a `DeviceCategory` value export already exists (RFC-0109 utils/device).
+  DeviceCategory as DeviceTariffCategory,
+  DeviceCategoryRow,
+  DeviceCategoryPort,
+  FakeDeviceSeed,
+  FakeDeviceCategoryPortOptions,
+  FakeDeviceCategoryPortHandle,
+  HttpDeviceCategoryPortConfig,
+  OpenDeviceCategoryPanelParams,
+  DeviceCategoryPanelHandle,
+  DeviceCategoryFilter,
 } from './components/financial-goals';
 
 // RFC-0108: Measurement Setup Modal

--- a/src/index.ts
+++ b/src/index.ts
@@ -1065,6 +1065,18 @@ export {
   decimalStringToCents,
   centsToDecimalString,
   REPORT_MONEY_HEADER,
+  // RFC-0228 A7 — per-consumer realized-vs-goal variance in R$ (DEC-6 withholding).
+  computeMoneyVariance,
+  buildMoneyVarianceHTML,
+  renderMoneyVariance,
+  createMoneyVarianceColumn,
+  resolveGoalAmount,
+  overlayWithholdsVerdict,
+  VARIANCE_LABEL_ABOVE,
+  VARIANCE_LABEL_BELOW,
+  VARIANCE_LABEL_ONTARGET,
+  VARIANCE_LABEL_WITHHELD,
+  MONEY_VARIANCE_HEADER,
 } from './components/financial-goals';
 export type {
   MoneyDomain,
@@ -1107,6 +1119,13 @@ export type {
   ReportMoneyColumnConfig,
   ReportMoneyColumn,
   ReportMoneyTotal,
+  // RFC-0228 A7 — per-consumer R$ variance types.
+  MoneyVarianceInput,
+  MoneyVarianceResult,
+  MoneyVarianceVerdict,
+  MoneyVarianceOptions,
+  MoneyVarianceColumn,
+  MoneyVarianceColumnConfig,
 } from './components/financial-goals';
 
 // RFC-0108: Measurement Setup Modal
@@ -1349,6 +1368,8 @@ export type {
   CustomerGoalsSeries,
   CustomerGoalsTotals,
   CustomerGoalsThemeMode,
+  // RFC-0228 A7 — optional R$ variance readout on the card (money naming bridge).
+  CustomerGoalsMoneyVariance,
 } from './components/cards/customer-goals/v1.0.0';
 
 // RFC-0132: EnergyPanel Component

--- a/src/index.ts
+++ b/src/index.ts
@@ -1042,6 +1042,11 @@ export {
   buildFinancialRowHTML,
   resolveMoneyRowValues,
   subtractDecimals,
+  // RFC-0228 A3 — native CURRENCY budget view (Target/Projected + DEC-6 verdict).
+  renderBudgetView,
+  buildBudgetHTML,
+  buildVerdictHTML,
+  resolveBudget,
 } from './components/financial-goals';
 export type {
   MoneyDomain,
@@ -1065,6 +1070,9 @@ export type {
   FinancialMoneyValues,
   FinancialChipColors,
   FinancialValueColors,
+  BudgetViewOptions,
+  BudgetValueColors,
+  BudgetChipColors,
 } from './components/financial-goals';
 
 // RFC-0108: Measurement Setup Modal

--- a/src/index.ts
+++ b/src/index.ts
@@ -1058,6 +1058,13 @@ export {
   panelTermToDeviceCategory,
   injectDeviceCategoryStyles,
   DEVICE_CATEGORY_STYLE_ID,
+  // RFC-0228 A6 — R$ money column for aggregate report rows/totals (DEC-8 contract).
+  createReportMoneyColumn,
+  isMoneyColumnConfident,
+  sumMoneyDecimals,
+  decimalStringToCents,
+  centsToDecimalString,
+  REPORT_MONEY_HEADER,
 } from './components/financial-goals';
 export type {
   MoneyDomain,
@@ -1096,6 +1103,10 @@ export type {
   OpenDeviceCategoryPanelParams,
   DeviceCategoryPanelHandle,
   DeviceCategoryFilter,
+  // RFC-0228 A6 — R$ money report column types.
+  ReportMoneyColumnConfig,
+  ReportMoneyColumn,
+  ReportMoneyTotal,
 } from './components/financial-goals';
 
 // RFC-0108: Measurement Setup Modal

--- a/src/thingsboard/MYIO-SIM/v5.2.0_UNIQUE/controller.js
+++ b/src/thingsboard/MYIO-SIM/v5.2.0_UNIQUE/controller.js
@@ -4129,6 +4129,67 @@ body.filter-modal-open { overflow: hidden !important; }
     const totalEl = overlay.querySelector('[data-side-total]');
     const evoStatusEl = overlay.querySelector('[data-evo-status]');
     const evoCanvas = overlay.querySelector('[data-evo-chart]');
+
+    // ── RFC-0228 A2a — overlay de dinheiro (R$) no card, piloto GATED ──────────
+    // Opt-in: só entra quando settings.goalsMoneyApi está configurado (fonte de
+    // dados em R$) E a lib expõe os símbolos novos (getGoalWithMoney/renderer).
+    // Ausente → nada é buscado nem anexado: o painel fica byte-idêntico (só kWh/m³),
+    // sem mudança de comportamento para quem não optou. Espelha o gate do A1
+    // (params.tariffApi religa o pricing panel; aqui settings.goalsMoneyApi liga o R$).
+    const _moneyGate =
+      settings && settings.goalsMoneyApi &&
+      typeof MyIOLibrary?.createGoalsMoneyClient === 'function' &&
+      typeof MyIOLibrary?.renderFinancialIndicators === 'function'
+        ? settings.goalsMoneyApi
+        : null;
+    let _moneyOverlays = new Map(); // tbId -> MoneyOverlay (por load; limpo a cada load)
+    // Anexa (do cache, síncrono) a linha de R$ / a visão de cobertura A4 a cada card
+    // já renderizado. Sem gate/cache → no-op (não toca o DOM).
+    const _appendMoneyRows = () => {
+      if (!_moneyGate || _moneyOverlays.size === 0 || !tableEl) return;
+      tableEl.querySelectorAll('[data-cust-eye]').forEach((eyeBtn) => {
+        const card = eyeBtn.closest('.gc-side-item');
+        if (!card || card.querySelector('.myio-fin, .myio-cov')) return;
+        const overlayData = _moneyOverlays.get(eyeBtn.getAttribute('data-cust-eye'));
+        if (!overlayData) return;
+        try {
+          const el = MyIOLibrary.renderFinancialIndicators({
+            overlay: overlayData,
+            // Cobertura indisponível/incompleta (A4) → deep-link para o painel de tarifas.
+            onManageCategories: () => { try { openPricing(); } catch (_) { /* enfeite */ } },
+          });
+          if (el) card.appendChild(el);
+        } catch (err) {
+          LogHelper.warn('[GoalsCompare] money row render falhou:', err?.message || err);
+        }
+      });
+    };
+    // Busca o overlay de R$ por shopping VIA A LIB (getGoalWithMoney) e popula o
+    // cache; re-renderiza uma vez p/ pintar. Degrada em silêncio (lib/creds/cobertura).
+    const _fetchMoneyOverlays = async (rows, seq) => {
+      if (!_moneyGate) return;
+      const domain = domainKey === 'water' ? 'WATER' : 'ENERGY';
+      const year = Number(isoLocalDay(period.startISO).slice(0, 4));
+      const baseUrl = GCDR_API_BASE || window.MyIOOrchestrator?.gcdrApiBaseUrl || '';
+      await Promise.all(
+        (rows || []).map(async (row) => {
+          const attrs = row._attrs || {};
+          const customerId = attrs.gcdrCustomerId;
+          const apiKey = attrs.gcdrApiKey || GCDR_API_KEY || settings.gcdrApiKey || '';
+          if (!customerId || row.tbId == null || !baseUrl || !apiKey) return;
+          try {
+            const client = MyIOLibrary.createGoalsMoneyClient({ baseUrl, apiKey });
+            const proj = await client.getGoalWithMoney({ customerId, domain, year, granularity: 'month' });
+            if (seq !== reqSeq) return;
+            if (proj && proj.money) _moneyOverlays.set(String(row.tbId), proj.money);
+          } catch (err) {
+            LogHelper.warn('[GoalsCompare] getGoalWithMoney falhou:', customerId, err?.code || err?.message || err);
+          }
+        })
+      );
+      if (seq !== reqSeq) return;
+      renderTable(lastRows, lastUnit); // re-render → _appendMoneyRows pinta do cache
+    };
     const dialogEl = overlay.querySelector('[data-gc-dialog]');
 
     // ── Tema (sincronizado com o dashboard via myio:theme-change / RFC-0120) ──
@@ -5017,11 +5078,15 @@ body.myio-gbt-dark .myio-gbt__empty{color:#64748b;}
           }
         });
       }
+      // RFC-0228 A2a (gated): anexa a linha de R$ / cobertura A4 aos cards (do cache).
+      // Gate off → no-op; DOM idêntico ao de hoje.
+      _appendMoneyRows();
       paintSideSort();
     };
 
     const load = async () => {
       const seq = ++reqSeq;
+      _moneyOverlays = new Map(); // RFC-0228 A2a: cache de overlays é por load (domínio/período)
       const cfg = GOALS_COMPARE_DOMAINS[domainKey];
       const startISO = period.startISO;
       const endISO = period.endISO;
@@ -5106,6 +5171,8 @@ body.myio-gbt-dark .myio-gbt__empty{color:#64748b;}
           refresh();
         });
       await Promise.all([goalsP, consP, consPrevP]);
+      // RFC-0228 A2a (gated): dados assentaram → busca overlays de R$ via lib e pinta.
+      void _fetchMoneyOverlays(rows, seq);
     };
 
     // Abas superiores Dashboards | Analítico (pills) — o resto da config vive no Engine.

--- a/src/thingsboard/MYIO-SIM/v5.2.0_UNIQUE/controller.js
+++ b/src/thingsboard/MYIO-SIM/v5.2.0_UNIQUE/controller.js
@@ -4181,7 +4181,38 @@ body.filter-modal-open { overflow: hidden !important; }
             const client = MyIOLibrary.createGoalsMoneyClient({ baseUrl, apiKey });
             const proj = await client.getGoalWithMoney({ customerId, domain, year, granularity: 'month' });
             if (seq !== reqSeq) return;
-            if (proj && proj.money) _moneyOverlays.set(String(row.tbId), proj.money);
+            // ── RFC-0228 A2b — broad-rollout gate (per-customer eligibility) ────────
+            // A2a's _moneyGate (checked at the top) already AND-ed (feature configured)
+            // × (lib symbols). A2b adds the 2nd/3rd axes VIA THE LIB: is THIS customer
+            // explicitly curated/allowlisted, and is the sampled overlay coverage-sane.
+            // Non-curated / broken-coverage customers degrade to the honest A4 coverage
+            // state (unavailable overlay) instead of a R$ row — never a fabricated total.
+            // Base defaults OFF: with no allowlist configured every customer is
+            // 'not-eligible'. Lib symbol absent → A2a's original behavior (byte-identical).
+            if (proj && proj.money) {
+              if (typeof MyIOLibrary?.resolveMoneyRollout === 'function') {
+                const decision = MyIOLibrary.resolveMoneyRollout({
+                  customerId,
+                  settings,
+                  overlaySample: proj.money,
+                  allowlist: settings.goalsMoneyRolloutAllowlist,
+                });
+                if (decision.enabled) {
+                  _moneyOverlays.set(String(row.tbId), proj.money);
+                } else if (decision.reason === 'not-eligible' || decision.reason === 'coverage-gap') {
+                  // Honest coverage (A4): reuse the unavailable overlay, else synthesize it.
+                  _moneyOverlays.set(
+                    String(row.tbId),
+                    proj.money.state === 'unavailable'
+                      ? proj.money
+                      : { state: 'unavailable', reason: MyIOLibrary.MONEY_REQUIRES_DEVICE_GRANULARITY }
+                  );
+                }
+                // reason 'disabled' → cache nothing (no row appended; byte-identical off).
+              } else {
+                _moneyOverlays.set(String(row.tbId), proj.money); // A2a fallback (lib pre-A2b)
+              }
+            }
           } catch (err) {
             LogHelper.warn('[GoalsCompare] getGoalWithMoney falhou:', customerId, err?.code || err?.message || err);
           }

--- a/src/utils/tooltips/EnergySummaryTooltip.ts
+++ b/src/utils/tooltips/EnergySummaryTooltip.ts
@@ -18,6 +18,12 @@
  * EnergySummaryTooltip.hide();
  */
 
+// RFC-0228 A6 — R$ money column for the summary total (additive + gated). Reuses
+// A2a/F0 formatting + A4 coverage under DEC-8; disabled config → '' (byte-identical).
+import { createReportMoneyColumn } from '../../components/financial-goals/reportMoneyColumn';
+import { injectCoverageStyles } from '../../components/financial-goals/coverageStyles';
+import type { MoneyOverlay } from '../../components/financial-goals/moneyTypes';
+
 // ============================================
 // Types
 // ============================================
@@ -105,6 +111,29 @@ export interface DashboardEnergySummary {
   unfilteredTotal?: number;
   /** Label for the entity grouping dimension (default: 'Shopping'). Comes from goalsEntityLabel setting. */
   entityLabel?: string;
+  /**
+   * RFC-0228 A6 — optional R$ money overlay for the summary total (additive + gated).
+   * Absent → the tooltip renders exactly as before (byte-identical). Present → an R$
+   * figure is shown beside the "Consumo Total" on the DEC-8 rounding contract
+   * (GCDR RFC-0054): the backend aggregate string verbatim when coverage is complete,
+   * else A4's honest coverage state — never R$ 0 / NaN.
+   */
+  money?: EnergySummaryMoney;
+}
+
+/** RFC-0228 A6 — money overlay carried by {@link DashboardEnergySummary}. */
+export interface EnergySummaryMoney {
+  /** Aggregate coverage overlay (F0). Gates whether a numeric R$ total is shown. */
+  overlay: MoneyOverlay;
+  /**
+   * Backend-authoritative aggregate R$ (DEC-8 top-down parent) as a decimal string.
+   * Shown verbatim (never re-derived) when the overlay is confidently priced.
+   */
+  total?: string | null;
+  /** Optional per-device R$ (decimal strings) for a DEC-8 fallback row-sum. */
+  perDevice?: Record<string, string | null | undefined>;
+  /** Optional R$ deviation vs the meta for the total (A7 owns the per-consumer chip). */
+  variance?: string | null;
 }
 
 // ============================================
@@ -1195,6 +1224,33 @@ export const EnergySummaryTooltip = {
   },
 
   /**
+   * RFC-0228 A6 — the R$ figure shown beside "Consumo Total", or `''` when no money
+   * overlay is present (gate off → byte-identical to the pre-A6 tooltip).
+   *
+   * DEC-8 (GCDR RFC-0054): clients consume the backend decimal string and never
+   * re-derive. When the overlay is confidently priced this shows the backend
+   * aggregate verbatim; otherwise it shows A4's honest coverage indicator — never a
+   * fabricated R$ 0. Amounts are formatted string-in/string-out via A2a/F0.
+   */
+  formatMoneyTotal(summary: DashboardEnergySummary): string {
+    const money = summary.money;
+    const column = createReportMoneyColumn(
+      money ? { overlay: money.overlay, perDevice: money.perDevice || {}, total: money.total, variance: money.variance } : null
+    );
+    if (!column.enabled) return '';
+    // Coverage indicator (incomplete/unavailable) needs the A4 stylesheet.
+    if (typeof document !== 'undefined') injectCoverageStyles(document);
+    const rowValues = money?.perDevice ? Object.values(money.perDevice) : [];
+    const inner = column.totalHTML(rowValues);
+    return (
+      `<div class="energy-summary-tooltip__total energy-summary-tooltip__total--money" data-money-total-row="1">` +
+      `<span class="energy-summary-tooltip__total-label">Custo projetado (R$)</span>` +
+      `<span class="energy-summary-tooltip__total-value">${inner}</span>` +
+      `</div>`
+    );
+  },
+
+  /**
    * Render shopping view rows (for "Por Shopping" tab)
    * Shows device count and consumption breakdown by shopping with expandable subcategories
    */
@@ -1372,7 +1428,7 @@ export const EnergySummaryTooltip = {
         <div class="energy-summary-tooltip__total">
           <span class="energy-summary-tooltip__total-label">Consumo Total</span>
           <span class="energy-summary-tooltip__total-value">${this.formatTotalWithFilter(summary)}</span>
-        </div>
+        </div>${this.formatMoneyTotal(summary)}
       </div>
     `;
   },

--- a/tests/components/cards/customer-goals/customerGoalsCard.test.ts
+++ b/tests/components/cards/customer-goals/customerGoalsCard.test.ts
@@ -574,3 +574,120 @@ describe('CustomerGoalsCard (RFC-0217)', () => {
     expect(card.el.querySelector('[data-total="realized"]')?.textContent).toBe('600,00 kWh');
   });
 });
+
+// ── RFC-0228 A7 — optional R$ variance readout (additive + gated) ────────────────
+
+describe('CustomerGoalsCard — RFC-0228 A7 money variance (gated, naming bridge)', () => {
+  const completeOverlay = {
+    state: 'available' as const,
+    currency: 'BRL',
+    coverageComplete: true,
+    pricedHours: 87600,
+    totalHours: 87600,
+    uncategorizedDevices: [],
+  };
+  const incompleteOverlay = {
+    state: 'available' as const,
+    currency: 'BRL',
+    coverageComplete: false,
+    pricedHours: 61320,
+    totalHours: 87600,
+    uncategorizedDevices: [],
+  };
+
+  it('GATE OFF: without moneyVariance the card is byte-identical (no money element)', () => {
+    const mk = (c: HTMLElement) =>
+      createCustomerGoalsCard({ container: c, title: 'Shopping Alpha', series: baseSeries() });
+
+    const cA = document.createElement('div');
+    const cB = document.createElement('div');
+    document.body.appendChild(cA);
+    document.body.appendChild(cB);
+    const a = mk(cA);
+    const b = mk(cB);
+
+    // No A7 element, and the two quantity-only cards are byte-identical.
+    expect(a.el.querySelector('.myio-cgc__money-variance')).toBeNull();
+    expect(a.el.querySelector('[data-money-variance-row]')).toBeNull();
+    expect(a.el.innerHTML).toBe(b.el.innerHTML);
+
+    a.destroy();
+    b.destroy();
+    cA.remove();
+    cB.remove();
+  });
+
+  it('GATE ON: an available overlay renders the variance chip + label (money names only)', () => {
+    const card = createCustomerGoalsCard({
+      container,
+      title: 'Shopping Alpha',
+      series: baseSeries(), // series.budget is a QUANTITY line — must not be read for money
+      moneyVariance: {
+        overlay: completeOverlay,
+        monetaryProjection: '1200.00', // realized R$
+        currencyBudget: '1000.00', // goal R$
+      },
+    });
+    const row = card.el.querySelector('.myio-cgc__money-variance');
+    expect(row).not.toBeNull();
+    expect(row!.querySelector('[data-money-variance="above"]')).not.toBeNull();
+    expect(row!.textContent).toContain('Variação vs meta (R$)');
+    expect(row!.textContent).toContain('Acima da meta (R$)');
+    expect(row!.textContent).toContain('R$ 200,00');
+  });
+
+  it('DEC-6: incomplete coverage → withheld chip, no number, no green/red', () => {
+    const card = createCustomerGoalsCard({
+      container,
+      title: 'Shopping Alpha',
+      series: baseSeries(),
+      moneyVariance: {
+        overlay: incompleteOverlay,
+        monetaryProjection: '1200.00',
+        currencyBudget: '1000.00',
+      },
+    });
+    const chip = card.el.querySelector('[data-money-variance="withheld"]');
+    expect(chip).not.toBeNull();
+    expect(chip!.textContent).toContain('Variação indisponível');
+    expect(chip!.innerHTML).not.toContain('R$');
+    expect(card.el.querySelector('[data-money-variance="above"]')).toBeNull();
+    expect(card.el.querySelector('[data-money-variance="below"]')).toBeNull();
+  });
+
+  it('naming bridge: the quantity series.budget is untouched by the money readout', () => {
+    // series.budget (quantity, kWh) drives the "Meta"/"Orçado" totals strip; the A7
+    // money readout must NOT change that behavior — the strip still reads budget[].
+    const withMoney = createCustomerGoalsCard({
+      container,
+      title: 'S',
+      series: { labels: ['Jan'], realized: [100], budget: [200] },
+      moneyVariance: {
+        overlay: completeOverlay,
+        monetaryProjection: '1200.00',
+        currencyBudget: '1000.00',
+      },
+    });
+    // The quantity budget total still renders from series.budget (200 kWh), unaffected.
+    expect(withMoney.el.querySelector('[data-total="budget"]')?.textContent).toBe('200,00 kWh');
+    // And the money chip lives in its own row, sourced from money names only.
+    expect(withMoney.el.querySelector('.myio-cgc__money-variance')).not.toBeNull();
+  });
+
+  it('update() can add the variance readout after construction', () => {
+    const card = createCustomerGoalsCard({
+      container,
+      title: 'S',
+      series: baseSeries(),
+    });
+    expect(card.el.querySelector('.myio-cgc__money-variance')).toBeNull();
+    card.update({
+      moneyVariance: {
+        overlay: completeOverlay,
+        monetaryProjection: '800.00',
+        currencyBudget: '1000.00',
+      },
+    });
+    expect(card.el.querySelector('[data-money-variance="below"]')).not.toBeNull();
+  });
+});

--- a/tests/components/financial-goals/budgetView.test.ts
+++ b/tests/components/financial-goals/budgetView.test.ts
@@ -1,0 +1,313 @@
+/**
+ * RFC-0228 A3 — Native CURRENCY budget view (`budgetView.ts`).
+ *
+ * Proves the renderer shows the committed Target and the Projected R$ (decimal
+ * strings via formatBRL), and — the **headline invariant** (GCDR RFC-0054 DEC-6) —
+ * that it declares in/over budget **only** when `withinBudget` is a strict boolean;
+ * a `null` verdict (coverage incomplete) is explicitly WITHHELD, carries no
+ * in/over-budget word, and defers to A4 for the why. No `budget` block → empty
+ * state (never an error, never `R$ 0`). Guards the wording contract (feedback §8):
+ * no billing-grade words, no `NaN`. Pure — jsdom DOM + callbacks, no fetch.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  renderBudgetView,
+  buildBudgetHTML,
+  buildVerdictHTML,
+  resolveBudget,
+} from '../../../src/components/financial-goals/budgetView';
+import {
+  MONEY_REQUIRES_DEVICE_GRANULARITY,
+  type MoneyOverlay,
+  type BudgetOverlay,
+} from '../../../src/components/financial-goals/moneyTypes';
+
+/** Words that would turn this coverage/estimation UX into billing wording. */
+const FORBIDDEN = ['fatura', 'faturamento', 'valor final', 'total a pagar'];
+/** In/over-budget conclusions that must NEVER appear over a withheld verdict. */
+const CONCLUSIONS = ['dentro do orçamento', 'acima do orçamento'];
+
+function assertNoForbidden(text: string): void {
+  const lower = text.toLowerCase();
+  for (const word of FORBIDDEN) expect(lower).not.toContain(word);
+  expect(text).not.toContain('NaN');
+}
+
+/** A complete, within-budget overlay: projected < target, verdict resolved true. */
+const within: MoneyOverlay = {
+  state: 'available',
+  currency: 'BRL',
+  coverageComplete: true,
+  pricedHours: 87600,
+  totalHours: 87600,
+  uncategorizedDevices: [],
+  budget: {
+    projected: { amount: '110000.00', source: 'OVERLAY', coverageComplete: true },
+    target: { amount: '120000.00', source: 'NATIVE' },
+    verdict: { withinBudget: true, variance: '-10000.00' },
+  },
+};
+
+/** A complete, over-budget overlay: projected > target, verdict resolved false. */
+const over: MoneyOverlay = {
+  state: 'available',
+  currency: 'BRL',
+  coverageComplete: true,
+  pricedHours: 87600,
+  totalHours: 87600,
+  uncategorizedDevices: [],
+  budget: {
+    projected: { amount: '138000.00', source: 'OVERLAY', coverageComplete: true },
+    target: { amount: '120000.00', source: 'NATIVE' },
+    verdict: { withinBudget: false, variance: '18000.00' },
+  },
+};
+
+/** An INCOMPLETE overlay: budget present but verdict withheld (DEC-6). */
+const withheld: MoneyOverlay = {
+  state: 'available',
+  currency: 'BRL',
+  coverageComplete: false,
+  pricedHours: 61320,
+  totalHours: 87600,
+  tariffCoverageGaps: { missing: ['2026-03-01T00'], truncated: false, missingHours: 24 },
+  uncategorizedDevices: [
+    { deviceId: 'dev-1', code: 'Q303A_L3', label: 'Loja 303A' },
+  ],
+  budget: {
+    projected: { amount: '128000.00', source: 'OVERLAY', coverageComplete: false },
+    target: { amount: '120000.00', source: 'NATIVE' },
+    verdict: { withinBudget: null, variance: null },
+  },
+};
+
+/** Available + complete but NO native budget block. */
+const noBudget: MoneyOverlay = {
+  state: 'available',
+  currency: 'BRL',
+  coverageComplete: true,
+  pricedHours: 87600,
+  totalHours: 87600,
+  uncategorizedDevices: [],
+};
+
+/** Unavailable overlay (customer-granular). No budget. */
+const unavailable: MoneyOverlay = {
+  state: 'unavailable',
+  reason: MONEY_REQUIRES_DEVICE_GRANULARITY,
+};
+
+describe('resolveBudget — extracts the native budget honestly', () => {
+  it('returns the budget block for an available overlay that carries one', () => {
+    expect(resolveBudget(within)).toBe((within as any).budget);
+  });
+  it('returns undefined for available-without-budget, unavailable, and null', () => {
+    expect(resolveBudget(noBudget)).toBeUndefined();
+    expect(resolveBudget(unavailable)).toBeUndefined();
+    expect(resolveBudget(null)).toBeUndefined();
+    expect(resolveBudget(undefined)).toBeUndefined();
+  });
+});
+
+describe('renderBudgetView — Target + Projected figures', () => {
+  it('renders both R$ figures via formatBRL (decimal strings preserved)', () => {
+    const el = renderBudgetView({ overlay: within })!;
+    expect(el).not.toBeNull();
+    expect(el.getAttribute('data-budget-state')).toBe('budget');
+    const html = el.innerHTML;
+    expect(html).toContain('R$ 120.000,00'); // target
+    expect(html).toContain('R$ 110.000,00'); // projected
+    assertNoForbidden(el.textContent || '');
+  });
+});
+
+describe('renderBudgetView — verdict: withinBudget:true + complete', () => {
+  it('shows "Dentro do orçamento" with the R$ and % variance', () => {
+    const el = renderBudgetView({ overlay: within })!;
+    const chip = el.querySelector('[data-budget-verdict="within"]')!;
+    expect(chip).not.toBeNull();
+    expect(chip.textContent).toContain('Dentro do orçamento');
+    const html = el.innerHTML;
+    // variance = projected − target = −10000.00; pct = −8,3%
+    expect(html).toContain('−R$ 10.000,00');
+    expect(html).toContain('−8,3%');
+    // No withheld / over language.
+    expect((el.textContent || '').toLowerCase()).not.toContain('acima do orçamento');
+    expect((el.textContent || '').toLowerCase()).not.toContain('veredito indisponível');
+    assertNoForbidden(el.textContent || '');
+  });
+});
+
+describe('renderBudgetView — verdict: withinBudget:false + complete', () => {
+  it('shows "Acima do orçamento" with the R$ and % variance', () => {
+    const el = renderBudgetView({ overlay: over })!;
+    const chip = el.querySelector('[data-budget-verdict="over"]')!;
+    expect(chip).not.toBeNull();
+    expect(chip.textContent).toContain('Acima do orçamento');
+    const html = el.innerHTML;
+    // variance = +18000.00; pct = +15,0%
+    expect(html).toContain('+R$ 18.000,00');
+    expect(html).toContain('+15,0%');
+    expect((el.textContent || '').toLowerCase()).not.toContain('dentro do orçamento');
+    assertNoForbidden(el.textContent || '');
+  });
+});
+
+describe('renderBudgetView — DEC-6: withinBudget:null → verdict WITHHELD', () => {
+  it('shows the withheld message, NO in/over-budget word, and defers to A4', () => {
+    const onCategorizeDevice = vi.fn();
+    const el = renderBudgetView({ overlay: withheld, onCategorizeDevice })!;
+    const text = (el.textContent || '').toLowerCase();
+
+    // The headline invariant: never a conclusion over a partial projection.
+    for (const word of CONCLUSIONS) expect(text).not.toContain(word);
+
+    // The explicit withheld chip.
+    const chip = el.querySelector('[data-budget-verdict="withheld"]')!;
+    expect(chip).not.toBeNull();
+    expect(chip.textContent).toContain('Veredito indisponível');
+    expect(chip.textContent).toContain('cobertura incompleta');
+
+    // Defers to A4 for the why (the coverage element is appended).
+    const why = el.querySelector('[data-budget-why="1"]');
+    expect(why).not.toBeNull();
+    expect(why!.getAttribute('data-cov-state')).toBe('available-incomplete');
+
+    // The A5a deep-link is wired through to A4.
+    const deviceBtn = el.querySelector<HTMLElement>('[data-cov-device="dev-1"]')!;
+    expect(deviceBtn).not.toBeNull();
+    deviceBtn.click();
+    expect(onCategorizeDevice).toHaveBeenCalledWith('dev-1');
+
+    assertNoForbidden(el.textContent || '');
+  });
+
+  it('buildVerdictHTML never emits a conclusion when withinBudget is null', () => {
+    const budget = (withheld as any).budget as BudgetOverlay;
+    const html = buildVerdictHTML(budget, {
+      overBg: '#f', overText: '#f', withinBg: '#f', withinText: '#f',
+      neutralBg: '#f', neutralText: '#f',
+    }).toLowerCase();
+    for (const word of CONCLUSIONS) expect(html).not.toContain(word);
+    expect(html).toContain('veredito indisponível');
+    expect(html).toContain('data-budget-verdict="withheld"');
+  });
+
+  it('withholds even if variance is (wrongly) populated while withinBudget is null', () => {
+    // Defense in depth: a stray non-null variance must NOT unlock a conclusion.
+    const budget: BudgetOverlay = {
+      projected: { amount: '128000.00', source: 'OVERLAY', coverageComplete: false },
+      target: { amount: '120000.00', source: 'NATIVE' },
+      verdict: { withinBudget: null, variance: '8000.00' },
+    };
+    const html = buildVerdictHTML(budget, {
+      overBg: '#f', overText: '#f', withinBg: '#f', withinText: '#f',
+      neutralBg: '#f', neutralText: '#f',
+    }).toLowerCase();
+    for (const word of CONCLUSIONS) expect(html).not.toContain(word);
+    expect(html).toContain('withheld');
+  });
+});
+
+describe('renderBudgetView — no budget block → empty state', () => {
+  it('renders an empty state (no error, no R$ 0) when the budget is absent', () => {
+    const el = renderBudgetView({ overlay: noBudget })!;
+    expect(el).not.toBeNull();
+    expect(el.getAttribute('data-budget-state')).toBe('empty');
+    const text = el.textContent || '';
+    expect(text).not.toContain('R$ 0');
+    expect(text).not.toContain('NaN');
+    // No verdict chips at all.
+    expect(el.querySelector('[data-budget-verdict]')).toBeNull();
+    assertNoForbidden(text);
+  });
+
+  it('renders empty state for an unavailable overlay too (no budget there)', () => {
+    const el = renderBudgetView({ overlay: unavailable })!;
+    expect(el.getAttribute('data-budget-state')).toBe('empty');
+    expect(el.querySelector('[data-budget-verdict]')).toBeNull();
+    assertNoForbidden(el.textContent || '');
+  });
+});
+
+describe('renderBudgetView — no overlay → null (money off)', () => {
+  it('returns null when there is no overlay / no state', () => {
+    expect(renderBudgetView({ overlay: null })).toBeNull();
+    expect(renderBudgetView({ overlay: undefined })).toBeNull();
+    expect(renderBudgetView({ overlay: {} as MoneyOverlay })).toBeNull();
+  });
+});
+
+describe('renderBudgetView — missing amounts render — (never R$ 0 / NaN)', () => {
+  it('renders the em-dash for absent target/projected amounts', () => {
+    const partial: MoneyOverlay = {
+      state: 'available',
+      currency: 'BRL',
+      coverageComplete: true,
+      pricedHours: 87600,
+      totalHours: 87600,
+      uncategorizedDevices: [],
+      budget: {
+        projected: { amount: '', source: 'OVERLAY', coverageComplete: true },
+        verdict: { withinBudget: true, variance: null },
+      } as BudgetOverlay,
+    };
+    const el = renderBudgetView({ overlay: partial })!;
+    const text = el.textContent || '';
+    expect(text).toContain('—'); // DASH for the missing amounts
+    expect(text).not.toContain('R$ 0');
+    expect(text).not.toContain('NaN');
+    assertNoForbidden(text);
+  });
+});
+
+describe('renderBudgetView — decimal-string amounts preserved (no float)', () => {
+  it('formats large decimal strings by grouping the string, not summing floats', () => {
+    const big: MoneyOverlay = {
+      state: 'available',
+      currency: 'BRL',
+      coverageComplete: true,
+      pricedHours: 87600,
+      totalHours: 87600,
+      uncategorizedDevices: [],
+      budget: {
+        projected: { amount: '9007199254740991.10', source: 'OVERLAY', coverageComplete: true },
+        target: { amount: '9007199254740992.20', source: 'NATIVE' },
+        verdict: { withinBudget: true, variance: '-1.10' },
+      },
+    };
+    const html = renderBudgetView({ overlay: big })!.innerHTML;
+    expect(html).toContain('R$ 9.007.199.254.740.991,10');
+    expect(html).toContain('R$ 9.007.199.254.740.992,20');
+    expect(html).not.toContain('NaN');
+  });
+});
+
+describe('renderBudgetView — optional stub edit affordance', () => {
+  it('fires onSaveBudget with a best-effort annual tree echo of the target', () => {
+    const onSaveBudget = vi.fn();
+    const el = renderBudgetView({ overlay: within, onSaveBudget })!;
+    const btn = el.querySelector<HTMLElement>('[data-budget-edit="1"]')!;
+    expect(btn).not.toBeNull();
+    btn.click();
+    expect(onSaveBudget).toHaveBeenCalledTimes(1);
+    expect(onSaveBudget).toHaveBeenCalledWith({ annual: { value: 120000 } });
+  });
+
+  it('omits the edit button when no onSaveBudget is given', () => {
+    const el = renderBudgetView({ overlay: within })!;
+    expect(el.querySelector('[data-budget-edit]')).toBeNull();
+  });
+});
+
+describe('buildBudgetHTML — pure, testable, honest', () => {
+  it('emits both figures and the resolved verdict as a string', () => {
+    const budget = (within as any).budget as BudgetOverlay;
+    const html = buildBudgetHTML(budget);
+    expect(html).toContain('R$ 120.000,00');
+    expect(html).toContain('R$ 110.000,00');
+    expect(html.toLowerCase()).toContain('dentro do orçamento');
+    assertNoForbidden(html);
+  });
+});

--- a/tests/components/financial-goals/coverageView.test.ts
+++ b/tests/components/financial-goals/coverageView.test.ts
@@ -1,0 +1,218 @@
+/**
+ * RFC-0228 A4 — Honest coverage UI (`coverageView.ts`).
+ *
+ * Proves the reusable renderer describes each `MoneyOverlay` coverage state
+ * honestly: the device-granularity message (never R$ 0), the incomplete badge with
+ * covered %, the full uncategorized-devices list as A5a deep-link affordances, the
+ * tariff-gaps summary — and that the quiet "complete" state shows none of that
+ * noise. Also guards the wording contract (feedback §8): no billing-grade words,
+ * ever, and no `NaN`. Pure — jsdom DOM + callbacks, no fetch.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  renderCoverageView,
+  buildCoverageHTML,
+  coveragePercentLabel,
+} from '../../../src/components/financial-goals/coverageView';
+import {
+  MONEY_REQUIRES_DEVICE_GRANULARITY,
+  type MoneyOverlay,
+} from '../../../src/components/financial-goals/moneyTypes';
+
+/** Words that would turn this coverage/estimation UX into billing wording. */
+const FORBIDDEN = ['fatura', 'faturamento', 'valor final', 'total a pagar'];
+
+function assertNoForbidden(text: string): void {
+  const lower = text.toLowerCase();
+  for (const word of FORBIDDEN) {
+    expect(lower).not.toContain(word);
+  }
+  expect(text).not.toContain('NaN');
+}
+
+const unavailable: MoneyOverlay = {
+  state: 'unavailable',
+  reason: MONEY_REQUIRES_DEVICE_GRANULARITY,
+};
+
+const incomplete: MoneyOverlay = {
+  state: 'available',
+  currency: 'BRL',
+  coverageComplete: false,
+  pricedHours: 61320,
+  totalHours: 87600, // 61320/87600 = 70%
+  tariffCoverageGaps: { missing: ['2026-03-01T00'], truncated: false, missingHours: 24 },
+  uncategorizedDevices: [
+    { deviceId: 'dev-1', code: 'Q303A_L3', label: 'Loja 303A' },
+    { deviceId: 'dev-2', code: 'Q104_L1', label: 'Loja 104' },
+  ],
+};
+
+const complete: MoneyOverlay = {
+  state: 'available',
+  currency: 'BRL',
+  coverageComplete: true,
+  pricedHours: 87600,
+  totalHours: 87600,
+  uncategorizedDevices: [],
+};
+
+describe('coveragePercentLabel — honest, never NaN', () => {
+  it('computes device-hour coverage as a pt-BR percent', () => {
+    expect(coveragePercentLabel(61320, 87600)).toBe('70%');
+    expect(coveragePercentLabel(43800, 87600)).toBe('50%');
+  });
+
+  it('returns the em-dash (not NaN, not R$ 0) for a missing/zero denominator', () => {
+    expect(coveragePercentLabel(100, 0)).toBe('—');
+    expect(coveragePercentLabel(100, undefined)).toBe('—');
+    expect(coveragePercentLabel(undefined, 87600)).toBe('—');
+    expect(coveragePercentLabel(NaN, 87600)).toBe('—');
+  });
+});
+
+describe('unavailable (MONEY_REQUIRES_DEVICE_GRANULARITY)', () => {
+  it('renders the device-granularity message — not an error, not R$ 0', () => {
+    const el = renderCoverageView(unavailable);
+    const text = el.textContent || '';
+    expect(el.getAttribute('data-cov-state')).toBe('unavailable');
+    expect(text).toContain('Visão em R$ indisponível');
+    expect(text.toLowerCase()).toContain('device-granular');
+    expect(text.toLowerCase()).toContain('categoria de tarifa');
+    // Never a fabricated zero amount.
+    expect(text).not.toContain('R$ 0');
+    assertNoForbidden(el.outerHTML);
+  });
+
+  it('offers the generic manage-categories deep-link only when a callback is given', () => {
+    const withoutCb = renderCoverageView(unavailable);
+    expect(withoutCb.querySelector('[data-cov-manage]')).toBeNull();
+
+    const onManageCategories = vi.fn();
+    const withCb = renderCoverageView(unavailable, { onManageCategories });
+    const manageBtn = withCb.querySelector<HTMLElement>('[data-cov-manage]');
+    expect(manageBtn).not.toBeNull();
+    manageBtn!.click();
+    expect(onManageCategories).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('available + coverageComplete:false — the key honest state', () => {
+  it('renders the incomplete badge, covered %, every device, and the gaps summary', () => {
+    const el = renderCoverageView(incomplete);
+    const text = el.textContent || '';
+    expect(el.getAttribute('data-cov-state')).toBe('available-incomplete');
+    expect(text).toContain('Cobertura incompleta');
+    expect(text).toContain('70%');
+    // covered fraction detail (device-hours, pt-BR grouped)
+    expect(text).toContain('61.320');
+    expect(text).toContain('87.600');
+    // partial-sum wording, never a total
+    expect(text.toLowerCase()).toContain('soma parcial');
+    // every uncategorized device is present as a click affordance
+    const deviceBtns = el.querySelectorAll('[data-cov-device]');
+    expect(deviceBtns.length).toBe(2);
+    expect(text).toContain('Loja 303A');
+    expect(text).toContain('Q303A_L3');
+    expect(text).toContain('Loja 104');
+    // tariff coverage gaps summary
+    expect(text).toContain('24');
+    expect(text.toLowerCase()).toContain('horas-dispositivo sem tarifa');
+    assertNoForbidden(el.outerHTML);
+  });
+
+  it('shows the truncated hint only when gaps.truncated is true', () => {
+    const truncated: MoneyOverlay = {
+      ...(incomplete as Extract<MoneyOverlay, { state: 'available' }>),
+      tariffCoverageGaps: { missing: [], truncated: true, missingHours: 999 },
+    };
+    const el = renderCoverageView(truncated);
+    expect((el.textContent || '').toLowerCase()).toContain('truncada');
+    // grouped large number, not NaN
+    expect(el.textContent).toContain('999');
+    assertNoForbidden(el.outerHTML);
+  });
+
+  it('fires onCategorizeDevice with the clicked device id (A5a deep-link)', () => {
+    const onCategorizeDevice = vi.fn();
+    const el = renderCoverageView(incomplete, { onCategorizeDevice });
+    const buttons = el.querySelectorAll<HTMLElement>('[data-cov-device]');
+    buttons[1].click();
+    expect(onCategorizeDevice).toHaveBeenCalledTimes(1);
+    expect(onCategorizeDevice).toHaveBeenCalledWith('dev-2');
+    buttons[0].click();
+    expect(onCategorizeDevice).toHaveBeenCalledWith('dev-1');
+    expect(onCategorizeDevice).toHaveBeenCalledTimes(2);
+  });
+
+  it('renders badge + note even with no uncategorized devices and no gaps', () => {
+    const bare: MoneyOverlay = {
+      state: 'available',
+      currency: 'BRL',
+      coverageComplete: false,
+      pricedHours: 10,
+      totalHours: 20,
+      uncategorizedDevices: [],
+    };
+    const el = renderCoverageView(bare);
+    const text = el.textContent || '';
+    expect(text).toContain('Cobertura incompleta');
+    expect(text).toContain('50%');
+    expect(el.querySelectorAll('[data-cov-device]').length).toBe(0);
+    assertNoForbidden(el.outerHTML);
+  });
+});
+
+describe('available + coverageComplete:true — quiet, no noise', () => {
+  it('shows the complete affordance and none of the incomplete/uncategorized noise', () => {
+    const el = renderCoverageView(complete);
+    const text = el.textContent || '';
+    expect(el.getAttribute('data-cov-state')).toBe('available-complete');
+    expect(text).toContain('Cobertura completa');
+    expect(text).not.toContain('Cobertura incompleta');
+    expect(text.toLowerCase()).not.toContain('sem categoria de tarifa');
+    expect(el.querySelectorAll('[data-cov-device]').length).toBe(0);
+    assertNoForbidden(el.outerHTML);
+  });
+
+  it('does not fire onCategorizeDevice when complete (nothing to categorize)', () => {
+    const onCategorizeDevice = vi.fn();
+    const el = renderCoverageView(complete, { onCategorizeDevice });
+    expect(el.querySelectorAll('[data-cov-device]').length).toBe(0);
+    expect(onCategorizeDevice).not.toHaveBeenCalled();
+  });
+});
+
+describe('wording contract (feedback §8) — no billing words, no NaN, across all states', () => {
+  it('every state output is free of forbidden billing words and NaN', () => {
+    assertNoForbidden(buildCoverageHTML(unavailable, true));
+    assertNoForbidden(buildCoverageHTML(incomplete));
+    assertNoForbidden(buildCoverageHTML(complete));
+    // a malformed/absent overlay degrades to the honest unavailable panel
+    assertNoForbidden(buildCoverageHTML(undefined as unknown as MoneyOverlay));
+  });
+
+  it('escapes untrusted device label/code (no raw HTML injection)', () => {
+    const hostile: MoneyOverlay = {
+      state: 'available',
+      currency: 'BRL',
+      coverageComplete: false,
+      pricedHours: 1,
+      totalHours: 2,
+      uncategorizedDevices: [{ deviceId: 'x', label: '<img src=x onerror=alert(1)>' }],
+    };
+    const html = buildCoverageHTML(hostile);
+    expect(html).not.toContain('<img src=x');
+    expect(html).toContain('&lt;img');
+  });
+});
+
+describe('injected styles', () => {
+  it('injects the coverage stylesheet once (id-guarded)', () => {
+    renderCoverageView(unavailable);
+    renderCoverageView(incomplete);
+    const styles = document.querySelectorAll('#myio-fin-coverage-styles');
+    expect(styles.length).toBe(1);
+  });
+});

--- a/tests/components/financial-goals/deviceCategoryPanel.test.ts
+++ b/tests/components/financial-goals/deviceCategoryPanel.test.ts
@@ -1,0 +1,216 @@
+/**
+ * RFC-0228 A5a — device tariff-category management UI (`deviceCategoryPanel.ts`).
+ *
+ * Proves the UI depends ONLY on the injected DeviceCategoryPort seam (feedback §5):
+ * every test drives the component through `createFakeDeviceCategoryPort` — no HTTP,
+ * no host. Covers list render, the uncategorized filter (A4 deep-link entry),
+ * single + bulk edits, focus highlight, version-conflict surfacing without losing
+ * other edits, category-term mapping reuse (A1), and the explicit-only discipline
+ * (RFC-0207: never infer a category from a device's name).
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  openDeviceCategoryPanel,
+  deviceCategoryLabel,
+  deviceCategoryToPanelTerm,
+  panelTermToDeviceCategory,
+} from '../../../src/components/financial-goals/deviceCategoryPanel';
+import { createFakeDeviceCategoryPort } from '../../../src/components/financial-goals/deviceCategoryPort';
+import {
+  WIRE_TO_PANEL_CATEGORY,
+  PANEL_TO_WIRE_CATEGORY,
+} from '../../../src/components/pricing-panel/tariffApiAdapter';
+
+/** Flush microtasks + a macrotask so async port writes settle. */
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+const seed = [
+  { deviceId: 'd1', code: 'SCP-001', label: 'Loja 1', tariffCategory: 'SPECIFIC' as const, version: '3' },
+  { deviceId: 'd2', code: 'SCP-002', label: 'Corredor L2', tariffCategory: null, version: '0' },
+  { deviceId: 'd3', code: 'SCP-003', label: 'Praça Central', tariffCategory: 'COMMON_AREA' as const, version: '1' },
+];
+
+function change(el: HTMLSelectElement | HTMLInputElement): void {
+  el.dispatchEvent(new Event('change'));
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  document.head.innerHTML = '';
+});
+
+describe('openDeviceCategoryPanel — list & filter', () => {
+  it('renders every device with its current category', async () => {
+    const port = createFakeDeviceCategoryPort(seed);
+    const h = openDeviceCategoryPanel({ port, customerId: 'c1' });
+    await h.ready;
+    expect(h.getVisibleDeviceIds()).toEqual(['d1', 'd2', 'd3']);
+    const root = h.getRoot();
+    const sel1 = root.querySelector<HTMLSelectElement>('[data-devcat-rowselect="d1"]')!;
+    expect(sel1.value).toBe('SPECIFIC');
+    const sel2 = root.querySelector<HTMLSelectElement>('[data-devcat-rowselect="d2"]')!;
+    expect(sel2.value).toBe(''); // uncategorized
+  });
+
+  it('uncategorized filter shows only tariffCategory === null', async () => {
+    const port = createFakeDeviceCategoryPort(seed);
+    const h = openDeviceCategoryPanel({ port, customerId: 'c1' });
+    await h.ready;
+    h.setCategoryFilter('uncategorized');
+    expect(h.getVisibleDeviceIds()).toEqual(['d2']);
+  });
+
+  it('search filters by label or code', async () => {
+    const port = createFakeDeviceCategoryPort(seed);
+    const h = openDeviceCategoryPanel({ port, customerId: 'c1' });
+    await h.ready;
+    h.setSearch('praça');
+    expect(h.getVisibleDeviceIds()).toEqual(['d3']);
+    h.setSearch('SCP-001');
+    expect(h.getVisibleDeviceIds()).toEqual(['d1']);
+  });
+});
+
+describe('openDeviceCategoryPanel — single edit', () => {
+  it('setting a row category calls port.setCategory with the right args and updates the row', async () => {
+    const port = createFakeDeviceCategoryPort(seed);
+    const spy = vi.spyOn(port, 'setCategory');
+    const h = openDeviceCategoryPanel({ port, customerId: 'c1' });
+    await h.ready;
+    const sel = h.getRoot().querySelector<HTMLSelectElement>('[data-devcat-rowselect="d2"]')!;
+    sel.value = 'COMMON_AREA';
+    change(sel);
+    await flush();
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith({ deviceId: 'd2', category: 'COMMON_AREA', expectedVersion: '0' });
+    expect(h.getRows().find((r) => r.deviceId === 'd2')!.tariffCategory).toBe('COMMON_AREA');
+  });
+});
+
+describe('openDeviceCategoryPanel — bulk edit', () => {
+  it('bulk-sets N devices via a single setCategoryBulk with the selected ids', async () => {
+    const port = createFakeDeviceCategoryPort(seed); // supportsBulk default true
+    const bulkSpy = vi.spyOn(port, 'setCategoryBulk');
+    const h = openDeviceCategoryPanel({ port, customerId: 'c1' });
+    await h.ready;
+    const root = h.getRoot();
+    const c1 = root.querySelector<HTMLInputElement>('[data-devcat-rowcheck="d1"]')!;
+    const c2 = root.querySelector<HTMLInputElement>('[data-devcat-rowcheck="d2"]')!;
+    c1.checked = true; change(c1);
+    c2.checked = true; change(c2);
+    const bulkCat = root.querySelector<HTMLSelectElement>('[data-devcat-bulkcat]')!;
+    bulkCat.value = 'COMMON_AREA';
+    root.querySelector<HTMLButtonElement>('[data-devcat-bulkapply]')!.click();
+    await flush();
+    expect(bulkSpy).toHaveBeenCalledTimes(1);
+    const arg = bulkSpy.mock.calls[0][0];
+    expect(new Set(arg.deviceIds)).toEqual(new Set(['d1', 'd2']));
+    expect(arg.category).toBe('COMMON_AREA');
+    expect(h.getRows().find((r) => r.deviceId === 'd2')!.tariffCategory).toBe('COMMON_AREA');
+  });
+
+  it('falls back to N setCategory calls when the port has no setCategoryBulk', async () => {
+    const port = createFakeDeviceCategoryPort(seed, { supportsBulk: false });
+    const singleSpy = vi.spyOn(port, 'setCategory');
+    const h = openDeviceCategoryPanel({ port, customerId: 'c1' });
+    await h.ready;
+    const root = h.getRoot();
+    const c1 = root.querySelector<HTMLInputElement>('[data-devcat-rowcheck="d1"]')!;
+    const c3 = root.querySelector<HTMLInputElement>('[data-devcat-rowcheck="d3"]')!;
+    c1.checked = true; change(c1);
+    c3.checked = true; change(c3);
+    const bulkCat = root.querySelector<HTMLSelectElement>('[data-devcat-bulkcat]')!;
+    bulkCat.value = 'SPECIFIC';
+    root.querySelector<HTMLButtonElement>('[data-devcat-bulkapply]')!.click();
+    await flush();
+    expect(singleSpy).toHaveBeenCalledTimes(2);
+    const ids = singleSpy.mock.calls.map((c) => c[0].deviceId);
+    expect(new Set(ids)).toEqual(new Set(['d1', 'd3']));
+  });
+});
+
+describe('openDeviceCategoryPanel — focus deep-link', () => {
+  it('focusDeviceId highlights the right row', async () => {
+    const port = createFakeDeviceCategoryPort(seed);
+    const h = openDeviceCategoryPanel({ port, customerId: 'c1', focusDeviceId: 'd3' });
+    await h.ready;
+    const focused = h.getRoot().querySelectorAll('[data-focused="1"]');
+    expect(focused.length).toBe(1);
+    expect(focused[0].getAttribute('data-devcat-row')).toBe('d3');
+  });
+});
+
+describe('openDeviceCategoryPanel — version conflict', () => {
+  it('surfaces a conflict on one device while preserving another pending edit', async () => {
+    const port = createFakeDeviceCategoryPort(seed);
+    const h = openDeviceCategoryPanel({ port, customerId: 'c1' });
+    await h.ready;
+    const root = h.getRoot();
+
+    // Someone else edits d1 concurrently → our stale expectedVersion will conflict.
+    port.bumpVersion('d1');
+
+    // Edit d1 (will conflict) and d3 (will succeed).
+    const selD1 = root.querySelector<HTMLSelectElement>('[data-devcat-rowselect="d1"]')!;
+    selD1.value = 'COMMON_AREA'; change(selD1);
+    await flush();
+
+    const selD3 = root.querySelector<HTMLSelectElement>('[data-devcat-rowselect="d3"]')!;
+    selD3.value = 'SPECIFIC'; change(selD3);
+    await flush();
+
+    // d1 shows a conflict banner...
+    const rowD1 = root.querySelector<HTMLElement>('[data-devcat-row="d1"]')!;
+    expect(rowD1.getAttribute('data-conflict')).toBe('1');
+    const banner = root.querySelector<HTMLElement>('[data-devcat-conflict="d1"]')!;
+    expect(banner.textContent && banner.textContent.length).toBeGreaterThan(0);
+    expect(h.getRows().find((r) => r.deviceId === 'd1')!.tariffCategory).toBe('SPECIFIC'); // unchanged
+
+    // ...but d3's edit is preserved (not lost by d1's failure).
+    expect(h.getRows().find((r) => r.deviceId === 'd3')!.tariffCategory).toBe('SPECIFIC');
+    const rowD3 = root.querySelector<HTMLElement>('[data-devcat-row="d3"]')!;
+    expect(rowD3.getAttribute('data-conflict')).toBeNull();
+  });
+});
+
+describe('category term mapping reuses A1 (no duplicate logic)', () => {
+  it('maps COMMON_AREA↔area_comum and SPECIFIC↔lojas via the shared A1 map', () => {
+    // The panel helpers must agree with A1's centralized map for every token.
+    expect(deviceCategoryToPanelTerm('COMMON_AREA')).toBe(WIRE_TO_PANEL_CATEGORY.COMMON_AREA);
+    expect(deviceCategoryToPanelTerm('SPECIFIC')).toBe(WIRE_TO_PANEL_CATEGORY.SPECIFIC);
+    expect(deviceCategoryToPanelTerm('COMMON_AREA')).toBe('area_comum');
+    expect(deviceCategoryToPanelTerm('SPECIFIC')).toBe('lojas');
+    expect(deviceCategoryToPanelTerm(null)).toBeNull();
+
+    expect(panelTermToDeviceCategory('area_comum')).toBe(PANEL_TO_WIRE_CATEGORY.area_comum);
+    expect(panelTermToDeviceCategory('lojas')).toBe(PANEL_TO_WIRE_CATEGORY.lojas);
+    expect(panelTermToDeviceCategory('area_comum')).toBe('COMMON_AREA');
+    expect(panelTermToDeviceCategory('lojas')).toBe('SPECIFIC');
+    expect(panelTermToDeviceCategory(null)).toBeNull();
+  });
+
+  it('labels derive from the same map (round-trip)', () => {
+    expect(deviceCategoryLabel('COMMON_AREA')).toBe('Área Comum');
+    expect(deviceCategoryLabel('SPECIFIC')).toBe('Lojas');
+    expect(deviceCategoryLabel(null)).toContain('Sem categoria');
+  });
+});
+
+describe('explicit-only discipline (RFC-0207)', () => {
+  it('a device labeled "Loja X" with tariffCategory:null stays uncategorized', async () => {
+    // Name says "Loja" but the explicit attribute is null — must NOT be inferred.
+    const port = createFakeDeviceCategoryPort([
+      { deviceId: 'x1', code: 'SCP-X', label: 'Loja X', tariffCategory: null, version: '0' },
+    ]);
+    const h = openDeviceCategoryPanel({ port, customerId: 'c1' });
+    await h.ready;
+    h.setCategoryFilter('uncategorized');
+    expect(h.getVisibleDeviceIds()).toEqual(['x1']);
+    const sel = h.getRoot().querySelector<HTMLSelectElement>('[data-devcat-rowselect="x1"]')!;
+    expect(sel.value).toBe(''); // none — no inference from the "Loja" label
+    expect(h.getRows()[0].tariffCategory).toBeNull();
+  });
+});

--- a/tests/components/financial-goals/deviceCategoryPort.test.ts
+++ b/tests/components/financial-goals/deviceCategoryPort.test.ts
@@ -1,0 +1,91 @@
+/**
+ * RFC-0228 A5a — the device-category SEAM (`deviceCategoryPort.ts`).
+ *
+ * Proves the injectable port contract that the UI depends on (feedback §5), using
+ * ONLY the in-memory fake — no HTTP, no host. Also proves the HTTP stub refuses to
+ * run until B6 ships, so nothing accidentally relies on a presumed device API.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createFakeDeviceCategoryPort,
+  createHttpDeviceCategoryPort,
+  DeviceCategoryConflictError,
+  type DeviceCategoryPort,
+} from '../../../src/components/financial-goals/deviceCategoryPort';
+
+const seed = [
+  { deviceId: 'd1', code: 'SCP-001', label: 'Loja 1', tariffCategory: 'SPECIFIC' as const, version: '3' },
+  { deviceId: 'd2', code: 'SCP-002', label: 'Corredor L2', tariffCategory: null, version: '0' },
+  { deviceId: 'd3', code: 'SCP-003', label: 'Praça', tariffCategory: 'COMMON_AREA' as const, version: '1' },
+];
+
+describe('createFakeDeviceCategoryPort', () => {
+  it('lists all seeded devices with their explicit category', async () => {
+    const port = createFakeDeviceCategoryPort(seed);
+    const rows = await port.listDevices({ customerId: 'c1' });
+    expect(rows.map((r) => r.deviceId)).toEqual(['d1', 'd2', 'd3']);
+    expect(rows.find((r) => r.deviceId === 'd2')!.tariffCategory).toBeNull();
+    expect(rows.find((r) => r.deviceId === 'd1')!.tariffCategory).toBe('SPECIFIC');
+  });
+
+  it('filters by domain when the seed tags one', async () => {
+    const port = createFakeDeviceCategoryPort([
+      { deviceId: 'e1', domain: 'ENERGY', tariffCategory: null },
+      { deviceId: 'w1', domain: 'WATER', tariffCategory: null },
+    ]);
+    const energy = await port.listDevices({ customerId: 'c1', domain: 'ENERGY' });
+    expect(energy.map((r) => r.deviceId)).toEqual(['e1']);
+  });
+
+  it('setCategory updates the row and bumps version', async () => {
+    const port = createFakeDeviceCategoryPort(seed);
+    const updated = await port.setCategory({ deviceId: 'd2', category: 'COMMON_AREA', expectedVersion: '0' });
+    expect(updated.tariffCategory).toBe('COMMON_AREA');
+    expect(updated.version).toBe('1');
+    const rows = await port.listDevices({ customerId: 'c1' });
+    expect(rows.find((r) => r.deviceId === 'd2')!.tariffCategory).toBe('COMMON_AREA');
+  });
+
+  it('setCategory can clear a category to null', async () => {
+    const port = createFakeDeviceCategoryPort(seed);
+    const updated = await port.setCategory({ deviceId: 'd1', category: null, expectedVersion: '3' });
+    expect(updated.tariffCategory).toBeNull();
+  });
+
+  it('rejects a stale expectedVersion with a conflict error', async () => {
+    const port = createFakeDeviceCategoryPort(seed);
+    await expect(
+      port.setCategory({ deviceId: 'd1', category: 'COMMON_AREA', expectedVersion: '999' })
+    ).rejects.toBeInstanceOf(DeviceCategoryConflictError);
+  });
+
+  it('bumpVersion simulates a concurrent edit that then conflicts', async () => {
+    const port = createFakeDeviceCategoryPort(seed);
+    port.bumpVersion('d3'); // someone else edited d3
+    await expect(
+      port.setCategory({ deviceId: 'd3', category: 'SPECIFIC', expectedVersion: '1' })
+    ).rejects.toBeInstanceOf(DeviceCategoryConflictError);
+  });
+
+  it('exposes setCategoryBulk by default and reports per-device failures', async () => {
+    const port = createFakeDeviceCategoryPort(seed);
+    expect(typeof port.setCategoryBulk).toBe('function');
+    const res = await port.setCategoryBulk!({ deviceIds: ['d1', 'd2', 'missing'], category: 'COMMON_AREA' });
+    expect(res.updated).toBe(2);
+    expect(res.failed).toEqual([{ deviceId: 'missing', reason: 'UNKNOWN_DEVICE' }]);
+  });
+
+  it('omits setCategoryBulk when supportsBulk:false (exercises the N-call fallback)', () => {
+    const port = createFakeDeviceCategoryPort(seed, { supportsBulk: false });
+    expect(port.setCategoryBulk).toBeUndefined();
+  });
+});
+
+describe('createHttpDeviceCategoryPort (awaits B6)', () => {
+  it('is a marked stub: every method throws until B6 lands', async () => {
+    const port: DeviceCategoryPort = createHttpDeviceCategoryPort({ baseUrl: 'https://example.invalid' });
+    await expect(port.listDevices({ customerId: 'c1' })).rejects.toThrow(/B6/);
+    await expect(port.setCategory({ deviceId: 'd1', category: null })).rejects.toThrow(/B6/);
+  });
+});

--- a/tests/components/financial-goals/energySummaryMoney.test.ts
+++ b/tests/components/financial-goals/energySummaryMoney.test.ts
@@ -1,0 +1,96 @@
+/**
+ * RFC-0228 A6 — money wiring into the energy summary (`EnergySummaryTooltip`).
+ *
+ * Proves the R$ figure is shown beside "Consumo Total" when a money overlay is
+ * present, honours DEC-8 (backend string verbatim / A4 coverage), and — critically —
+ * that `renderHTML` is **byte-identical** to the pre-A6 output when the gate is off.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  EnergySummaryTooltip,
+  type DashboardEnergySummary,
+} from '../../../src/utils/tooltips/EnergySummaryTooltip';
+import type { MoneyOverlay } from '../../../src/components/financial-goals/moneyTypes';
+import { MONEY_REQUIRES_DEVICE_GRANULARITY } from '../../../src/components/financial-goals/moneyTypes';
+
+const FORBIDDEN = ['fatura', 'faturamento', 'valor final', 'total a pagar'];
+
+function baseSummary(): DashboardEnergySummary {
+  return {
+    totalDevices: 3,
+    totalConsumption: 1500,
+    unit: 'kWh',
+    byCategory: [],
+    byStatus: {
+      waiting: 0,
+      weakConnection: 0,
+      offline: 0,
+      normal: 3,
+      alert: 0,
+      failure: 0,
+      standby: 0,
+      noConsumption: 0,
+    },
+    lastUpdated: '2026-07-01T12:00:00.000Z',
+  };
+}
+
+const complete: MoneyOverlay = {
+  state: 'available',
+  currency: 'BRL',
+  coverageComplete: true,
+  pricedHours: 8760,
+  totalHours: 8760,
+  uncategorizedDevices: [],
+};
+
+const incomplete: MoneyOverlay = {
+  state: 'available',
+  currency: 'BRL',
+  coverageComplete: false,
+  pricedHours: 4000,
+  totalHours: 8760,
+  uncategorizedDevices: [{ deviceId: 'd1' }],
+};
+
+describe('EnergySummaryTooltip — A6 money total', () => {
+  it('gate OFF → renderHTML is byte-identical to the pre-A6 output', () => {
+    const summary = baseSummary();
+    const off = EnergySummaryTooltip.renderHTML(summary);
+    // No money field, and formatMoneyTotal must contribute nothing.
+    expect(EnergySummaryTooltip.formatMoneyTotal(summary)).toBe('');
+    expect(off).not.toContain('Custo projetado');
+    expect(off).not.toContain('data-money-total-row');
+  });
+
+  it('available + complete → shows the backend R$ total verbatim beside Consumo Total', () => {
+    const summary = { ...baseSummary(), money: { overlay: complete, total: '223000.00' } };
+    const html = EnergySummaryTooltip.renderHTML(summary);
+    expect(html).toContain('Custo projetado (R$)');
+    expect(html).toContain('R$ 223.000,00');
+    expect(html).toContain('data-money-total-row="1"');
+  });
+
+  it('incomplete coverage → honest coverage indicator, never R$ 0 / NaN', () => {
+    const summary = {
+      ...baseSummary(),
+      money: { overlay: incomplete, total: '100000.00' },
+    };
+    const money = EnergySummaryTooltip.formatMoneyTotal(summary);
+    expect(money).toContain('Cobertura incompleta');
+    expect(money).not.toContain('R$ 0');
+    expect(money).not.toContain('NaN');
+  });
+
+  it('unavailable → coverage indicator, no number', () => {
+    const summary = {
+      ...baseSummary(),
+      money: { overlay: { state: 'unavailable', reason: MONEY_REQUIRES_DEVICE_GRANULARITY } as MoneyOverlay },
+    };
+    const money = EnergySummaryTooltip.formatMoneyTotal(summary);
+    expect(money).toContain('indisponível');
+    const lower = money.toLowerCase();
+    for (const w of FORBIDDEN) expect(lower).not.toContain(w);
+  });
+});

--- a/tests/components/financial-goals/financialIndicators.test.ts
+++ b/tests/components/financial-goals/financialIndicators.test.ts
@@ -1,0 +1,267 @@
+/**
+ * RFC-0228 A2a — R$ money overlay row for one Metas × Consumo card
+ * (`financialIndicators.ts`).
+ *
+ * Proves the renderer maps an `available`+complete `MoneyOverlay` to a R$ row
+ * (Realizado / Orçado / Meta em R$ via decimal-string formatting, plus a signed
+ * deviation chip), and that it **defers to A4** (`renderCoverageView`) for the
+ * incomplete and unavailable states — never inventing `R$ 0`, never a total. Also
+ * proves the money-off gate (no overlay → `null`), A5a callback pass-through, and
+ * that decimal-string amounts are not `Number()`-drifted. Pure — jsdom DOM +
+ * callbacks, no fetch, no ThingsBoard.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  renderFinancialIndicators,
+  buildFinancialRowHTML,
+  resolveMoneyRowValues,
+  subtractDecimals,
+} from '../../../src/components/financial-goals/financialIndicators';
+import {
+  MONEY_REQUIRES_DEVICE_GRANULARITY,
+  type MoneyOverlay,
+} from '../../../src/components/financial-goals/moneyTypes';
+
+/** Words that would turn this coverage/estimation UX into billing wording (§8). */
+const FORBIDDEN = ['fatura', 'faturamento', 'valor final', 'total a pagar'];
+function assertNoForbidden(text: string): void {
+  const lower = text.toLowerCase();
+  for (const word of FORBIDDEN) expect(lower).not.toContain(word);
+  expect(text).not.toContain('NaN');
+}
+
+const completeOverlay: MoneyOverlay = {
+  state: 'available',
+  currency: 'BRL',
+  coverageComplete: true,
+  pricedHours: 87600,
+  totalHours: 87600,
+  uncategorizedDevices: [],
+  budget: {
+    projected: { amount: '223000.00', source: 'OVERLAY', coverageComplete: true },
+    target: { amount: '250000.00', source: 'NATIVE' },
+    verdict: { withinBudget: true, variance: '-27000.00' },
+  },
+};
+
+const incompleteOverlay: MoneyOverlay = {
+  state: 'available',
+  currency: 'BRL',
+  coverageComplete: false,
+  pricedHours: 61320,
+  totalHours: 87600,
+  tariffCoverageGaps: { missing: ['2026-03-01T00'], truncated: false, missingHours: 24 },
+  uncategorizedDevices: [
+    { deviceId: 'dev-1', code: 'Q303A_L3', label: 'Loja 303A' },
+    { deviceId: 'dev-2', code: 'Q104_L1', label: 'Loja 104' },
+  ],
+};
+
+const unavailableOverlay: MoneyOverlay = {
+  state: 'unavailable',
+  reason: MONEY_REQUIRES_DEVICE_GRANULARITY,
+};
+
+describe('renderFinancialIndicators — available + complete → R$ row', () => {
+  it('shows Realizado / Orçado / Meta em R$ from decimal strings (formatted, not Number-drifted)', () => {
+    const el = renderFinancialIndicators({
+      overlay: completeOverlay,
+      // Realized R$ is not carried by a goal overlay → supplied explicitly.
+      money: { realized: '228123.45', orcado: '223000.00', meta: '250000.00' },
+    });
+    expect(el).not.toBeNull();
+    const root = el as HTMLElement;
+    expect(root.getAttribute('data-fin-state')).toBe('available-money');
+    const html = root.innerHTML;
+    // Decimal strings become pt-BR BRL (grouping + comma decimal), verbatim.
+    expect(html).toContain('R$ 228.123,45'); // Realizado
+    expect(html).toContain('R$ 223.000,00'); // Orçado
+    expect(html).toContain('R$ 250.000,00'); // Meta
+    expect(html).toContain('Realizado');
+    expect(html).toContain('Orçado');
+    expect(html).toContain('Meta');
+    assertNoForbidden(root.textContent || '');
+  });
+
+  it('preserves full decimal-string precision without float drift', () => {
+    const el = renderFinancialIndicators({
+      overlay: completeOverlay,
+      money: { realized: '1234567.89', orcado: '999999.99', meta: '1000000.01' },
+    }) as HTMLElement;
+    const html = el.innerHTML;
+    expect(html).toContain('R$ 1.234.567,89');
+    expect(html).toContain('R$ 999.999,99');
+    expect(html).toContain('R$ 1.000.000,01');
+  });
+
+  it('deviation chip: Realizado > Meta → over (↑, positive %)', () => {
+    // Realizado 264000 vs Meta 250000 → +5.6% over.
+    const el = renderFinancialIndicators({
+      overlay: completeOverlay,
+      money: { realized: '264000.00', orcado: '223000.00', meta: '250000.00' },
+    }) as HTMLElement;
+    const chip = el.querySelector('[data-fin-chip]') as HTMLElement;
+    expect(chip.getAttribute('data-fin-chip')).toBe('over');
+    expect(chip.textContent).toContain('↑');
+    expect(chip.textContent).toContain('+');
+    // signed R$ delta rides in the title (string math, +14.000,00)
+    expect(chip.getAttribute('title')).toBe('+R$ 14.000,00');
+  });
+
+  it('deviation chip: Realizado < Meta → under (↓, negative %)', () => {
+    // Realizado 230000 vs Meta 250000 → −8% under.
+    const el = renderFinancialIndicators({
+      overlay: completeOverlay,
+      money: { realized: '230000.00', orcado: '223000.00', meta: '250000.00' },
+    }) as HTMLElement;
+    const chip = el.querySelector('[data-fin-chip]') as HTMLElement;
+    expect(chip.getAttribute('data-fin-chip')).toBe('under');
+    expect(chip.textContent).toContain('↓');
+    expect(chip.textContent).toContain('−'); // true minus
+    expect(chip.getAttribute('title')).toBe('−R$ 20.000,00');
+  });
+
+  it('deviation chip: no realized R$ → neutral dash chip (never R$ 0)', () => {
+    const el = renderFinancialIndicators({
+      overlay: completeOverlay,
+      money: { orcado: '223000.00', meta: '250000.00' },
+    }) as HTMLElement;
+    const chip = el.querySelector('[data-fin-chip]') as HTMLElement;
+    expect(chip.getAttribute('data-fin-chip')).toBe('none');
+    expect(chip.textContent).toBe('—');
+    // A missing Realizado renders the em-dash figure, not "R$ 0,00".
+    expect(el.innerHTML).not.toContain('R$ 0,00');
+  });
+
+  it('derives Orçado/Meta em R$ from overlay.budget when money is omitted', () => {
+    const el = renderFinancialIndicators({ overlay: completeOverlay }) as HTMLElement;
+    const html = el.innerHTML;
+    expect(html).toContain('R$ 223.000,00'); // projected → Orçado
+    expect(html).toContain('R$ 250.000,00'); // target → Meta
+  });
+});
+
+describe('renderFinancialIndicators — defers to A4 for non-confident states', () => {
+  it('available + coverageComplete:false → A4 incomplete view, NOT R$ numbers', () => {
+    const el = renderFinancialIndicators({ overlay: incompleteOverlay }) as HTMLElement;
+    expect(el).not.toBeNull();
+    // A4's element carries data-cov-state, not our R$ data-fin-state.
+    expect(el.getAttribute('data-cov-state')).toBe('available-incomplete');
+    expect(el.getAttribute('data-fin-state')).toBeNull();
+    const html = el.innerHTML;
+    expect(html).toContain('Cobertura incompleta');
+    // The R$ figures/labels of the money row are absent (deferred, not priced).
+    expect(html).not.toContain('data-fin-row');
+    assertNoForbidden(el.textContent || '');
+  });
+
+  it('unavailable → A4 unavailable view, no R$ 0', () => {
+    const el = renderFinancialIndicators({ overlay: unavailableOverlay }) as HTMLElement;
+    expect(el.getAttribute('data-cov-state')).toBe('unavailable');
+    expect(el.getAttribute('data-fin-state')).toBeNull();
+    const html = el.innerHTML;
+    expect(html).not.toContain('R$ 0');
+    expect(html).not.toContain('data-fin-row');
+    assertNoForbidden(el.textContent || '');
+  });
+});
+
+describe('renderFinancialIndicators — A5a callback pass-through', () => {
+  it('onCategorizeDevice fires with the deviceId from the incomplete view', () => {
+    const onCategorizeDevice = vi.fn();
+    const el = renderFinancialIndicators({
+      overlay: incompleteOverlay,
+      onCategorizeDevice,
+    }) as HTMLElement;
+    const btn = el.querySelector('[data-cov-device="dev-1"]') as HTMLElement;
+    expect(btn).not.toBeNull();
+    btn.click();
+    expect(onCategorizeDevice).toHaveBeenCalledWith('dev-1');
+  });
+
+  it('onManageCategories is offered in the unavailable state and fires', () => {
+    const onManageCategories = vi.fn();
+    const el = renderFinancialIndicators({
+      overlay: unavailableOverlay,
+      onManageCategories,
+    }) as HTMLElement;
+    const btn = el.querySelector('[data-cov-manage]') as HTMLElement;
+    expect(btn).not.toBeNull();
+    btn.click();
+    expect(onManageCategories).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('renderFinancialIndicators — money-off gate', () => {
+  it('returns null when there is no overlay (money disabled → no R$ row)', () => {
+    expect(renderFinancialIndicators({ overlay: null })).toBeNull();
+    expect(renderFinancialIndicators({ overlay: undefined })).toBeNull();
+    // A malformed overlay (no state) is treated as off, not an error.
+    expect(
+      renderFinancialIndicators({ overlay: {} as unknown as MoneyOverlay })
+    ).toBeNull();
+  });
+});
+
+describe('resolveMoneyRowValues — explicit wins, else derive from budget', () => {
+  it('derives orcado/meta from overlay.budget; realized/prevYear only from explicit', () => {
+    const v = resolveMoneyRowValues(completeOverlay);
+    expect(v.orcado).toBe('223000.00');
+    expect(v.meta).toBe('250000.00');
+    expect(v.realized).toBeNull();
+    expect(v.prevYear).toBeNull();
+  });
+
+  it('explicit money.* overrides the derived budget amounts', () => {
+    const v = resolveMoneyRowValues(completeOverlay, {
+      orcado: '1.00',
+      meta: '2.00',
+      realized: '3.00',
+    });
+    expect(v.orcado).toBe('1.00');
+    expect(v.meta).toBe('2.00');
+    expect(v.realized).toBe('3.00');
+  });
+
+  it('unavailable overlay carries no budget → all null unless explicit', () => {
+    const v = resolveMoneyRowValues(unavailableOverlay);
+    expect(v).toEqual({ realized: null, orcado: null, meta: null, prevYear: null });
+  });
+});
+
+describe('subtractDecimals — string cents math (no float drift)', () => {
+  it('subtracts two decimal strings preserving 2dp and sign', () => {
+    expect(subtractDecimals('264000.00', '250000.00')).toBe('14000.00');
+    expect(subtractDecimals('230000.00', '250000.00')).toBe('-20000.00');
+    expect(subtractDecimals('0.30', '0.10')).toBe('0.20'); // classic float trap avoided
+    expect(subtractDecimals('0.10', '0.30')).toBe('-0.20');
+  });
+
+  it('returns null on invalid input', () => {
+    expect(subtractDecimals('abc', '1.00')).toBeNull();
+    expect(subtractDecimals('1.00', null)).toBeNull();
+  });
+});
+
+describe('buildFinancialRowHTML — pure string builder', () => {
+  it('renders the three figures and a chip; no billing words, no NaN', () => {
+    const html = buildFinancialRowHTML(
+      { realized: '228123.45', orcado: '223000.00', meta: '250000.00', prevYear: null },
+      'meta',
+      {
+        overBg: '#fee2e2',
+        overText: '#b91c1c',
+        underBg: '#dcfce7',
+        underText: '#15803d',
+        neutralBg: '#f1f5f9',
+        neutralText: '#64748b',
+      },
+      { realized: '#2563eb', orcado: '#f59e0b', meta: '#7c3aed', prevYear: '#94a3b8' }
+    );
+    expect(html).toContain('R$ 228.123,45');
+    expect(html).toContain('data-fin-row');
+    expect(html).toContain('Estimativa em R$');
+    assertNoForbidden(html);
+  });
+});

--- a/tests/components/financial-goals/goalsMoneyClient.test.ts
+++ b/tests/components/financial-goals/goalsMoneyClient.test.ts
@@ -1,0 +1,215 @@
+/**
+ * RFC-0228 F0 — GoalsMoneyClient (mocked fetch, no live backend).
+ *
+ * Proves: the withMoney read parses tree + normalized overlay and keeps every
+ * amount a decimal string (no drift on "223000.00"); budget PUT sends the
+ * decimal tree + expectedVersion + If-Match; a 409 GOAL_VERSION_CONFLICT is
+ * surfaced (not swallowed) with currentVersion.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createGoalsMoneyClient,
+  GoalsMoneyApiError,
+} from '../../../src/components/financial-goals/goalsMoneyClient';
+
+const BASE = 'https://gcdr-api.example.com';
+
+function jsonResponse(body: unknown, init?: { status?: number; etag?: string }): Response {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (init?.etag) headers.ETag = init.etag;
+  return new Response(JSON.stringify(body), { status: init?.status ?? 200, headers });
+}
+
+describe('getGoalWithMoney', () => {
+  it('parses the quantity tree + overlay and preserves amounts as decimal strings', async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse(
+        {
+          customerId: 'c1',
+          domain: 'ENERGY',
+          year: 2026,
+          measure: 'QUANTITY',
+          version: 5,
+          unit: 'kWh',
+          money: {
+            currency: 'BRL',
+            coverageComplete: false,
+            pricedHours: 61320,
+            totalHours: 87600,
+            tariffCoverageGaps: { missing: ['2026-03-01T00'], truncated: false, missingHours: 24 },
+            uncategorizedDevices: [{ deviceId: 'd1', code: 'Q303A_L3', label: 'Loja 303A' }],
+          },
+          budget: {
+            projected: { amount: '128000.00', source: 'OVERLAY', coverageComplete: false },
+            target: { amount: '120000.00', source: 'NATIVE' },
+            variance: null,
+            withinBudget: null,
+          },
+          tree: { annual: { value: 250000, monetaryValue: '223000.00' } },
+        },
+        { etag: '"5"' }
+      )
+    );
+    const client = createGoalsMoneyClient({ baseUrl: BASE, apiKey: 'gcdr_cust_x', fetchImpl });
+
+    const res = await client.getGoalWithMoney({
+      customerId: 'c1',
+      domain: 'ENERGY',
+      year: 2026,
+      granularity: 'month',
+    });
+
+    // URL carries withMoney=true and no measure (it is a QUANTITY overlay read).
+    const url = String(fetchImpl.mock.calls[0][0]);
+    expect(url).toContain('/customers/c1/goals');
+    expect(url).toContain('withMoney=true');
+    expect(url).toContain('domain=ENERGY');
+    expect(url).toContain('granularity=month');
+    expect(url).not.toContain('measure=');
+
+    expect(res.version).toBe(5);
+    expect(res.measure).toBe('QUANTITY');
+    // monetaryValue preserved verbatim as a string — no float drift.
+    expect(res.goal.tree.annual?.monetaryValue).toBe('223000.00');
+    expect(typeof res.goal.tree.annual?.monetaryValue).toBe('string');
+    // The quantity value stays a number (it is a quantity, not money).
+    expect(res.goal.tree.annual?.value).toBe(250000);
+
+    expect(res.money.state).toBe('available');
+    if (res.money.state === 'available') {
+      expect(res.money.budget!.projected.amount).toBe('128000.00');
+      expect(res.money.budget!.target!.amount).toBe('120000.00');
+      expect(res.money.budget!.verdict.withinBudget).toBeNull();
+      expect(res.money.uncategorizedDevices[0].code).toBe('Q303A_L3');
+    }
+  });
+
+  it('customer-granular goal → money overlay unavailable (a value, not an error)', async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({
+        customerId: 'c1',
+        domain: 'ENERGY',
+        year: 2026,
+        measure: 'QUANTITY',
+        version: 2,
+        money: { reason: 'MONEY_REQUIRES_DEVICE_GRANULARITY' },
+        tree: { annual: { value: 250000 } },
+      })
+    );
+    const client = createGoalsMoneyClient({ baseUrl: BASE, jwt: 'jwt', fetchImpl });
+    const res = await client.getGoalWithMoney({ customerId: 'c1', domain: 'ENERGY', year: 2026 });
+    expect(res.money.state).toBe('unavailable');
+    if (res.money.state === 'unavailable') {
+      expect(res.money.reason).toBe('MONEY_REQUIRES_DEVICE_GRANULARITY');
+    }
+  });
+});
+
+describe('getBudget', () => {
+  it('reads the CURRENCY goal and keeps the tree verbatim', async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse(
+        {
+          customerId: 'c1',
+          domain: 'ENERGY',
+          year: 2026,
+          measure: 'CURRENCY',
+          currency: 'BRL',
+          version: 3,
+          tree: { annual: { value: '120000.00' } },
+        },
+        { etag: '"3"' }
+      )
+    );
+    const client = createGoalsMoneyClient({ baseUrl: BASE, apiKey: 'k', fetchImpl });
+    const res = await client.getBudget({ customerId: 'c1', domain: 'ENERGY', year: 2026 });
+    const url = String(fetchImpl.mock.calls[0][0]);
+    expect(url).toContain('measure=CURRENCY');
+    expect(res.version).toBe(3);
+    expect(res.tree.annual?.value).toBe('120000.00');
+  });
+});
+
+describe('putBudget', () => {
+  it('sends the decimal tree + expectedVersion in body and If-Match header', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ version: 4 }, { etag: '"4"' }));
+    const client = createGoalsMoneyClient({ baseUrl: BASE, apiKey: 'k', fetchImpl });
+
+    const out = await client.putBudget({
+      customerId: 'c1',
+      domain: 'ENERGY',
+      year: 2026,
+      tree: { annual: { value: '120000.00' } },
+      expectedVersion: 3,
+    });
+
+    expect(out.version).toBe(4);
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(String(url)).toContain('measure=CURRENCY');
+    expect(init.method).toBe('PUT');
+    const headers = init.headers as Record<string, string>;
+    expect(headers['If-Match']).toBe('"3"');
+    const body = JSON.parse(String(init.body));
+    // Decimal string preserved in the wire body (no numeric coercion).
+    expect(body.annual.value).toBe('120000.00');
+    expect(typeof body.annual.value).toBe('string');
+    expect(body.expectedVersion).toBe(3);
+  });
+
+  it('surfaces 409 GOAL_VERSION_CONFLICT with currentVersion (not swallowed)', async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse(
+        { error: { code: 'GOAL_VERSION_CONFLICT', message: 'stale', details: { currentVersion: 9 } } },
+        { status: 409 }
+      )
+    );
+    const client = createGoalsMoneyClient({ baseUrl: BASE, apiKey: 'k', fetchImpl });
+
+    await expect(
+      client.putBudget({
+        customerId: 'c1',
+        domain: 'ENERGY',
+        year: 2026,
+        tree: { annual: { value: '120000.00' } },
+        expectedVersion: 3,
+      })
+    ).rejects.toMatchObject({ code: 'GOAL_VERSION_CONFLICT', status: 409, currentVersion: 9 });
+
+    // And it is the typed error class.
+    try {
+      await client.putBudget({
+        customerId: 'c1',
+        domain: 'ENERGY',
+        year: 2026,
+        tree: { annual: { value: '1.00' } },
+        expectedVersion: 3,
+      });
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(GoalsMoneyApiError);
+    }
+  });
+});
+
+describe('deleteBudget', () => {
+  it('idempotent whole-year delete returns {} on 204', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 204 }));
+    const client = createGoalsMoneyClient({ baseUrl: BASE, apiKey: 'k', fetchImpl });
+    const out = await client.deleteBudget({ customerId: 'c1', domain: 'ENERGY', year: 2026 });
+    expect(out).toEqual({});
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(String(url)).toContain('measure=CURRENCY');
+    expect(init.method).toBe('DELETE');
+  });
+
+  it('guarded delete sends If-Match + expectedVersion', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ version: 5 }));
+    const client = createGoalsMoneyClient({ baseUrl: BASE, apiKey: 'k', fetchImpl });
+    await client.deleteBudget({ customerId: 'c1', domain: 'ENERGY', year: 2026, expectedVersion: 4 });
+    const init = fetchImpl.mock.calls[0][1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers['If-Match']).toBe('"4"');
+    expect(JSON.parse(String(init.body)).expectedVersion).toBe(4);
+  });
+});

--- a/tests/components/financial-goals/moneyFormat.test.ts
+++ b/tests/components/financial-goals/moneyFormat.test.ts
@@ -1,0 +1,106 @@
+/**
+ * RFC-0228 F0 — money display formatting (decimal-string in, pt-BR BRL out).
+ *
+ * Proves: "1234.56" → "R$ 1.234,56"; null/missing/invalid → "—" (never NaN,
+ * never a misleading R$ 0); large values group; and independent string inputs
+ * like "0.10"/"0.20" are formatted verbatim, never summed as floats.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  formatBRL,
+  formatBRLDelta,
+  formatDeltaPct,
+  computeDeltaPct,
+  signOf,
+  DASH,
+} from '../../../src/components/financial-goals/moneyFormat';
+
+describe('formatBRL', () => {
+  it('formats a plain decimal string', () => {
+    expect(formatBRL('1234.56')).toBe('R$ 1.234,56');
+  });
+
+  it('pads to two decimals', () => {
+    expect(formatBRL('223000')).toBe('R$ 223.000,00');
+    expect(formatBRL('0.1')).toBe('R$ 0,10');
+  });
+
+  it('groups large values (millions/billions) correctly', () => {
+    expect(formatBRL('1000000.00')).toBe('R$ 1.000.000,00');
+    expect(formatBRL('1234567890.99')).toBe('R$ 1.234.567.890,99');
+  });
+
+  it('renders — for null / undefined / empty / invalid (never NaN, never R$ 0)', () => {
+    expect(formatBRL(null)).toBe(DASH);
+    expect(formatBRL(undefined)).toBe(DASH);
+    expect(formatBRL('')).toBe(DASH);
+    expect(formatBRL('abc')).toBe(DASH);
+    expect(formatBRL('R$ 5')).toBe(DASH); // not a bare decimal string
+    expect(formatBRL(null)).not.toContain('NaN');
+    expect(formatBRL(null)).not.toContain('0');
+  });
+
+  it('does not sum inputs — "0.10" and "0.20" format independently (no float error)', () => {
+    // If these were ever added as JS numbers (0.1 + 0.2 = 0.30000000000000004),
+    // formatting would drift. Each string is formatted verbatim instead.
+    expect(formatBRL('0.10')).toBe('R$ 0,10');
+    expect(formatBRL('0.20')).toBe('R$ 0,20');
+    // The canonical string is the source of truth; no arithmetic is performed.
+    expect(formatBRL('0.30')).toBe('R$ 0,30');
+  });
+
+  it('rounds half-up on the third decimal using string carry (no float)', () => {
+    expect(formatBRL('1.005')).toBe('R$ 1,01');
+    expect(formatBRL('0.999')).toBe('R$ 1,00'); // carry into the integer part
+    expect(formatBRL('9.996')).toBe('R$ 10,00');
+    expect(formatBRL('1.004')).toBe('R$ 1,00');
+  });
+
+  it('handles a negative amount', () => {
+    expect(formatBRL('-1500.00')).toBe('R$ -1.500,00');
+    expect(formatBRL('-0.00')).toBe('R$ 0,00'); // negative zero shows no sign
+  });
+});
+
+describe('formatBRLDelta', () => {
+  it('adds an explicit sign for the deviation chip', () => {
+    expect(formatBRLDelta('1234.56')).toBe('+R$ 1.234,56');
+    expect(formatBRLDelta('-50.00')).toBe('−R$ 50,00');
+    expect(formatBRLDelta('0')).toBe('R$ 0,00');
+  });
+  it('renders — for missing/invalid', () => {
+    expect(formatBRLDelta(null)).toBe(DASH);
+    expect(formatBRLDelta('nope')).toBe(DASH);
+  });
+});
+
+describe('formatDeltaPct + computeDeltaPct + signOf', () => {
+  it('computes a signed deviation percentage from decimal strings', () => {
+    // (128000 - 120000) / 120000 * 100 = 6.666…%
+    const pct = computeDeltaPct('128000.00', '120000.00');
+    expect(pct).toBeCloseTo(6.6667, 3);
+    expect(formatDeltaPct(pct)).toBe('+6,7%');
+  });
+
+  it('returns null (→ —) when the baseline is zero or inputs invalid', () => {
+    expect(computeDeltaPct('100', '0')).toBeNull();
+    expect(computeDeltaPct(null, '100')).toBeNull();
+    expect(computeDeltaPct('x', '100')).toBeNull();
+    expect(formatDeltaPct(null)).toBe(DASH);
+  });
+
+  it('formats zero and negative percentages with the true minus sign', () => {
+    expect(formatDeltaPct(0)).toBe('0,0%');
+    expect(formatDeltaPct(-1.5)).toBe('−1,5%');
+    expect(formatDeltaPct(3.2)).toBe('+3,2%');
+  });
+
+  it('signOf returns +/−/empty', () => {
+    expect(signOf(5)).toBe('+');
+    expect(signOf(-5)).toBe('−');
+    expect(signOf(0)).toBe('');
+    expect(signOf(null)).toBe('');
+    expect(signOf(NaN)).toBe('');
+  });
+});

--- a/tests/components/financial-goals/moneyRolloutGate.test.ts
+++ b/tests/components/financial-goals/moneyRolloutGate.test.ts
@@ -1,0 +1,334 @@
+/**
+ * RFC-0228 A2b — broad-rollout gate (`moneyRolloutGate.ts`).
+ *
+ * Proves the per-customer eligibility layer that decides whether the R$ money overlay
+ * turns on:
+ *  - defaults **OFF for the whole production base** (no allowlist → `not-eligible`);
+ *  - composes with A2a as an AND: (feature available) × (customer curated) × (coverage
+ *    sane), and names the first failing layer in `reason`;
+ *  - never enables a broken (`unavailable`) overlay → `coverage-gap`;
+ *  - never enables a customer by inference (name/domain/size), only explicit allowlist /
+ *    curated flag / base-wide flip;
+ *  - the wiring helper routes `!enabled` to A4 coverage and the feature-off path to
+ *    render-nothing (byte-identical to pre-A2b).
+ * Pure — no fetch, no ThingsBoard; the DOM helper uses jsdom-injected renderers.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  resolveMoneyRollout,
+  routeMoneyRender,
+  renderGatedMoney,
+} from '../../../src/components/financial-goals/moneyRolloutGate';
+import {
+  MONEY_REQUIRES_DEVICE_GRANULARITY,
+  type MoneyOverlay,
+} from '../../../src/components/financial-goals/moneyTypes';
+
+const completeOverlay: MoneyOverlay = {
+  state: 'available',
+  currency: 'BRL',
+  coverageComplete: true,
+  pricedHours: 87600,
+  totalHours: 87600,
+  uncategorizedDevices: [],
+};
+
+const unavailableOverlay: MoneyOverlay = {
+  state: 'unavailable',
+  reason: MONEY_REQUIRES_DEVICE_GRANULARITY,
+};
+
+const FEATURE_ON = { goalsMoneyApi: { baseUrl: 'https://x', apiKey: 'k' } };
+
+describe('resolveMoneyRollout — layer (a): global feature flag', () => {
+  it('feature off → disabled regardless of allowlist (via settings)', () => {
+    const d = resolveMoneyRollout({
+      customerId: 'cust-1',
+      settings: { goalsMoneyRolloutAllowlist: ['cust-1'] }, // no goalsMoneyApi
+      overlaySample: completeOverlay,
+    });
+    expect(d).toEqual({ enabled: false, reason: 'disabled' });
+  });
+
+  it('feature off → disabled even with base-wide flip and allowlisted id', () => {
+    const d = resolveMoneyRollout({
+      customerId: 'cust-1',
+      settings: { goalsMoneyRolloutBaseWide: true, goalsMoneyRolloutAllowlist: ['cust-1'] },
+      overlaySample: completeOverlay,
+    });
+    expect(d).toEqual({ enabled: false, reason: 'disabled' });
+  });
+
+  it('explicit featureAvailable:false wins over a truthy goalsMoneyApi (composed A2a gate)', () => {
+    const d = resolveMoneyRollout({
+      customerId: 'cust-1',
+      featureAvailable: false,
+      settings: { ...FEATURE_ON, goalsMoneyRolloutAllowlist: ['cust-1'] },
+      overlaySample: completeOverlay,
+    });
+    expect(d).toEqual({ enabled: false, reason: 'disabled' });
+  });
+});
+
+describe('resolveMoneyRollout — layer (b): explicit customer eligibility (base defaults OFF)', () => {
+  it('feature on + customer NOT in allowlist → not-eligible (the base-wide default)', () => {
+    const d = resolveMoneyRollout({
+      customerId: 'cust-1',
+      settings: FEATURE_ON, // no allowlist at all
+      overlaySample: completeOverlay,
+    });
+    expect(d).toEqual({ enabled: false, reason: 'not-eligible' });
+  });
+
+  it('feature on + empty allowlist → not-eligible', () => {
+    const d = resolveMoneyRollout({
+      customerId: 'cust-1',
+      settings: { ...FEATURE_ON, goalsMoneyRolloutAllowlist: [] },
+      overlaySample: completeOverlay,
+    });
+    expect(d).toEqual({ enabled: false, reason: 'not-eligible' });
+  });
+
+  it('feature on + allowlisted + complete overlay → eligible (pilot curated customer)', () => {
+    const d = resolveMoneyRollout({
+      customerId: 'cust-1',
+      settings: { ...FEATURE_ON, goalsMoneyRolloutAllowlist: ['cust-9', 'cust-1'] },
+      overlaySample: completeOverlay,
+    });
+    expect(d).toEqual({ enabled: true, reason: 'eligible' });
+  });
+
+  it('eligible with no overlay sample at all (coverage deferred to per-card A2a/A4)', () => {
+    const d = resolveMoneyRollout({
+      customerId: 'cust-1',
+      settings: { ...FEATURE_ON, goalsMoneyRolloutAllowlist: ['cust-1'] },
+    });
+    expect(d).toEqual({ enabled: true, reason: 'eligible' });
+  });
+
+  it('explicit allowlist param overrides settings allowlist', () => {
+    const d = resolveMoneyRollout({
+      customerId: 'cust-1',
+      settings: { ...FEATURE_ON, goalsMoneyRolloutAllowlist: ['other'] },
+      allowlist: ['cust-1'],
+      overlaySample: completeOverlay,
+    });
+    expect(d).toEqual({ enabled: true, reason: 'eligible' });
+  });
+
+  it('accepts a Set allowlist and numeric customerId (String-normalized)', () => {
+    const d = resolveMoneyRollout({
+      customerId: 42,
+      settings: FEATURE_ON,
+      allowlist: new Set(['42']),
+      overlaySample: completeOverlay,
+    });
+    expect(d).toEqual({ enabled: true, reason: 'eligible' });
+  });
+});
+
+describe('resolveMoneyRollout — layer (c): coverage sanity', () => {
+  it('allowlisted + unavailable overlay → coverage-gap (never enable a broken overlay)', () => {
+    const d = resolveMoneyRollout({
+      customerId: 'cust-1',
+      settings: { ...FEATURE_ON, goalsMoneyRolloutAllowlist: ['cust-1'] },
+      overlaySample: unavailableOverlay,
+    });
+    expect(d).toEqual({ enabled: false, reason: 'coverage-gap' });
+  });
+
+  it('allowlisted + MONEY_REQUIRES_DEVICE_GRANULARITY reason → coverage-gap', () => {
+    const d = resolveMoneyRollout({
+      customerId: 'cust-1',
+      settings: { ...FEATURE_ON, goalsMoneyRolloutAllowlist: ['cust-1'] },
+      overlaySample: { state: 'unavailable', reason: MONEY_REQUIRES_DEVICE_GRANULARITY },
+    });
+    expect(d.enabled).toBe(false);
+    expect(d.reason).toBe('coverage-gap');
+  });
+
+  it('available-but-incomplete overlay is NOT "broken" → still eligible (A4 handles per-card)', () => {
+    const partial: MoneyOverlay = {
+      state: 'available',
+      currency: 'BRL',
+      coverageComplete: false,
+      pricedHours: 61320,
+      totalHours: 87600,
+      uncategorizedDevices: [{ deviceId: 'd1' }],
+    };
+    const d = resolveMoneyRollout({
+      customerId: 'cust-1',
+      settings: { ...FEATURE_ON, goalsMoneyRolloutAllowlist: ['cust-1'] },
+      overlaySample: partial,
+    });
+    expect(d).toEqual({ enabled: true, reason: 'eligible' });
+  });
+});
+
+describe('resolveMoneyRollout — no inference (RFC-0207 explicit-only)', () => {
+  it('a customer is NEVER enabled by name/domain/size — only explicit allowlist', () => {
+    // Rich, "obviously a big energy mall" context — must still be not-eligible.
+    const d = resolveMoneyRollout({
+      customerId: 'shopping-flagship-energy-XL',
+      settings: FEATURE_ON,
+      overlaySample: completeOverlay,
+    });
+    expect(d).toEqual({ enabled: false, reason: 'not-eligible' });
+  });
+
+  it('missing customerId is unverifiable → not-eligible even with a populated allowlist', () => {
+    const d = resolveMoneyRollout({
+      customerId: null,
+      settings: { ...FEATURE_ON, goalsMoneyRolloutAllowlist: ['cust-1'] },
+      overlaySample: completeOverlay,
+    });
+    expect(d).toEqual({ enabled: false, reason: 'not-eligible' });
+  });
+});
+
+describe('resolveMoneyRollout — B1 base-wide flip (one-line policy change)', () => {
+  it('goalsMoneyRolloutBaseWide:true enables any customer (post-B1)', () => {
+    const d = resolveMoneyRollout({
+      customerId: 'any-customer',
+      settings: { ...FEATURE_ON, goalsMoneyRolloutBaseWide: true },
+      overlaySample: completeOverlay,
+    });
+    expect(d).toEqual({ enabled: true, reason: 'eligible' });
+  });
+
+  it("'*' sentinel in the allowlist enables any customer", () => {
+    const d = resolveMoneyRollout({
+      customerId: 'any-customer',
+      settings: FEATURE_ON,
+      allowlist: ['*'],
+      overlaySample: completeOverlay,
+    });
+    expect(d).toEqual({ enabled: true, reason: 'eligible' });
+  });
+
+  it('base-wide still respects coverage sanity (unavailable → coverage-gap)', () => {
+    const d = resolveMoneyRollout({
+      customerId: 'any-customer',
+      settings: { ...FEATURE_ON, goalsMoneyRolloutBaseWide: true },
+      overlaySample: unavailableOverlay,
+    });
+    expect(d).toEqual({ enabled: false, reason: 'coverage-gap' });
+  });
+});
+
+describe('routeMoneyRender — wiring helper', () => {
+  it('disabled → render-nothing (byte-identical to pre-A2b: no coverage panel added)', () => {
+    const r = routeMoneyRender({
+      customerId: 'cust-1',
+      settings: {}, // feature off
+      overlaySample: completeOverlay,
+    });
+    expect(r.action).toBe('render-nothing');
+    expect(r.coverageOverlay).toBeUndefined();
+    expect(r.decision).toEqual({ enabled: false, reason: 'disabled' });
+  });
+
+  it('eligible → render-money', () => {
+    const r = routeMoneyRender({
+      customerId: 'cust-1',
+      settings: { ...FEATURE_ON, goalsMoneyRolloutAllowlist: ['cust-1'] },
+      overlaySample: completeOverlay,
+    });
+    expect(r.action).toBe('render-money');
+  });
+
+  it('not-eligible → render-coverage with a synthesized unavailable overlay (A4)', () => {
+    const r = routeMoneyRender({
+      customerId: 'cust-1',
+      settings: FEATURE_ON, // no allowlist
+      overlaySample: completeOverlay, // real overlay is complete, but customer not curated
+    });
+    expect(r.action).toBe('render-coverage');
+    expect(r.coverageOverlay).toEqual({
+      state: 'unavailable',
+      reason: MONEY_REQUIRES_DEVICE_GRANULARITY,
+    });
+  });
+
+  it('coverage-gap → render-coverage reusing the real unavailable overlay', () => {
+    const sample: MoneyOverlay = { state: 'unavailable', reason: 'SOME_OTHER_REASON' };
+    const r = routeMoneyRender({
+      customerId: 'cust-1',
+      settings: { ...FEATURE_ON, goalsMoneyRolloutAllowlist: ['cust-1'] },
+      overlaySample: sample,
+    });
+    expect(r.action).toBe('render-coverage');
+    expect(r.coverageOverlay).toBe(sample); // reused verbatim, not synthesized
+  });
+});
+
+describe('renderGatedMoney — DOM composition (A2a money × A4 coverage)', () => {
+  function makeRenderers() {
+    const moneyEl = document.createElement('div');
+    moneyEl.setAttribute('data-money', '1');
+    const covEl = document.createElement('div');
+    covEl.setAttribute('data-coverage', '1');
+    return {
+      moneyEl,
+      covEl,
+      renderMoney: vi.fn(() => moneyEl),
+      renderCoverage: vi.fn(() => covEl),
+    };
+  }
+
+  it('eligible → calls renderMoney with the overlay sample, returns its element', () => {
+    const r = makeRenderers();
+    const el = renderGatedMoney(
+      {
+        customerId: 'cust-1',
+        settings: { ...FEATURE_ON, goalsMoneyRolloutAllowlist: ['cust-1'] },
+        overlaySample: completeOverlay,
+      },
+      r
+    );
+    expect(el).toBe(r.moneyEl);
+    expect(r.renderMoney).toHaveBeenCalledWith(completeOverlay);
+    expect(r.renderCoverage).not.toHaveBeenCalled();
+  });
+
+  it('!enabled (not-eligible) → routes to A4 renderCoverage, never money', () => {
+    const r = makeRenderers();
+    const el = renderGatedMoney(
+      { customerId: 'cust-1', settings: FEATURE_ON, overlaySample: completeOverlay },
+      r
+    );
+    expect(el).toBe(r.covEl);
+    expect(r.renderCoverage).toHaveBeenCalledTimes(1);
+    expect(r.renderCoverage.mock.calls[0][0]).toEqual({
+      state: 'unavailable',
+      reason: MONEY_REQUIRES_DEVICE_GRANULARITY,
+    });
+    expect(r.renderMoney).not.toHaveBeenCalled();
+  });
+
+  it('coverage-gap → routes to A4 renderCoverage', () => {
+    const r = makeRenderers();
+    const el = renderGatedMoney(
+      {
+        customerId: 'cust-1',
+        settings: { ...FEATURE_ON, goalsMoneyRolloutAllowlist: ['cust-1'] },
+        overlaySample: unavailableOverlay,
+      },
+      r
+    );
+    expect(el).toBe(r.covEl);
+    expect(r.renderMoney).not.toHaveBeenCalled();
+  });
+
+  it('feature off → renders nothing (null); neither renderer is called (byte-identical off)', () => {
+    const r = makeRenderers();
+    const el = renderGatedMoney(
+      { customerId: 'cust-1', settings: {}, overlaySample: completeOverlay },
+      r
+    );
+    expect(el).toBeNull();
+    expect(r.renderMoney).not.toHaveBeenCalled();
+    expect(r.renderCoverage).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/financial-goals/moneyTypes.test.ts
+++ b/tests/components/financial-goals/moneyTypes.test.ts
@@ -1,0 +1,140 @@
+/**
+ * RFC-0228 F0 — normalizeMoneyBlock / normalizeBudgetBlock.
+ *
+ * Proves the naming-bridge normalizer collapses BOTH ambiguous backend money
+ * shapes into one discriminated union, preserves decimal strings, and keeps the
+ * budget verdict withheld (null) while coverage is incomplete (GCDR RFC-0054
+ * DEC-6). Pure — no fetch, no DOM.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeMoneyBlock,
+  normalizeBudgetBlock,
+  MONEY_REQUIRES_DEVICE_GRANULARITY,
+  type RawMoneyBlock,
+  type RawBudgetBlock,
+} from '../../../src/components/financial-goals/moneyTypes';
+
+describe('normalizeMoneyBlock — collapses the two backend shapes', () => {
+  it('money:null (reason out-of-band) → unavailable with canonical reason', () => {
+    const overlay = normalizeMoneyBlock(null);
+    expect(overlay.state).toBe('unavailable');
+    if (overlay.state === 'unavailable') {
+      expect(overlay.reason).toBe(MONEY_REQUIRES_DEVICE_GRANULARITY);
+    }
+  });
+
+  it('money:undefined → unavailable with canonical reason', () => {
+    const overlay = normalizeMoneyBlock(undefined);
+    expect(overlay.state).toBe('unavailable');
+  });
+
+  it('money:{reason} → unavailable carrying that exact reason', () => {
+    const overlay = normalizeMoneyBlock({ reason: MONEY_REQUIRES_DEVICE_GRANULARITY });
+    expect(overlay.state).toBe('unavailable');
+    if (overlay.state === 'unavailable') {
+      expect(overlay.reason).toBe(MONEY_REQUIRES_DEVICE_GRANULARITY);
+    }
+  });
+
+  it('money:{reason:"SOME_OTHER"} → unavailable passes the reason through verbatim', () => {
+    const overlay = normalizeMoneyBlock({ reason: 'SOME_OTHER_REASON' });
+    expect(overlay).toEqual({ state: 'unavailable', reason: 'SOME_OTHER_REASON' });
+  });
+
+  it('populated money block → available with fields intact', () => {
+    const raw: RawMoneyBlock = {
+      currency: 'BRL',
+      coverageComplete: false,
+      pricedHours: 61320,
+      totalHours: 87600,
+      tariffCoverageGaps: { missing: ['2026-03-01T00'], truncated: false, missingHours: 24 },
+      uncategorizedDevices: [{ deviceId: 'd1', code: 'Q303A_L3', label: 'Loja 303A' }],
+    };
+    const overlay = normalizeMoneyBlock(raw);
+    expect(overlay.state).toBe('available');
+    if (overlay.state === 'available') {
+      expect(overlay.currency).toBe('BRL');
+      expect(overlay.coverageComplete).toBe(false);
+      expect(overlay.pricedHours).toBe(61320);
+      expect(overlay.totalHours).toBe(87600);
+      expect(overlay.tariffCoverageGaps).toEqual({
+        missing: ['2026-03-01T00'],
+        truncated: false,
+        missingHours: 24,
+      });
+      expect(overlay.uncategorizedDevices).toHaveLength(1);
+      expect(overlay.uncategorizedDevices[0].deviceId).toBe('d1');
+    }
+  });
+
+  it('available with coverageComplete:true and no gaps', () => {
+    const overlay = normalizeMoneyBlock({ currency: 'BRL', coverageComplete: true });
+    expect(overlay.state).toBe('available');
+    if (overlay.state === 'available') {
+      expect(overlay.coverageComplete).toBe(true);
+      // uncategorizedDevices defaults to [] (never omitted).
+      expect(overlay.uncategorizedDevices).toEqual([]);
+    }
+  });
+
+  it('folds the sibling budget block; verdict withheld (null) while incomplete (DEC-6)', () => {
+    const rawMoney: RawMoneyBlock = { currency: 'BRL', coverageComplete: false };
+    const rawBudget: RawBudgetBlock = {
+      projected: { amount: '128000.00', source: 'OVERLAY', coverageComplete: false },
+      target: { amount: '120000.00', source: 'NATIVE' },
+      variance: null,
+      withinBudget: null,
+    };
+    const overlay = normalizeMoneyBlock(rawMoney, rawBudget);
+    expect(overlay.state).toBe('available');
+    if (overlay.state === 'available') {
+      expect(overlay.budget).toBeDefined();
+      expect(overlay.budget!.projected.amount).toBe('128000.00'); // decimal string intact
+      expect(overlay.budget!.target).toEqual({ amount: '120000.00', source: 'NATIVE' });
+      // The whole point of DEC-6: both verdict fields stay null while incomplete.
+      expect(overlay.budget!.verdict.withinBudget).toBeNull();
+      expect(overlay.budget!.verdict.variance).toBeNull();
+    }
+  });
+
+  it('fully-covered budget carries a concrete verdict (boolean + string variance)', () => {
+    const overlay = normalizeMoneyBlock(
+      { currency: 'BRL', coverageComplete: true },
+      {
+        projected: { amount: '118500.00', source: 'OVERLAY', coverageComplete: true },
+        target: { amount: '120000.00', source: 'NATIVE' },
+        variance: '-1500.00',
+        withinBudget: true,
+      }
+    );
+    expect(overlay.state).toBe('available');
+    if (overlay.state === 'available') {
+      expect(overlay.budget!.verdict.withinBudget).toBe(true);
+      expect(overlay.budget!.verdict.variance).toBe('-1500.00');
+    }
+  });
+});
+
+describe('normalizeBudgetBlock', () => {
+  it('returns undefined when no budget block is present', () => {
+    expect(normalizeBudgetBlock(null)).toBeUndefined();
+    expect(normalizeBudgetBlock(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when projected.amount is missing', () => {
+    expect(normalizeBudgetBlock({ target: { amount: '1.00', source: 'NATIVE' } })).toBeUndefined();
+  });
+
+  it('wraps variance/withinBudget into a single verdict', () => {
+    const b = normalizeBudgetBlock({
+      projected: { amount: '100.00', source: 'OVERLAY', coverageComplete: true },
+      variance: '5.00',
+      withinBudget: false,
+    });
+    expect(b).toBeDefined();
+    expect(b!.verdict).toEqual({ withinBudget: false, variance: '5.00' });
+    expect(b!.target).toBeUndefined();
+  });
+});

--- a/tests/components/financial-goals/moneyVariance.test.ts
+++ b/tests/components/financial-goals/moneyVariance.test.ts
@@ -1,0 +1,401 @@
+/**
+ * RFC-0228 A7 — per-consumer realized-vs-goal variance in R$ (`moneyVariance.ts`).
+ *
+ * Proves:
+ *  - realized > goal → "Acima da meta (R$)" **unfavorable** chip with the exact
+ *    signed R$ string + %; realized < goal → "Abaixo da meta (R$)" **favorable** chip;
+ *  - null verdict / incomplete coverage → **withheld** chip ("Variação indisponível"),
+ *    NOT green/red, with **no number** (DEC-6);
+ *  - the signed subtraction reuses A2a's `subtractDecimals` and has **no float drift**
+ *    on a cents case that would drift under `Number()`;
+ *  - the GATE: a null config / no `perDeviceGoal` → disabled column (fragments all '')
+ *    → a host splicing them is byte-identical when money is off;
+ *  - the **naming-bridge** guard: A7 sources money ONLY from `monetaryProjection` /
+ *    `currencyBudget` — never from a `budget` (quantity) field;
+ *  - the §8 forbidden-wording contract across every state.
+ *
+ * Pure — jsdom, no fetch.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  computeMoneyVariance,
+  buildMoneyVarianceHTML,
+  renderMoneyVariance,
+  createMoneyVarianceColumn,
+  resolveGoalAmount,
+  overlayWithholdsVerdict,
+  MONEY_VARIANCE_HEADER,
+  VARIANCE_LABEL_ABOVE,
+  VARIANCE_LABEL_BELOW,
+  VARIANCE_LABEL_WITHHELD,
+  type MoneyVarianceColumnConfig,
+} from '../../../src/components/financial-goals/moneyVariance';
+import type { MoneyOverlay } from '../../../src/components/financial-goals/moneyTypes';
+import { MONEY_REQUIRES_DEVICE_GRANULARITY } from '../../../src/components/financial-goals/moneyTypes';
+
+/** Words that would turn this projection UX into billing wording (§8). */
+const FORBIDDEN = ['fatura', 'faturamento', 'valor final', 'total a pagar'];
+
+function assertNoForbidden(text: string): void {
+  const lower = text.toLowerCase();
+  for (const word of FORBIDDEN) expect(lower).not.toContain(word);
+  expect(text).not.toContain('NaN');
+}
+
+const complete: MoneyOverlay = {
+  state: 'available',
+  currency: 'BRL',
+  coverageComplete: true,
+  pricedHours: 87600,
+  totalHours: 87600,
+  uncategorizedDevices: [],
+};
+
+const incomplete: MoneyOverlay = {
+  state: 'available',
+  currency: 'BRL',
+  coverageComplete: false,
+  pricedHours: 61320,
+  totalHours: 87600,
+  uncategorizedDevices: [{ deviceId: 'dev-9', code: 'Q9', label: 'Loja 9' }],
+};
+
+const unavailable: MoneyOverlay = {
+  state: 'unavailable',
+  reason: MONEY_REQUIRES_DEVICE_GRANULARITY,
+};
+
+// ── computeMoneyVariance — verdict + signed variance + pct ───────────────────────
+
+describe('computeMoneyVariance — verdict, signed R$, %', () => {
+  it('realized > goal → "above" (unfavorable) with exact signed R$ + %', () => {
+    // 1200.00 − 1000.00 = +200.00 ; pct = +20%.
+    const r = computeMoneyVariance({
+      overlay: complete,
+      monetaryProjection: '1200.00',
+      currencyBudget: '1000.00',
+    });
+    expect(r.verdict).toBe('above');
+    expect(r.variance).toBe('200.00');
+    expect(r.pct).toBeCloseTo(20, 6);
+  });
+
+  it('realized < goal → "below" (favorable) with exact signed R$ + %', () => {
+    // 800.00 − 1000.00 = −200.00 ; pct = −20%.
+    const r = computeMoneyVariance({
+      overlay: complete,
+      monetaryProjection: '800.00',
+      currencyBudget: '1000.00',
+    });
+    expect(r.verdict).toBe('below');
+    expect(r.variance).toBe('-200.00');
+    expect(r.pct).toBeCloseTo(-20, 6);
+  });
+
+  it('realized == goal → "onTarget" with variance 0,00 (a real number, not withheld)', () => {
+    const r = computeMoneyVariance({
+      overlay: complete,
+      monetaryProjection: '1000.00',
+      currencyBudget: '1000.00',
+    });
+    expect(r.verdict).toBe('onTarget');
+    expect(r.variance).toBe('0.00');
+    expect(r.pct).toBeCloseTo(0, 6);
+  });
+
+  it('goal is zero → variance present but % is null (no divide-by-zero)', () => {
+    const r = computeMoneyVariance({
+      overlay: complete,
+      monetaryProjection: '50.00',
+      currencyBudget: '0.00',
+    });
+    expect(r.verdict).toBe('above');
+    expect(r.variance).toBe('50.00');
+    expect(r.pct).toBeNull();
+  });
+
+  it('resolveGoalAmount defaults to the overlay native budget target', () => {
+    const overlayWithBudget: MoneyOverlay = {
+      ...complete,
+      budget: {
+        projected: { amount: '900.00', source: 'OVERLAY', coverageComplete: true },
+        target: { amount: '1000.00', source: 'NATIVE' },
+        verdict: { withinBudget: true, variance: '-100.00' },
+      },
+    };
+    expect(resolveGoalAmount({ overlay: overlayWithBudget })).toBe('1000.00');
+    const r = computeMoneyVariance({
+      overlay: overlayWithBudget,
+      monetaryProjection: '1200.00',
+      // no explicit currencyBudget → falls back to target 1000.00
+    });
+    expect(r.verdict).toBe('above');
+    expect(r.variance).toBe('200.00');
+  });
+});
+
+// ── DEC-6 withholding — indeterminate / incomplete → withheld, no number ─────────
+
+describe('computeMoneyVariance — DEC-6 withholding', () => {
+  it('incomplete coverage → withheld (no variance, no pct)', () => {
+    const r = computeMoneyVariance({
+      overlay: incomplete,
+      monetaryProjection: '1200.00',
+      currencyBudget: '1000.00',
+    });
+    expect(r.verdict).toBe('withheld');
+    expect(r.variance).toBeNull();
+    expect(r.pct).toBeNull();
+  });
+
+  it('unavailable coverage → withheld', () => {
+    const r = computeMoneyVariance({
+      overlay: unavailable,
+      monetaryProjection: '1200.00',
+      currencyBudget: '1000.00',
+    });
+    expect(r.verdict).toBe('withheld');
+  });
+
+  it('explicit withheld override → withheld even with valid amounts', () => {
+    const r = computeMoneyVariance({
+      monetaryProjection: '1200.00',
+      currencyBudget: '1000.00',
+      withheld: true,
+    });
+    expect(r.verdict).toBe('withheld');
+    expect(r.variance).toBeNull();
+  });
+
+  it('a null native budget verdict withholds even under a complete overlay', () => {
+    const nullVerdict: MoneyOverlay = {
+      ...complete,
+      budget: {
+        projected: { amount: '900.00', source: 'OVERLAY', coverageComplete: false },
+        target: { amount: '1000.00', source: 'NATIVE' },
+        verdict: { withinBudget: null, variance: null },
+      },
+    };
+    expect(overlayWithholdsVerdict(nullVerdict)).toBe(true);
+    const r = computeMoneyVariance({
+      overlay: nullVerdict,
+      monetaryProjection: '1200.00',
+      currencyBudget: '1000.00',
+    });
+    expect(r.verdict).toBe('withheld');
+  });
+
+  it('missing amounts → withheld', () => {
+    expect(computeMoneyVariance({ overlay: complete, currencyBudget: '1000.00' }).verdict).toBe(
+      'withheld'
+    );
+    expect(computeMoneyVariance({ overlay: complete, monetaryProjection: '1200.00' }).verdict).toBe(
+      'withheld'
+    );
+  });
+
+  it('an absent overlay does NOT gate — confident amounts still resolve', () => {
+    expect(overlayWithholdsVerdict(undefined)).toBe(false);
+    const r = computeMoneyVariance({ monetaryProjection: '1200.00', currencyBudget: '1000.00' });
+    expect(r.verdict).toBe('above');
+  });
+});
+
+// ── no float drift — the signed subtraction reuses A2a's integer-cent math ────────
+
+describe('computeMoneyVariance — no float drift (A2a subtractDecimals reuse)', () => {
+  it('a cents case that drifts under Number() stays exact', () => {
+    // 0.10 − (−0.20) = 0.30. Naive Number(0.10) + Number(0.20) = 0.30000000000000004.
+    const r = computeMoneyVariance({ monetaryProjection: '0.10', currencyBudget: '-0.20' });
+    expect(r.variance).toBe('0.30');
+    // Prove the float path WOULD have drifted (guards the test's own premise).
+    const floatDiff = Number('0.10') - Number('-0.20');
+    expect(floatDiff).not.toBe(0.3); // 0.30000000000000004
+  });
+
+  it('a one-cent negative flip is exact and drives the "below" verdict', () => {
+    // 1_000_000.00 − 1_000_000.02 = −0.02 (a single-cent shortfall). The sign is
+    // resolved from the variance string via A6's BigInt cents — exact, no rounding.
+    const r = computeMoneyVariance({
+      monetaryProjection: '1000000.00',
+      currencyBudget: '1000000.02',
+    });
+    expect(r.variance).toBe('-0.02');
+    expect(r.verdict).toBe('below');
+  });
+});
+
+// ── naming-bridge guard — money never sourced from a `budget` (quantity) field ────
+
+describe('computeMoneyVariance — naming-bridge guard', () => {
+  it('ignores a `budget` (quantity) field entirely — no money without money names', () => {
+    // A caller that mistakenly hands a quantity `budget` (kWh) must NOT be priced as R$.
+    const r = computeMoneyVariance({
+      overlay: complete,
+      // @ts-expect-error — `budget` is not a MoneyVarianceInput field (quantity, not money).
+      budget: [200, 200, 200],
+    });
+    expect(r.verdict).toBe('withheld'); // no monetaryProjection/currencyBudget → nothing to price
+    expect(r.variance).toBeNull();
+  });
+});
+
+// ── buildMoneyVarianceHTML — chip wording + colors ───────────────────────────────
+
+describe('buildMoneyVarianceHTML — chip', () => {
+  it('above → red unfavorable chip with "Acima da meta (R$)" + signed R$', () => {
+    const html = buildMoneyVarianceHTML({
+      overlay: complete,
+      monetaryProjection: '1200.00',
+      currencyBudget: '1000.00',
+    });
+    expect(html).toContain('data-money-variance="above"');
+    expect(html).toContain(VARIANCE_LABEL_ABOVE);
+    expect(html).toContain('+R$ 200,00');
+    expect(html).toContain('#b91c1c'); // over/red text — an unfavorable judgment
+    assertNoForbidden(html);
+  });
+
+  it('below → green favorable chip with "Abaixo da meta (R$)"', () => {
+    const html = buildMoneyVarianceHTML({
+      overlay: complete,
+      monetaryProjection: '800.00',
+      currencyBudget: '1000.00',
+    });
+    expect(html).toContain('data-money-variance="below"');
+    expect(html).toContain(VARIANCE_LABEL_BELOW);
+    expect(html).toContain('−R$ 200,00'); // true-minus signed delta
+    expect(html).toContain('#15803d'); // under/green text — a favorable judgment
+    assertNoForbidden(html);
+  });
+
+  it('withheld → grey "Variação indisponível", NO number, NO green/red judgment', () => {
+    const html = buildMoneyVarianceHTML({
+      overlay: incomplete,
+      monetaryProjection: '1200.00',
+      currencyBudget: '1000.00',
+    });
+    expect(html).toContain('data-money-variance="withheld"');
+    expect(html).toContain(VARIANCE_LABEL_WITHHELD);
+    // No fabricated R$ number, no percent, no favorable/unfavorable color.
+    expect(html).not.toContain('R$');
+    expect(html).not.toContain('%');
+    expect(html).not.toContain('#b91c1c');
+    expect(html).not.toContain('#15803d');
+    assertNoForbidden(html);
+  });
+
+  it('emits no billing word / NaN across above, below, withheld', () => {
+    const inputs = [
+      { overlay: complete, monetaryProjection: '1200.00', currencyBudget: '1000.00' },
+      { overlay: complete, monetaryProjection: '800.00', currencyBudget: '1000.00' },
+      { overlay: unavailable, monetaryProjection: '1200.00', currencyBudget: '1000.00' },
+    ];
+    for (const input of inputs) assertNoForbidden(buildMoneyVarianceHTML(input));
+  });
+});
+
+// ── renderMoneyVariance — DOM readout + gate ─────────────────────────────────────
+
+describe('renderMoneyVariance — DOM element / gate', () => {
+  it('returns null when there is nothing to show (money off)', () => {
+    expect(renderMoneyVariance({ document })).toBeNull();
+    expect(renderMoneyVariance({} as any)).toBeNull();
+  });
+
+  it('renders the chip element with a label when amounts are present', () => {
+    const el = renderMoneyVariance({
+      overlay: complete,
+      monetaryProjection: '1200.00',
+      currencyBudget: '1000.00',
+      label: 'Variação vs meta (R$)',
+      document,
+    });
+    expect(el).not.toBeNull();
+    expect(el!.getAttribute('data-money-variance-row')).toBe('1');
+    expect(el!.querySelector('[data-money-variance="above"]')).not.toBeNull();
+    expect(el!.textContent).toContain('Variação vs meta (R$)');
+  });
+
+  it('renders the withheld chip when coverage is incomplete', () => {
+    const el = renderMoneyVariance({
+      overlay: incomplete,
+      monetaryProjection: '1200.00',
+      currencyBudget: '1000.00',
+      document,
+    });
+    expect(el!.querySelector('[data-money-variance="withheld"]')).not.toBeNull();
+  });
+});
+
+// ── createMoneyVarianceColumn — report column + gate ─────────────────────────────
+
+function cfg(over: Partial<MoneyVarianceColumnConfig> = {}): MoneyVarianceColumnConfig {
+  return {
+    overlay: complete,
+    perDeviceRealized: { a: '1200.00', b: '800.00', c: '1000.00' },
+    perDeviceGoal: { a: '1000.00', b: '1000.00', c: '1000.00' },
+    ...over,
+  };
+}
+
+describe('createMoneyVarianceColumn — per-consumer variance cell', () => {
+  it('renders an above chip for a consumer over goal and below for one under', () => {
+    const col = createMoneyVarianceColumn(cfg());
+    expect(col.enabled).toBe(true);
+    expect(col.bodyCellHTML('a')).toContain('data-money-variance="above"');
+    expect(col.bodyCellHTML('a')).toContain('+R$ 200,00');
+    expect(col.bodyCellHTML('b')).toContain('data-money-variance="below"');
+    expect(col.bodyCellHTML('a').startsWith('<td')).toBe(true);
+  });
+
+  it('header uses the allowed §8 label', () => {
+    const col = createMoneyVarianceColumn(cfg());
+    expect(col.headerCellHTML()).toContain(MONEY_VARIANCE_HEADER);
+    expect(MONEY_VARIANCE_HEADER).toBe('Variação vs meta (R$)');
+    assertNoForbidden(col.headerCellHTML());
+  });
+
+  it('withholds every consumer under an incomplete overlay (DEC-6)', () => {
+    const col = createMoneyVarianceColumn(cfg({ overlay: incomplete }));
+    expect(col.bodyCellHTML('a')).toContain('data-money-variance="withheld"');
+    // The chip inner (no <td> data-label noise) carries no fabricated R$ amount.
+    expect(col.cellValueHTML('a')).not.toContain('R$');
+  });
+
+  it('a consumer with no goal renders withheld (never a fabricated number)', () => {
+    const col = createMoneyVarianceColumn(cfg({ perDeviceGoal: { a: '1000.00' } }));
+    expect(col.bodyCellHTML('b')).toContain('data-money-variance="withheld"');
+    expect(col.cellValueHTML('b')).not.toContain('R$');
+  });
+});
+
+describe('createMoneyVarianceColumn — GATE OFF is byte-identical', () => {
+  it('null config OR missing perDeviceGoal → disabled column (fragments all "")', () => {
+    const disabled = [
+      createMoneyVarianceColumn(null),
+      createMoneyVarianceColumn(undefined),
+      // config present but no goal map → no variance possible → disabled.
+      createMoneyVarianceColumn({
+        overlay: complete,
+        perDeviceRealized: { a: '1200.00' },
+      } as unknown as MoneyVarianceColumnConfig),
+    ];
+    for (const col of disabled) {
+      expect(col.enabled).toBe(false);
+      expect(col.headerCellHTML()).toBe('');
+      expect(col.bodyCellHTML('a')).toBe('');
+      expect(col.cellValueHTML('a')).toBe('');
+    }
+  });
+
+  it('splicing the disabled fragments into a host row changes nothing', () => {
+    const col = createMoneyVarianceColumn(null);
+    const baseline = `<tr><td>ID</td><td>Name</td><td>123 kWh</td><td>10%</td></tr>`;
+    const spliced = `<tr><td>ID</td><td>Name</td><td>123 kWh</td>${col.bodyCellHTML(
+      'a'
+    )}<td>10%</td></tr>`;
+    expect(spliced).toBe(baseline); // byte-identical when the money gate is off
+  });
+});

--- a/tests/components/financial-goals/reportMoneyColumn.test.ts
+++ b/tests/components/financial-goals/reportMoneyColumn.test.ts
@@ -1,0 +1,261 @@
+/**
+ * RFC-0228 A6 — R$ money column for aggregate report rows/totals (`reportMoneyColumn.ts`).
+ *
+ * Proves:
+ *  - the R$ cell renders beside kWh, formatted per DEC-8 (exact string, no re-derive);
+ *  - the footer total is a **string/cent (BigInt)** sum with **no float drift** — and
+ *    prefers the backend-authoritative parent over the row-sum (DEC-8 top-down);
+ *  - incomplete/unavailable coverage → A4 coverage indicator, **no number, no R$ 0**;
+ *  - the gate: a `null` config yields a disabled column whose fragments are all `''`
+ *    (so a host splicing them stays byte-identical when money is off);
+ *  - the §8 wording contract (no billing words, no NaN).
+ *
+ * Also pins the DEC-8 `round_half_up` golden vectors (V1 sum, V2 tie) at the
+ * cent-parse boundary. Pure — jsdom, no fetch.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createReportMoneyColumn,
+  isMoneyColumnConfident,
+  sumMoneyDecimals,
+  decimalStringToCents,
+  centsToDecimalString,
+  REPORT_MONEY_HEADER,
+  type ReportMoneyColumnConfig,
+} from '../../../src/components/financial-goals/reportMoneyColumn';
+import type { MoneyOverlay } from '../../../src/components/financial-goals/moneyTypes';
+import { MONEY_REQUIRES_DEVICE_GRANULARITY } from '../../../src/components/financial-goals/moneyTypes';
+
+/** Words that would turn this projection UX into billing wording (§8). */
+const FORBIDDEN = ['fatura', 'faturamento', 'valor final', 'total a pagar'];
+
+function assertNoForbidden(text: string): void {
+  const lower = text.toLowerCase();
+  for (const word of FORBIDDEN) {
+    expect(lower).not.toContain(word);
+  }
+  expect(text).not.toContain('NaN');
+}
+
+const complete: MoneyOverlay = {
+  state: 'available',
+  currency: 'BRL',
+  coverageComplete: true,
+  pricedHours: 87600,
+  totalHours: 87600,
+  uncategorizedDevices: [],
+};
+
+const incomplete: MoneyOverlay = {
+  state: 'available',
+  currency: 'BRL',
+  coverageComplete: false,
+  pricedHours: 61320,
+  totalHours: 87600,
+  uncategorizedDevices: [{ deviceId: 'dev-9', code: 'Q9', label: 'Loja 9' }],
+};
+
+const unavailable: MoneyOverlay = {
+  state: 'unavailable',
+  reason: MONEY_REQUIRES_DEVICE_GRANULARITY,
+};
+
+function cfg(over: Partial<ReportMoneyColumnConfig> = {}): ReportMoneyColumnConfig {
+  return {
+    overlay: complete,
+    perDevice: { a: '1234.56', b: '10.00', c: '0.44' },
+    ...over,
+  };
+}
+
+// ── cent / string math primitives (DEC-8 half-up + BigInt no-drift) ─────────────
+
+describe('decimalStringToCents / centsToDecimalString (DEC-8 half-up, BigInt)', () => {
+  it('parses a plain 2dp decimal string to integer cents', () => {
+    expect(decimalStringToCents('1234.56')).toBe(123456n);
+    expect(decimalStringToCents('10')).toBe(1000n);
+    expect(decimalStringToCents('0.44')).toBe(44n);
+    expect(decimalStringToCents('-50.00')).toBe(-5000n);
+  });
+
+  it('DEC-8 V2 tie: round_half_up at the 3rd fraction digit, half away from zero', () => {
+    // "raw = 2.005000 → 2.01"  (naive float64 toFixed would give 2.00 — must NOT)
+    expect(centsToDecimalString(decimalStringToCents('2.005')!)).toBe('2.01');
+    // "raw = 644.004999 → 644.00"
+    expect(centsToDecimalString(decimalStringToCents('644.004999')!)).toBe('644.00');
+    // "raw = 644.005000 → 644.01"
+    expect(centsToDecimalString(decimalStringToCents('644.005')!)).toBe('644.01');
+  });
+
+  it('carries 0.99x half-up into the integer part without float', () => {
+    expect(centsToDecimalString(decimalStringToCents('2.999')!)).toBe('3.00');
+  });
+
+  it('returns null for non-decimal input (caller renders —)', () => {
+    expect(decimalStringToCents('abc')).toBeNull();
+    expect(decimalStringToCents('')).toBeNull();
+    expect(decimalStringToCents(null)).toBeNull();
+    expect(decimalStringToCents(undefined)).toBeNull();
+  });
+});
+
+describe('sumMoneyDecimals (integer-cent BigInt sum, no float drift)', () => {
+  it('DEC-8 V1-style band sum is exact', () => {
+    // 220.00 + 120.00 + 240.00 + 64.00 = 644.00
+    expect(sumMoneyDecimals(['220.00', '120.00', '240.00', '64.00'])).toBe('644.00');
+  });
+
+  it('does NOT drift on a case that float addition would corrupt', () => {
+    // Naive: 0.1 + 0.2 = 0.30000000000000004 ; ten 0.10 accumulate to 0.9999999999999999.
+    expect(sumMoneyDecimals(['0.10', '0.20'])).toBe('0.30');
+    const tenDimes = Array.from({ length: 10 }, () => '0.10');
+    expect(sumMoneyDecimals(tenDimes)).toBe('1.00');
+    // Prove the float path WOULD have drifted (guards the test's own premise).
+    const floatSum = tenDimes.reduce((s, v) => s + Number(v), 0);
+    expect(floatSum).not.toBe(1); // 0.9999999999999999
+  });
+
+  it('stays exact beyond Number.MAX_SAFE_INTEGER cents (BigInt)', () => {
+    // 99_999_999_999_999.99 + 0.02 = 100_000_000_000_000.01 (cents exceed 2^53)
+    expect(sumMoneyDecimals(['99999999999999.99', '0.02'])).toBe('100000000000000.01');
+  });
+
+  it('returns null when any value is missing/invalid — an honest "cannot total"', () => {
+    expect(sumMoneyDecimals(['1.00', null, '2.00'])).toBeNull();
+    expect(sumMoneyDecimals([])).toBeNull();
+  });
+});
+
+// ── the column: cells, header, total, coverage, gate ────────────────────────────
+
+describe('createReportMoneyColumn — R$ cell beside kWh (available, DEC-8 display)', () => {
+  it('renders the R$ cell with the backend string formatted per DEC-8 (exact)', () => {
+    const col = createReportMoneyColumn(cfg());
+    expect(col.enabled).toBe(true);
+    const cell = col.bodyCellHTML('a');
+    // "1234.56" → "R$ 1.234,56" (string-based BRL, never Number()-round-tripped).
+    expect(cell).toContain('R$ 1.234,56');
+    expect(cell).toContain('data-money-col="1"');
+    expect(cell.startsWith('<td')).toBe(true);
+  });
+
+  it('renders — (not R$ 0) for a device with no money value', () => {
+    const col = createReportMoneyColumn(cfg());
+    const cell = col.bodyCellHTML('missing-id');
+    expect(cell).toContain('—');
+    expect(cell).not.toContain('R$ 0');
+  });
+
+  it('header uses the allowed §8 label', () => {
+    const col = createReportMoneyColumn(cfg());
+    expect(col.headerCellHTML()).toContain(REPORT_MONEY_HEADER);
+    expect(REPORT_MONEY_HEADER).toBe('Custo projetado (R$)');
+    assertNoForbidden(col.headerCellHTML());
+  });
+});
+
+describe('createReportMoneyColumn — footer total (honest, DEC-8)', () => {
+  it('sums the visible rows via cent math when no backend total is provided', () => {
+    const col = createReportMoneyColumn(cfg());
+    const rows = ['1234.56', '10.00', '0.44']; // = 1245.00
+    const total = col.resolveTotal(rows);
+    expect(total).not.toBeNull();
+    expect(total!.kind).toBe('amount');
+    if (total!.kind === 'amount') {
+      expect(total!.amount).toBe('1245.00');
+      expect(total!.formatted).toBe('R$ 1.245,00');
+      expect(total!.source).toBe('row-sum');
+    }
+    expect(col.totalHTML(rows)).toContain('R$ 1.245,00');
+  });
+
+  it('PREFERS the backend-authoritative parent over the row-sum (DEC-8 top-down)', () => {
+    // Rows of already-rounded children sum to 644.00, but the backend parent =
+    // round(Σ full-precision raws) = 644.01. DEC-8 says show the parent, not the sum.
+    const col = createReportMoneyColumn(cfg({ total: '644.01' }));
+    const total = col.resolveTotal(['322.00', '322.00']); // = 644.00
+    expect(total!.kind).toBe('amount');
+    if (total!.kind === 'amount') {
+      expect(total!.amount).toBe('644.01');
+      expect(total!.source).toBe('backend');
+    }
+    expect(col.totalHTML(['322.00', '322.00'])).toContain('R$ 644,01');
+  });
+
+  it('renders a "vs Meta" note when the overlay carries a variance', () => {
+    const col = createReportMoneyColumn(cfg({ total: '1000.00', variance: '-50.00' }));
+    const html = col.totalHTML();
+    expect(html).toContain('vs Meta');
+    expect(html).toContain('−R$ 50,00'); // true-minus signed delta
+    assertNoForbidden(html);
+  });
+
+  it('falls back to coverage when rows are missing under a complete overlay', () => {
+    const col = createReportMoneyColumn(cfg());
+    const total = col.resolveTotal(['1234.56', null]); // cannot honestly total
+    expect(total!.kind).toBe('coverage');
+    const html = col.totalHTML(['1234.56', null]);
+    expect(html).not.toContain('data-money-total="amount"');
+    expect(html).not.toContain('R$ 0');
+  });
+});
+
+describe('createReportMoneyColumn — honest coverage (incomplete / unavailable)', () => {
+  it('incomplete coverage → A4 indicator, NO numeric total, NO R$ 0', () => {
+    const col = createReportMoneyColumn(cfg({ overlay: incomplete, total: '900.00' }));
+    expect(isMoneyColumnConfident(incomplete)).toBe(false);
+    const total = col.resolveTotal(['500.00', '400.00']);
+    expect(total!.kind).toBe('coverage'); // even with a backend total present
+    const html = col.totalHTML(['500.00', '400.00']);
+    expect(html).toContain('Cobertura incompleta');
+    expect(html).not.toContain('data-money-total="amount"');
+    expect(html).not.toContain('R$ 0');
+    assertNoForbidden(html);
+  });
+
+  it('unavailable coverage → A4 indicator, no number', () => {
+    const col = createReportMoneyColumn(cfg({ overlay: unavailable }));
+    const total = col.resolveTotal(['1.00']);
+    expect(total!.kind).toBe('coverage');
+    const html = col.totalHTML();
+    expect(html).toContain('indisponível');
+    expect(html).not.toContain('R$ 0');
+    assertNoForbidden(html);
+  });
+});
+
+describe('createReportMoneyColumn — GATE OFF is byte-identical', () => {
+  it('a null/undefined config yields a disabled column whose fragments are all ""', () => {
+    for (const c of [null, undefined]) {
+      const col = createReportMoneyColumn(c);
+      expect(col.enabled).toBe(false);
+      expect(col.headerCellHTML()).toBe('');
+      expect(col.bodyCellHTML('a')).toBe('');
+      expect(col.cellValueHTML('a')).toBe('');
+      expect(col.totalHTML(['1.00'])).toBe('');
+      expect(col.resolveTotal(['1.00'])).toBeNull();
+    }
+  });
+
+  it('splicing the disabled fragments into a host template changes nothing', () => {
+    const col = createReportMoneyColumn(null);
+    const baseline =
+      `<tr><td>ID</td><td>Name</td><td>123 kWh</td><td>10%</td></tr>`;
+    const withColumn =
+      `<tr><td>ID</td><td>Name</td><td>123 kWh</td>${col.bodyCellHTML('a')}<td>10%</td></tr>`;
+    expect(withColumn).toBe(baseline); // byte-identical when the money gate is off
+  });
+});
+
+describe('createReportMoneyColumn — wording contract across every state', () => {
+  it('emits no billing-grade word and no NaN in any state', () => {
+    const states: MoneyOverlay[] = [complete, incomplete, unavailable];
+    for (const overlay of states) {
+      const col = createReportMoneyColumn(cfg({ overlay, total: '1234.56', variance: '12.34' }));
+      assertNoForbidden(col.headerCellHTML());
+      assertNoForbidden(col.bodyCellHTML('a'));
+      assertNoForbidden(col.totalHTML(['1234.56']));
+    }
+  });
+});

--- a/tests/components/pricing-panel/pricingPanelTariffApi.test.ts
+++ b/tests/components/pricing-panel/pricingPanelTariffApi.test.ts
@@ -1,0 +1,115 @@
+/**
+ * RFC-0228 A1 — openPricingPanel persistence gate.
+ *
+ * Verifies the `tariffApi` gate: WITH it, the panel loads/saves through the
+ * hourly-tariff API and never touches localStorage as a source of truth;
+ * WITHOUT it, the panel keeps its byte-identical localStorage prototype.
+ *
+ * Real timers + a mocked `fetch` (via the `tariffApi.fetchImpl` test seam).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { openPricingPanel } from '../../../src/components/pricing-panel';
+
+const CUSTOMERS = [{ gcdrCustomerId: 'gc-1', tbId: 'tb-1', title: 'Shopping A' }];
+
+function getModal(): HTMLElement | null {
+  return document.getElementById('myio-pricing-panel');
+}
+function q<T extends HTMLElement>(sel: string): T {
+  return getModal()!.querySelector(sel) as T;
+}
+function flush(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+function addMonth(month: string, price: string): void {
+  q<HTMLSelectElement>('[data-testid="pricing-type"]').value = 'month';
+  q<HTMLSelectElement>('[data-testid="pricing-type"]').dispatchEvent(new Event('change'));
+  q<HTMLInputElement>('[data-testid="pricing-month"]').value = month;
+  q<HTMLInputElement>('[data-testid="pricing-price"]').value = price;
+  q<HTMLButtonElement>('[data-testid="pricing-add"]').click();
+}
+
+/** Empty tariff on GET; version bump on any write. */
+function makeFetchMock() {
+  return vi.fn(async (_url: string, init?: { method?: string }) => {
+    const method = init?.method || 'GET';
+    if (method === 'GET') {
+      return new Response(JSON.stringify({ version: 0, tree: {} }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json', ETag: '"0"' },
+      });
+    }
+    return new Response(JSON.stringify({ version: 1 }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json', ETag: '"1"' },
+    });
+  });
+}
+
+beforeEach(() => {
+  try {
+    window.localStorage.clear();
+  } catch {
+    /* ignore */
+  }
+});
+
+afterEach(() => {
+  getModal()?.remove();
+  document.getElementById('myio-pricing-panel-styles')?.remove();
+  delete (window as { MyIOUtils?: unknown }).MyIOUtils;
+  vi.restoreAllMocks();
+});
+
+describe('openPricingPanel — tariffApi gate ON', () => {
+  it('loads via the API on open (4 combos) and never persists pricing to localStorage', async () => {
+    const fetchMock = makeFetchMock();
+    const setItem = vi.spyOn(Storage.prototype, 'setItem');
+
+    openPricingPanel({
+      customers: CUSTOMERS,
+      currentUserEmail: 'op@myio.com.br',
+      tariffApi: { baseUrl: 'https://gcdr.example', apiKey: 'gcdr_cust_X', year: 2026, fetchImpl: fetchMock as unknown as typeof fetch },
+    });
+    await flush();
+
+    // Initial hydration read all four (domain × category) tariffs.
+    const gets = fetchMock.mock.calls.filter((c) => (c[1]?.method || 'GET') === 'GET');
+    expect(gets.length).toBe(4);
+
+    // Add a month → routes to a PATCH, not localStorage.
+    addMonth('2026-03', '0,90');
+    await flush();
+
+    const patches = fetchMock.mock.calls.filter((c) => c[1]?.method === 'PATCH');
+    expect(patches.length).toBe(1);
+    const body = JSON.parse((patches[0][1] as { body: string }).body);
+    expect(body.buckets.length).toBe(31 * 24);
+    expect(body.buckets[0].price).toBe('0.90');
+
+    // No pricing/audit keys were written to localStorage.
+    const pricingWrites = setItem.mock.calls.filter((c) => String(c[0]).includes('pricing'));
+    expect(pricingWrites.length).toBe(0);
+  });
+});
+
+describe('openPricingPanel — tariffApi gate OFF (localStorage prototype unchanged)', () => {
+  it('persists to localStorage and does not call fetch', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const setItem = vi.spyOn(Storage.prototype, 'setItem');
+
+    const handle = openPricingPanel({ customers: CUSTOMERS, currentUserEmail: 'op@myio.com.br' });
+    const d = q<HTMLSelectElement>('[data-testid="pricing-domain"]');
+    d.value = 'energy';
+    d.dispatchEvent(new Event('change'));
+    addMonth('2026-05', '1,20');
+    await flush();
+
+    expect(handle.getEntries()).toHaveLength(1);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const pricingWrites = setItem.mock.calls.filter((c) => String(c[0]).includes('pricing'));
+    expect(pricingWrites.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/components/pricing-panel/tariffApiAdapter.test.ts
+++ b/tests/components/pricing-panel/tariffApiAdapter.test.ts
@@ -1,0 +1,458 @@
+/**
+ * RFC-0228 A1 — TariffApiAdapter unit tests (pure mapping + a mocked client).
+ *
+ * Covers: category/domain maps both directions, price decimal-string
+ * preservation + legacy `pricePerKwh` alias, write expansion (day→24h, band→hours),
+ * read collapse (equal contiguous hours→band, unequal split, annual→year, empty),
+ * leap-year handling, round-trip precision, and version-conflict surfacing.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type {
+  TariffApiClient,
+  TariffTreeResponse,
+} from '../../../src/components/pricing-panel/tariffApiClient';
+import { TariffApiError } from '../../../src/components/pricing-panel/tariffApiClient';
+import {
+  PANEL_TO_WIRE_DOMAIN,
+  PANEL_TO_WIRE_CATEGORY,
+  panelDomainToWire,
+  wireDomainToPanel,
+  panelCategoryToWire,
+  wireCategoryToPanel,
+  normalizePriceString,
+  isLeapYear,
+  daysInMonthYear,
+  assertValidCivilDate,
+  eachDate,
+  normalizeBand,
+  panelEntryToBand,
+  bandToPanelEntry,
+  expandDayToHourBuckets,
+  expandBandHours,
+  expandBandToHourBucketsByYear,
+  collapseHoursToBands,
+  collapseTreeToBands,
+  TariffApiAdapter,
+  type TariffBand,
+} from '../../../src/components/pricing-panel/tariffApiAdapter';
+import type { PricingEntry } from '../../../src/components/pricing-panel/types';
+
+// ---------------------------------------------------------------------------
+// Dimension maps (both directions)
+// ---------------------------------------------------------------------------
+describe('category & domain maps', () => {
+  it('maps domains both directions (all values)', () => {
+    expect(panelDomainToWire('energy')).toBe('ENERGY');
+    expect(panelDomainToWire('water')).toBe('WATER');
+    expect(wireDomainToPanel('ENERGY')).toBe('energy');
+    expect(wireDomainToPanel('WATER')).toBe('water');
+    expect(PANEL_TO_WIRE_DOMAIN.energy).toBe('ENERGY');
+  });
+
+  it('maps categories both directions (lojas=SPECIFIC, area_comum=COMMON_AREA)', () => {
+    expect(panelCategoryToWire('lojas')).toBe('SPECIFIC');
+    expect(panelCategoryToWire('area_comum')).toBe('COMMON_AREA');
+    expect(wireCategoryToPanel('SPECIFIC')).toBe('lojas');
+    expect(wireCategoryToPanel('COMMON_AREA')).toBe('area_comum');
+    expect(PANEL_TO_WIRE_CATEGORY.area_comum).toBe('COMMON_AREA');
+  });
+
+  it('round-trips every value', () => {
+    (['energy', 'water'] as const).forEach((d) => expect(wireDomainToPanel(panelDomainToWire(d))).toBe(d));
+    (['lojas', 'area_comum'] as const).forEach((c) =>
+      expect(wireCategoryToPanel(panelCategoryToWire(c))).toBe(c)
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Price normalization + legacy alias
+// ---------------------------------------------------------------------------
+describe('normalizePriceString', () => {
+  it('preserves a decimal string verbatim (no Number() drift)', () => {
+    expect(normalizePriceString({ price: '0.892000' })).toBe('0.892000');
+    expect(normalizePriceString({ price: '2.000000' })).toBe('2.000000');
+    expect(normalizePriceString({ price: ' 1.234560 ' })).toBe('1.234560');
+  });
+
+  it('accepts the legacy numeric pricePerKwh alias and normalizes to a string', () => {
+    expect(normalizePriceString({ pricePerKwh: 0.75 })).toBe('0.75');
+    expect(normalizePriceString({ pricePerKwh: 2 })).toBe('2.00');
+  });
+
+  it('rejects non-positive prices', () => {
+    expect(() => normalizePriceString({ price: '0' })).toThrow();
+    expect(() => normalizePriceString({ pricePerKwh: -1 })).toThrow();
+    expect(() => normalizePriceString({})).toThrow();
+  });
+
+  it('normalizeBand never echoes pricePerKwh; canonical price only', () => {
+    const band = normalizeBand({
+      domain: 'energy',
+      category: 'lojas',
+      periodType: 'day',
+      date: '2026-07-01',
+      pricePerKwh: 0.9,
+    });
+    expect(band.price).toBe('0.90');
+    expect('pricePerKwh' in band).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Leap year / calendar
+// ---------------------------------------------------------------------------
+describe('leap year & calendar', () => {
+  it('classifies leap years', () => {
+    expect(isLeapYear(2024)).toBe(true);
+    expect(isLeapYear(2023)).toBe(false);
+    expect(isLeapYear(2000)).toBe(true);
+    expect(isLeapYear(1900)).toBe(false);
+  });
+
+  it('Feb has 29 days in a leap year, 28 otherwise', () => {
+    expect(daysInMonthYear(2024, 2)).toBe(29);
+    expect(daysInMonthYear(2023, 2)).toBe(28);
+  });
+
+  it('eachDate includes Feb 29 in a leap year and excludes it otherwise', () => {
+    const leap = [...eachDate('2024-02-27', '2024-03-01')];
+    expect(leap).toContain('2024-02-29');
+    const nonLeap = [...eachDate('2023-02-27', '2023-03-01')];
+    expect(nonLeap).not.toContain('2023-02-29');
+    expect(nonLeap).toContain('2023-02-28');
+  });
+
+  it('assertValidCivilDate rejects 02-29 in a non-leap year', () => {
+    expect(() => assertValidCivilDate('2023-02-29')).toThrow();
+    expect(() => assertValidCivilDate('2024-02-29')).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Write expansion
+// ---------------------------------------------------------------------------
+describe('write expansion → hourly buckets', () => {
+  it('a day price expands to exactly 24 HOUR buckets (T00..T23)', () => {
+    const buckets = expandDayToHourBuckets('2026-07-01', '2.000000');
+    expect(buckets).toHaveLength(24);
+    expect(buckets[0]).toEqual({ level: 'HOUR', ref: '2026-07-01T00', price: '2.000000' });
+    expect(buckets[23]).toEqual({ level: 'HOUR', ref: '2026-07-01T23', price: '2.000000' });
+    // never carries a numeric alias
+    expect(buckets.every((b) => !('pricePerKwh' in b))).toBe(true);
+  });
+
+  it('an intraday band (18–19h) expands to exactly those two hours', () => {
+    const buckets = expandBandHours('2026-07-01', 18, 19, '1.200000');
+    expect(buckets).toEqual([
+      { level: 'HOUR', ref: '2026-07-01T18', price: '1.200000' },
+      { level: 'HOUR', ref: '2026-07-01T19', price: '1.200000' },
+    ]);
+  });
+
+  it('a range expands to every hour of every day, grouped by year', () => {
+    const band: TariffBand = {
+      domain: 'energy',
+      category: 'lojas',
+      periodType: 'range',
+      start: '2026-07-01',
+      end: '2026-07-02',
+      price: '0.500000',
+    };
+    const byYear = expandBandToHourBucketsByYear(band);
+    expect([...byYear.keys()]).toEqual([2026]);
+    expect(byYear.get(2026)).toHaveLength(48);
+  });
+
+  it('a cross-year range writes once per year', () => {
+    const band: TariffBand = {
+      domain: 'energy',
+      category: 'lojas',
+      periodType: 'range',
+      start: '2025-12-31',
+      end: '2026-01-01',
+      price: '0.500000',
+    };
+    const byYear = expandBandToHourBucketsByYear(band);
+    expect([...byYear.keys()].sort()).toEqual([2025, 2026]);
+    expect(byYear.get(2025)).toHaveLength(24);
+    expect(byYear.get(2026)).toHaveLength(24);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Read collapse
+// ---------------------------------------------------------------------------
+const DIMS = { domain: 'energy', category: 'lojas' } as const;
+
+describe('read collapse ← hourly tree', () => {
+  it('24 equal hours collapse to a single day band', () => {
+    const hours = Array.from({ length: 24 }, (_, h) => ({ hour: h, price: '2.000000' }));
+    const bands = collapseHoursToBands('2026-07-01', hours, DIMS);
+    expect(bands).toHaveLength(1);
+    expect(bands[0]).toMatchObject({ periodType: 'day', date: '2026-07-01', price: '2.000000' });
+  });
+
+  it('equal contiguous hours collapse into one band; a differing window stays split', () => {
+    const hours = Array.from({ length: 24 }, (_, h) => ({
+      hour: h,
+      price: h === 18 || h === 19 ? '4.000000' : '2.000000',
+    }));
+    const bands = collapseHoursToBands('2026-07-01', hours, DIMS);
+    // 00–17 band, 18–19 band, 20–23 band
+    expect(bands).toHaveLength(3);
+    expect(bands[0]).toMatchObject({ periodType: 'band', startHour: 0, endHour: 17, price: '2.000000' });
+    expect(bands[1]).toMatchObject({ periodType: 'band', startHour: 18, endHour: 19, price: '4.000000' });
+    expect(bands[2]).toMatchObject({ periodType: 'band', startHour: 20, endHour: 23, price: '2.000000' });
+  });
+
+  it('alternating unequal hours stay fully split', () => {
+    const hours = [
+      { hour: 0, price: '1.000000' },
+      { hour: 1, price: '2.000000' },
+      { hour: 2, price: '1.000000' },
+    ];
+    const bands = collapseHoursToBands('2026-07-01', hours, DIMS);
+    expect(bands).toHaveLength(3);
+  });
+
+  it('an annual uniform tree collapses to one year band', () => {
+    const bands = collapseTreeToBands(
+      { annual: { price: '0.892000' } },
+      { year: 2026, domain: 'energy', category: 'lojas' }
+    );
+    expect(bands).toEqual([
+      { domain: 'energy', category: 'lojas', periodType: 'year', year: 2026, price: '0.892000' },
+    ]);
+  });
+
+  it('an empty tree collapses to no bands', () => {
+    expect(collapseTreeToBands({}, { year: 2026, domain: 'energy', category: 'lojas' })).toEqual([]);
+  });
+
+  it('a daily tree with a day price + intraday override collapses to day+band pieces', () => {
+    const tree = {
+      daily: {
+        '07-01': {
+          price: '2.000000',
+          hourly: { '15': { price: '4.000000' } },
+        },
+      },
+    };
+    const bands = collapseTreeToBands(tree, { year: 2026, domain: 'energy', category: 'lojas' });
+    // 00–14 @2, 15 @4, 16–23 @2
+    expect(bands).toHaveLength(3);
+    expect(bands.map((b) => b.price)).toEqual(['2.000000', '4.000000', '2.000000']);
+    expect(bands[1]).toMatchObject({ periodType: 'band', startHour: 15, endHour: 15 });
+  });
+
+  it('contiguous equal-price full days merge into a single range', () => {
+    const tree = {
+      daily: {
+        '07-01': { price: '2.000000' },
+        '07-02': { price: '2.000000' },
+        '07-03': { price: '2.000000' },
+      },
+    };
+    const bands = collapseTreeToBands(tree, { year: 2026, domain: 'energy', category: 'lojas' });
+    expect(bands).toHaveLength(1);
+    expect(bands[0]).toMatchObject({
+      periodType: 'range',
+      start: '2026-07-01',
+      end: '2026-07-03',
+      price: '2.000000',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Decimal-string round-trip
+// ---------------------------------------------------------------------------
+describe('decimal-string round-trip', () => {
+  it('"0.892000" survives expand → tree → collapse unchanged', () => {
+    const buckets = expandDayToHourBuckets('2026-07-01', '0.892000');
+    // Simulate the server echoing those hours back as a tree.
+    const hourly: Record<string, { price: string }> = {};
+    buckets.forEach((b) => {
+      const h = String(Number(b.ref.slice(-2)));
+      hourly[h] = { price: b.price };
+    });
+    const bands = collapseTreeToBands(
+      { daily: { '07-01': { hourly } } },
+      { year: 2026, domain: 'energy', category: 'lojas' }
+    );
+    expect(bands).toHaveLength(1);
+    expect(bands[0].price).toBe('0.892000');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Panel entry ↔ band
+// ---------------------------------------------------------------------------
+describe('panel entry ↔ band', () => {
+  it('a month PricingEntry maps to a month band with a decimal-string price', () => {
+    const e: PricingEntry = {
+      customerId: 'c',
+      domain: 'energy',
+      category: 'lojas',
+      periodType: 'month',
+      periodKey: '2026-03',
+      pricePerKwh: 0.75,
+      currency: 'BRL',
+    };
+    const band = panelEntryToBand(e);
+    expect(band).toMatchObject({ periodType: 'month', periodKey: '2026-03', price: '0.75' });
+  });
+
+  it('a band maps back to a PricingEntry with canonical price + numeric render view', () => {
+    const entry = bandToPanelEntry(
+      { domain: 'water', category: 'area_comum', periodType: 'range', start: '2026-01-01', end: '2026-12-31', price: '9.500000' },
+      'c'
+    );
+    expect(entry.price).toBe('9.500000');
+    expect(entry.pricePerKwh).toBe(9.5);
+    expect(entry.periodType).toBe('range');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adapter orchestration (mocked client)
+// ---------------------------------------------------------------------------
+function emptyTariff(sel: { domain: string; category: string; year: number }): TariffTreeResponse {
+  return {
+    customerId: 'c',
+    domain: sel.domain as 'ENERGY' | 'WATER',
+    category: sel.category as 'SPECIFIC' | 'COMMON_AREA',
+    year: sel.year,
+    version: 0,
+    tree: {},
+  };
+}
+
+function mockClient(overrides: Partial<Record<keyof TariffApiClient, unknown>> = {}) {
+  return {
+    getTariff: vi.fn(async (sel: { domain: string; category: string; year: number }) => emptyTariff(sel)),
+    putTariff: vi.fn(async () => ({ version: 1 })),
+    patchTariff: vi.fn(async () => ({ version: 1 })),
+    deleteTariff: vi.fn(async () => ({ version: 1 })),
+    ...overrides,
+  } as unknown as TariffApiClient & {
+    getTariff: ReturnType<typeof vi.fn>;
+    putTariff: ReturnType<typeof vi.fn>;
+    patchTariff: ReturnType<typeof vi.fn>;
+    deleteTariff: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe('TariffApiAdapter', () => {
+  it('loads all four combos; an empty tariff (version 0) yields no entries', async () => {
+    const client = mockClient();
+    const adapter = new TariffApiAdapter(client, { year: 2026 });
+    const entries = await adapter.loadEntriesForCustomer('c');
+    expect(client.getTariff).toHaveBeenCalledTimes(4); // ENERGY/WATER × SPECIFIC/COMMON_AREA
+    expect(entries).toEqual([]);
+  });
+
+  it('collapses a loaded annual tariff into one panel entry', async () => {
+    const client = mockClient({
+      getTariff: vi.fn(async (sel: { domain: string; category: string; year: number }) =>
+        sel.domain === 'ENERGY' && sel.category === 'SPECIFIC'
+          ? { ...emptyTariff(sel), version: 3, tree: { annual: { price: '0.892000' } } }
+          : emptyTariff(sel)
+      ),
+    });
+    const adapter = new TariffApiAdapter(client, { year: 2026 });
+    const entries = await adapter.loadEntriesForCustomer('c');
+    expect(entries).toHaveLength(1);
+    expect(entries[0].price).toBe('0.892000');
+    expect(entries[0]).toMatchObject({ domain: 'energy', category: 'lojas', periodType: 'range' });
+  });
+
+  it('saveEntry(month) PATCHes hourly buckets with the seen version as the guard', async () => {
+    const client = mockClient({
+      getTariff: vi.fn(async (sel: { domain: string; category: string; year: number }) => ({
+        ...emptyTariff(sel),
+        version: 5,
+      })),
+    });
+    const adapter = new TariffApiAdapter(client, { year: 2026 });
+    await adapter.loadEntriesForCustomer('c'); // seeds version cache to 5
+    const entry: PricingEntry = {
+      customerId: 'c',
+      domain: 'energy',
+      category: 'lojas',
+      periodType: 'month',
+      periodKey: '2026-03',
+      pricePerKwh: 0.9,
+      currency: 'BRL',
+    };
+    await adapter.saveEntry('c', entry);
+    expect(client.patchTariff).toHaveBeenCalledTimes(1);
+    const [sel, buckets, expectedVersion] = client.patchTariff.mock.calls[0];
+    expect(sel).toMatchObject({ domain: 'ENERGY', category: 'SPECIFIC', year: 2026 });
+    expect(expectedVersion).toBe(5);
+    expect(buckets).toHaveLength(31 * 24); // March 2026
+    expect(buckets[0].price).toBe('0.90');
+  });
+
+  it('saveEntry(year band) PUTs an annual replace with a decimal-string price', async () => {
+    const client = mockClient();
+    const adapter = new TariffApiAdapter(client, { year: 2026 });
+    await adapter.saveEntry('c', {
+      domain: 'water',
+      category: 'area_comum',
+      periodType: 'year',
+      year: 2026,
+      price: '7.500000',
+    });
+    expect(client.putTariff).toHaveBeenCalledTimes(1);
+    const [sel, tree] = client.putTariff.mock.calls[0];
+    expect(sel).toMatchObject({ domain: 'WATER', category: 'COMMON_AREA', year: 2026 });
+    expect(tree).toEqual({ annual: { price: '7.500000' } });
+  });
+
+  it('deleteEntry(single day) issues a DAY sub-bucket DELETE', async () => {
+    const client = mockClient();
+    const adapter = new TariffApiAdapter(client, { year: 2026 });
+    const entry: PricingEntry = {
+      customerId: 'c',
+      domain: 'energy',
+      category: 'lojas',
+      periodType: 'range',
+      start: '2026-07-01',
+      end: '2026-07-01',
+      pricePerKwh: 1,
+      currency: 'BRL',
+    };
+    await adapter.deleteEntry('c', entry);
+    expect(client.deleteTariff).toHaveBeenCalledTimes(1);
+    const [sel, opts] = client.deleteTariff.mock.calls[0];
+    expect(sel).toMatchObject({ domain: 'ENERGY', category: 'SPECIFIC', year: 2026 });
+    expect(opts.bucket).toEqual({ level: 'DAY', ref: '2026-07-01' });
+  });
+
+  it('surfaces a 409 TARIFF_VERSION_CONFLICT from a write (never swallowed)', async () => {
+    const conflict = new TariffApiError('TARIFF_VERSION_CONFLICT', 409, 'stale', { currentVersion: 12 });
+    const client = mockClient({
+      patchTariff: vi.fn(async () => {
+        throw conflict;
+      }),
+    });
+    const adapter = new TariffApiAdapter(client, { year: 2026 });
+    const entry: PricingEntry = {
+      customerId: 'c',
+      domain: 'energy',
+      category: 'lojas',
+      periodType: 'range',
+      start: '2026-07-01',
+      end: '2026-07-01',
+      pricePerKwh: 1,
+      currency: 'BRL',
+    };
+    await expect(adapter.saveEntry('c', entry)).rejects.toMatchObject({
+      code: 'TARIFF_VERSION_CONFLICT',
+      currentVersion: 12,
+    });
+  });
+});

--- a/tests/components/pricing-panel/tariffApiClient.test.ts
+++ b/tests/components/pricing-panel/tariffApiClient.test.ts
@@ -1,0 +1,165 @@
+/**
+ * RFC-0228 A1 — TariffApiClient unit tests (mocked `fetch`, frozen contract).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  TariffApiClient,
+  TariffApiError,
+  type TariffSelector,
+} from '../../../src/components/pricing-panel/tariffApiClient';
+
+const SEL: TariffSelector = {
+  customerId: 'cust-1',
+  domain: 'ENERGY',
+  category: 'SPECIFIC',
+  year: 2026,
+};
+
+function jsonResponse(body: unknown, init: { status?: number; etag?: string } = {}): Response {
+  const headers = new Headers({ 'Content-Type': 'application/json' });
+  if (init.etag) headers.set('ETag', init.etag);
+  return new Response(body == null ? '' : JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers,
+  });
+}
+
+function makeClient(fetchImpl: typeof fetch) {
+  return new TariffApiClient({
+    baseUrl: 'https://gcdr.example',
+    apiKey: 'gcdr_cust_ABC',
+    tenantId: 'tenant-9',
+    fetchImpl,
+  });
+}
+
+describe('TariffApiClient — GET', () => {
+  it('builds the customer-scoped URL with domain/category/year/granularity and auth headers', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({ version: 7, tree: { annual: { price: '0.892000' } } }, { etag: '"7"' })
+    );
+    const client = makeClient(fetchMock as unknown as typeof fetch);
+    const resp = await client.getTariff(SEL, 'hour');
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/v1/customers/cust-1/tariffs');
+    expect(url).toContain('domain=ENERGY');
+    expect(url).toContain('category=SPECIFIC');
+    expect(url).toContain('year=2026');
+    expect(url).toContain('granularity=hour');
+    expect(init.method).toBe('GET');
+    expect(init.headers['X-API-Key']).toBe('gcdr_cust_ABC');
+    expect(init.headers['X-Tenant-Id']).toBe('tenant-9');
+
+    expect(resp.version).toBe(7);
+    // Price preserved verbatim as a decimal STRING (never Number()).
+    expect(resp.tree.annual?.price).toBe('0.892000');
+  });
+
+  it('falls back to the ETag when the body omits version; empty tariff is version 0', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ tree: {} }, { etag: '"0"' }));
+    const client = makeClient(fetchMock as unknown as typeof fetch);
+    const resp = await client.getTariff(SEL);
+    expect(resp.version).toBe(0);
+    expect(resp.tree).toEqual({});
+  });
+});
+
+describe('TariffApiClient — writes carry the concurrency guard', () => {
+  it('PUT sends If-Match header and body expectedVersion (equal), returns new version', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ version: 8 }, { etag: '"8"' }));
+    const client = makeClient(fetchMock as unknown as typeof fetch);
+    const res = await client.putTariff(SEL, { annual: { price: '1.000000' } }, 7);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/customers/cust-1/tariffs');
+    expect(init.method).toBe('PUT');
+    expect(init.headers['If-Match']).toBe('"7"');
+    const body = JSON.parse(init.body);
+    expect(body.expectedVersion).toBe(7);
+    expect(body.annual.price).toBe('1.000000'); // decimal string, untouched
+    expect(res.version).toBe(8);
+  });
+
+  it('PATCH sends sparse buckets with decimal-string prices', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ version: 9 }));
+    const client = makeClient(fetchMock as unknown as typeof fetch);
+    await client.patchTariff(
+      SEL,
+      [{ level: 'HOUR', ref: '2026-07-01T18', price: '1.200000' }],
+      8
+    );
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.buckets).toEqual([{ level: 'HOUR', ref: '2026-07-01T18', price: '1.200000' }]);
+    expect(body.expectedVersion).toBe(8);
+  });
+});
+
+describe('TariffApiClient — DELETE', () => {
+  it('whole-year delete (204) returns {} without a body', async () => {
+    // A 204 cannot carry a body via the Response constructor; the client only
+    // reads `.status` on 204, so a minimal stub is sufficient.
+    const fetchMock = vi.fn().mockResolvedValue({ status: 204 } as unknown as Response);
+    const client = makeClient(fetchMock as unknown as typeof fetch);
+    const res = await client.deleteTariff(SEL);
+    expect(res).toEqual({});
+    const init = fetchMock.mock.calls[0][1];
+    expect(init.method).toBe('DELETE');
+    expect(init.body).toBeUndefined();
+  });
+
+  it('sub-bucket delete (200) sends the bucket + guard and returns the new version', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ version: 10 }, { etag: '"10"' }));
+    const client = makeClient(fetchMock as unknown as typeof fetch);
+    const res = await client.deleteTariff(SEL, {
+      bucket: { level: 'DAY', ref: '2026-07-01' },
+      expectedVersion: 9,
+    });
+    const init = fetchMock.mock.calls[0][1];
+    const body = JSON.parse(init.body);
+    expect(body.bucket).toEqual({ level: 'DAY', ref: '2026-07-01' });
+    expect(body.expectedVersion).toBe(9);
+    expect(init.headers['If-Match']).toBe('"9"');
+    expect(res.version).toBe(10);
+  });
+});
+
+describe('TariffApiClient — errors surface the stable code', () => {
+  it('409 TARIFF_VERSION_CONFLICT throws a TariffApiError carrying currentVersion', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(
+        {
+          error: {
+            code: 'TARIFF_VERSION_CONFLICT',
+            message: 'stale',
+            details: { currentVersion: 12 },
+          },
+        },
+        { status: 409 }
+      )
+    );
+    const client = makeClient(fetchMock as unknown as typeof fetch);
+    await expect(client.putTariff(SEL, { annual: { price: '1.000000' } }, 7)).rejects.toMatchObject({
+      code: 'TARIFF_VERSION_CONFLICT',
+      status: 409,
+      currentVersion: 12,
+    });
+    await expect(
+      client.putTariff(SEL, { annual: { price: '1.000000' } }, 7)
+    ).rejects.toBeInstanceOf(TariffApiError);
+  });
+
+  it('422 TARIFF_PRICE_INVALID surfaces the code, not the message', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({ error: { code: 'TARIFF_PRICE_INVALID', message: 'price ≤ 0' } }, { status: 422 })
+    );
+    const client = makeClient(fetchMock as unknown as typeof fetch);
+    await expect(client.patchTariff(SEL, [], 1)).rejects.toMatchObject({
+      code: 'TARIFF_PRICE_INVALID',
+      status: 422,
+    });
+  });
+});


### PR DESCRIPTION
## RFC-0228 Track A — Metas Financeiras (frontend HO), completo

Implementa **toda a Track A** do RFC-0228 (índice `docs/rfcs/RFC-0228-Financial-Goals-Gap-and-Rollout-Index.md`) contra o contrato **congelado** GCDR RFC-0054. Tracks **B** (backend gcdr) e **C** (modelo de tarifa) são de outro repositório e ficam fora deste PR.

Tudo é **aditivo e gated**: com o gate de dinheiro desligado, cada superfície (AllReportModal, EnergySummary, CustomerGoalsCard, GoalsPanel/UNIQUE controller) é **byte-idêntica** a hoje. Construído contra fetch mockado — não exige backend vivo.

### Itens entregues

| Item | Descrição | Testes |
|------|-----------|--------|
| **A1** | `openPricingPanel` → adaptador sobre a API de tarifas horárias (`GET/PUT/PATCH/DELETE /customers/:id/tariffs`); month/range/band ↔ buckets horários; preços decimal-string; ETag/expectedVersion; sem localStorage como fonte de verdade | 65 |
| **F0** | Fundação de dinheiro: ponte de nomes (`quantityGoal` × `monetaryProjection` × `currencyBudget` × `budgetVerdict`), `MoneyOverlay available\|unavailable`, `normalizeMoneyBlock`, `goalsMoneyClient`, `formatMoneyBRL` (string-based) | 31 |
| **A4** | UI honesta de cobertura: estados `unavailable`/`incomplete`/`complete`; deep-links `onCategorizeDevice`/`onManageCategories`; nunca R$ 0/NaN | 13 |
| **A2a** | Overlay R$ piloto em Metas × Consumo (linha R$ + chip de desvio), gated por `_moneyGate` (settings + símbolos MyIOLibrary) | 17 |
| **A3** | Meta nativa `CURRENCY` (Target/Projected) com **DEC-6** verdict-withholding (`withinBudget` estritamente true/false, senão chip "retido") | 16 |
| **A5a** | UI de categorização de tarifa por device contra a **seam injetável `DeviceCategoryPort`** (B6 do gcdr implementa depois; UI não depende de shape HTTP concreto) | 20 |
| **A6** | Coluna R$ ao lado de kWh/m³ em AllReportModal + EnergySummary, contrato de arredondamento **DEC-8** (soma em cents BigInt, arredonda uma vez, nunca `Number()`) | 24 |
| **A7** | Variância realizado-vs-meta em R$ (chip) para RFC-0182 / RFC-0217; honra DEC-6; sem colisão com o prop `budget` (quantidade) | 32 |
| **A2b** | Gate de rollout amplo: **default OFF para toda a base**; habilita só clientes curados/allowlist; degrada honestamente p/ A4; flip base-wide = 1 linha quando **B1** (gcdr) decidir | 25 |

### Disciplinas transversais
- **Decimal-string sempre** — nunca `Number()`-round-trip em valor monetário; soma em cents (BigInt); arredonda uma vez (DEC-8).
- **Cobertura honesta** — incompleta/indisponível → indicador de cobertura (A4), nunca R$ 0, NaN ou total parcial apresentado como completo.
- **DEC-6 verdict-withholding** — sem veredito quando a cobertura é incompleta.
- **Sem termos de faturamento** (§8): "Custo projetado / Estimado R$ / Cobertura incompleta"; proibidos "fatura/faturamento/valor final/total a pagar".
- **Classificação explícita** (RFC-0207) — `tariffCategory` lido/escrito como atributo explícito, nunca inferido de nome/label.

### Testes / build
- **293/293** nos surfaces de Track A (`financial-goals`, `pricing-panel`, `cards/customer-goals`, `premium-modals`).
- `npm run build` verde (ESM/CJS/DTS + UMD + min + verify-dts).

### Depende de (gcdr, PRs separados)
- **B6** — API device `tariffCategory` (read/write/audit) que satisfaz `DeviceCategoryPort`.
- **B1/B2** — decisão de rollout amplo (money customer-granular); até lá A2b mantém a base OFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
